### PR TITLE
Add mutation to save document and answers

### DIFF
--- a/caluma/document/schema.py
+++ b/caluma/document/schema.py
@@ -1,9 +1,12 @@
 import graphene
+from graphene.relay.mutation import ClientIDMutation
 from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.types import DjangoObjectType
+from graphql_relay import from_global_id
 
-from . import models
+from . import models, serializers
 from ..form.schema import Question
+from ..mutation import SerializerMutation
 
 
 class Answer(graphene.Interface):
@@ -45,12 +48,18 @@ class AnswerConnection(graphene.Connection):
         node = Answer
 
 
-ANSWER_TYPE = {
-    list: ListAnswer,
-    str: StringAnswer,
-    float: FloatAnswer,
-    int: IntegerAnswer,
-}
+def create_answer_node(answer):
+    ANSWER_TYPE = {
+        list: ListAnswer,
+        str: StringAnswer,
+        float: FloatAnswer,
+        int: IntegerAnswer,
+    }
+
+    answer_type = ANSWER_TYPE[type(answer.value)]
+    return answer_type(
+        id=answer.id, question=answer.question, meta=answer.meta, value=answer.value
+    )
 
 
 class Document(DjangoObjectType):
@@ -58,24 +67,82 @@ class Document(DjangoObjectType):
 
     def resolve_answers(self, info):
         # TODO: filter by question
-        answers = []
-        for answer in self.answers.all():
-            answer_type = ANSWER_TYPE[type(answer.value)]
-            answers.append(
-                answer_type(
-                    id=answer.id,
-                    question=answer.question,
-                    meta=answer.meta,
-                    value=answer.value,
-                )
-            )
-
-        return answers
+        return [create_answer_node(answer) for answer in self.answers.all()]
 
     class Meta:
         model = models.Document
         interfaces = (graphene.Node,)
         filter_fields = ("form",)
+
+
+class SaveDocument(SerializerMutation):
+    class Meta:
+        serializer_class = serializers.DocumentSerializer
+
+
+class SaveDocumentAnswer(ClientIDMutation):
+    # TODO: could be simplified once following issue is addressed:
+    # https://github.com/graphql-python/graphene-django/issues/121
+    class Meta:
+        abstract = True
+
+    answer = graphene.Field(Answer)
+
+    @classmethod
+    def mutate_and_get_payload(cls, root, info, **input):
+        _, question_id = from_global_id(input["question"])
+        _, document_id = from_global_id(input["document"])
+        answer = models.Answer.objects.filter(
+            question=question_id, document=document_id
+        ).first()
+
+        serializer = serializers.AnswerSerializer(
+            data=input, instance=answer, context={"request": info.context}
+        )
+        serializer.is_valid(raise_exception=True)
+        answer = serializer.save()
+
+        return cls(answer=create_answer_node(answer))
+
+
+class SaveDocumentStringAnswer(SaveDocumentAnswer):
+    class Input:
+        question = graphene.ID(required=True)
+        document = graphene.ID(required=True)
+        meta = graphene.JSONString(required=True)
+        value = graphene.String(required=True)
+
+
+class SaveDocumentListAnswer(SaveDocumentAnswer):
+    class Input:
+        question = graphene.ID(required=True)
+        document = graphene.ID(required=True)
+        meta = graphene.JSONString(required=True)
+        value = graphene.List(graphene.String, required=True)
+
+
+class SaveDocumentIntegerAnswer(SaveDocumentAnswer):
+    class Input:
+        question = graphene.ID(required=True)
+        document = graphene.ID(required=True)
+        meta = graphene.JSONString(required=True)
+        value = graphene.Int(required=True)
+
+
+class SaveDocumentFloatAnswer(SaveDocumentAnswer):
+    class Input:
+        question = graphene.ID(required=True)
+        document = graphene.ID(required=True)
+        meta = graphene.JSONString(required=True)
+        value = graphene.Float(required=True)
+
+
+class Mutation(object):
+    save_document = SaveDocument().Field()
+    save_document_string_answer = SaveDocumentStringAnswer().Field()
+    save_document_integer_answer = SaveDocumentIntegerAnswer().Field()
+    save_document_float_answer = SaveDocumentFloatAnswer().Field()
+    save_document_list_answer = SaveDocumentListAnswer().Field()
 
 
 class Query(object):

--- a/caluma/document/serializers.py
+++ b/caluma/document/serializers.py
@@ -1,0 +1,14 @@
+from . import models
+from .. import serializers
+
+
+class DocumentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Document
+        fields = ("form", "meta")
+
+
+class AnswerSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Answer
+        fields = ("question", "meta", "document", "value")

--- a/caluma/document/tests/snapshots/snap_test_document.py
+++ b/caluma/document/tests/snapshots/snap_test_document.py
@@ -106,3 +106,40 @@ snapshots["test_query_all_documents[checkbox-answer__value3] 1"] = {
         ]
     }
 }
+
+snapshots["test_save_document 1"] = {
+    "saveDocument": {
+        "clientMutationId": "testid",
+        "document": {"form": {"slug": "mrs-shake-recent"}},
+    }
+}
+
+snapshots["test_save_document_answer[text-Test-SaveDocumentStringAnswer] 1"] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"string_value": '"Test"'},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots["test_save_document_answer[integer-1-SaveDocumentIntegerAnswer] 1"] = {
+    "saveDocumentIntegerAnswer": {
+        "answer": {"integer_value": 1},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots["test_save_document_answer[float-2.1-SaveDocumentFloatAnswer] 1"] = {
+    "saveDocumentFloatAnswer": {
+        "answer": {"float_value": 2.1},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[checkbox-answer__value3-SaveDocumentListAnswer] 1"
+] = {
+    "saveDocumentListAnswer": {
+        "answer": {"list_value": ['["123", "1"]']},
+        "clientMutationId": "testid",
+    }
+}

--- a/caluma/document/tests/test_document.py
+++ b/caluma/document/tests/test_document.py
@@ -1,7 +1,9 @@
 import pytest
 
+from .. import serializers
 from ...form.models import Question
 from ...schema import schema
+from ...tests import extract_serializer_input_fields
 
 
 @pytest.mark.parametrize(
@@ -50,5 +52,72 @@ def test_query_all_documents(db, snapshot, formquestion, form, document, answer)
     """
 
     result = schema.execute(query)
+    assert not result.errors
+    snapshot.assert_match(result.data)
+
+
+def test_save_document(db, snapshot, document):
+    query = """
+        mutation SaveDocument($input: SaveDocumentInput!) {
+          saveDocument(input: $input) {
+            document {
+                form {
+                    slug
+                }
+            }
+            clientMutationId
+          }
+        }
+    """
+
+    inp = {
+        "input": extract_serializer_input_fields(
+            serializers.DocumentSerializer, document
+        )
+    }
+    result = schema.execute(query, variables=inp)
+
+    assert not result.errors
+    snapshot.assert_match(result.data)
+
+
+@pytest.mark.parametrize(
+    "question__type,answer__value,mutation",
+    [
+        (Question.TYPE_INTEGER, 1, "SaveDocumentIntegerAnswer"),
+        (Question.TYPE_FLOAT, 2.1, "SaveDocumentFloatAnswer"),
+        (Question.TYPE_TEXT, "Test", "SaveDocumentStringAnswer"),
+        (Question.TYPE_CHECKBOX, ["123", "1"], "SaveDocumentListAnswer"),
+    ],
+)
+def test_save_document_answer(db, snapshot, answer, mutation):
+    mutation_func = mutation[0].lower() + mutation[1:]
+    query = f"""
+        mutation {mutation}($input: {mutation}Input!) {{
+          {mutation_func}(input: $input) {{
+            answer {{
+              ... on StringAnswer {{
+                string_value: value
+              }}
+              ... on IntegerAnswer {{
+                integer_value: value
+              }}
+              ... on ListAnswer {{
+                list_value: value
+              }}
+              ... on FloatAnswer {{
+                float_value: value
+              }}
+            }}
+            clientMutationId
+          }}
+        }}
+    """
+
+    inp = {
+        "input": extract_serializer_input_fields(serializers.AnswerSerializer, answer)
+    }
+    result = schema.execute(query, variables=inp)
+
     assert not result.errors
     snapshot.assert_match(result.data)

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -70,18 +70,18 @@ class AddFormQuestion(relay.ClientIDMutation):
     """Add question at the end of form."""
 
     class Input:
-        form_id = graphene.ID(required=True)
-        question_id = graphene.ID(required=True)
+        form = graphene.ID(required=True)
+        question = graphene.ID(required=True)
 
     form = graphene.Field(Form)
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
-        _, form_id = from_global_id(input["form_id"])
+        _, form_id = from_global_id(input["form"])
         form = get_object_or_404(models.Form, pk=form_id)
         form.validate_editable()
 
-        _, question_id = from_global_id(input["question_id"])
+        _, question_id = from_global_id(input["question"])
         question = get_object_or_404(models.Question, pk=question_id)
 
         models.FormQuestion.objects.create(form=form, question=question)
@@ -92,18 +92,18 @@ class RemoveFormQuestion(relay.ClientIDMutation):
     """Add question at the end of form."""
 
     class Input:
-        form_id = graphene.ID(required=True)
-        question_id = graphene.ID(required=True)
+        form = graphene.ID(required=True)
+        question = graphene.ID(required=True)
 
     form = graphene.Field(Form)
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
-        _, form_id = from_global_id(input["form_id"])
+        _, form_id = from_global_id(input["form"])
         form = get_object_or_404(models.Form, pk=form_id)
         form.validate_editable()
 
-        _, question_id = from_global_id(input["question_id"])
+        _, question_id = from_global_id(input["question"])
         question = get_object_or_404(models.Question, pk=question_id)
 
         models.FormQuestion.objects.filter(form=form, question=question).delete()
@@ -112,19 +112,19 @@ class RemoveFormQuestion(relay.ClientIDMutation):
 
 class ReorderFormQuestions(relay.ClientIDMutation):
     class Input:
-        form_id = graphene.ID(required=True)
-        question_ids = graphene.List(graphene.ID, required=True)
+        form = graphene.ID(required=True)
+        questions = graphene.List(graphene.ID, required=True)
 
     form = graphene.Field(Form)
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
-        _, form_id = from_global_id(input["form_id"])
+        _, form_id = from_global_id(input["form"])
         form = get_object_or_404(models.Form, pk=form_id)
 
         curr_questions = form.questions.values_list("slug", flat=True)
         inp_questions = [
-            from_global_id(question_id)[1] for question_id in input["question_ids"]
+            from_global_id(question_id)[1] for question_id in input["questions"]
         ]
         diff_questions = set(curr_questions).symmetric_difference(inp_questions)
 

--- a/caluma/form/tests/test_form.py
+++ b/caluma/form/tests/test_form.py
@@ -130,8 +130,8 @@ def test_add_form_question(db, form, question, snapshot):
         query,
         variables={
             "input": {
-                "formId": to_global_id(type(form).__name__, form.pk),
-                "questionId": to_global_id(type(question).__name__, question.pk),
+                "form": to_global_id(type(form).__name__, form.pk),
+                "question": to_global_id(type(question).__name__, question.pk),
             }
         },
     )
@@ -162,8 +162,8 @@ def test_remove_form_question(db, form, formquestion, question, snapshot):
         query,
         variables={
             "input": {
-                "formId": to_global_id(type(form).__name__, form.pk),
-                "questionId": to_global_id(type(question).__name__, question.pk),
+                "form": to_global_id(type(form).__name__, form.pk),
+                "question": to_global_id(type(question).__name__, question.pk),
             }
         },
     )
@@ -198,8 +198,8 @@ def test_reorder_form_questions(db, form, form_question_factory):
         query,
         variables={
             "input": {
-                "formId": to_global_id(type(form).__name__, form.pk),
-                "questionIds": [
+                "form": to_global_id(type(form).__name__, form.pk),
+                "questions": [
                     to_global_id(type(models.Question).__name__, question_id)
                     for question_id in question_ids
                 ],
@@ -241,8 +241,8 @@ def test_reorder_form_questions_invalid_question(db, form):
         query,
         variables={
             "input": {
-                "formId": to_global_id(type(form).__name__, form.pk),
-                "questionIds": [
+                "form": to_global_id(type(form).__name__, form.pk),
+                "questions": [
                     to_global_id(type(models.Question).__name__, "invalidquestion")
                 ],
             }

--- a/caluma/mutation.py
+++ b/caluma/mutation.py
@@ -7,7 +7,16 @@ from graphene.types import Field, InputField
 from graphene.types.mutation import MutationOptions
 from graphene.types.objecttype import yank_fields_from_attrs
 from graphene_django.registry import get_global_registry
+from graphene_django.rest_framework import serializer_converter
 from graphene_django.rest_framework.mutation import fields_for_serializer
+from rest_framework import relations
+
+
+@serializer_converter.get_graphene_type_from_serializer_field.register(
+    relations.RelatedField
+)
+def convert_serializer_relation_to_id(field):
+    return graphene.ID
 
 
 class SerializerMutationOptions(MutationOptions):

--- a/caluma/schema.py
+++ b/caluma/schema.py
@@ -9,7 +9,7 @@ from .form import schema as form_schema
 convert_django_field.register(LocalizedField, convert_field_to_string)
 
 
-class Mutation(form_schema.Mutation, graphene.ObjectType):
+class Mutation(form_schema.Mutation, document_schema.Mutation, graphene.ObjectType):
     pass
 
 

--- a/caluma/serializers.py
+++ b/caluma/serializers.py
@@ -1,0 +1,16 @@
+from graphql_relay import from_global_id, to_global_id
+from rest_framework import relations, serializers
+
+
+class GlobalIDPrimaryKeyRelatedField(relations.PrimaryKeyRelatedField):
+    def to_internal_value(self, data):
+        _, data = from_global_id(data)
+        return super().to_internal_value(data)
+
+    def to_representation(self, value):
+        value = super().to_representation(value)
+        return to_global_id(self.get_queryset().model.__name__, value)
+
+
+class ModelSerializer(serializers.ModelSerializer):
+    serializer_related_field = GlobalIDPrimaryKeyRelatedField

--- a/caluma/tests/__init__.py
+++ b/caluma/tests/__init__.py
@@ -2,6 +2,7 @@ import json
 
 from graphene.utils.str_converters import to_camel_case
 from graphql_relay import to_global_id
+from rest_framework import fields
 
 
 def extract_serializer_input_fields(serializer_class, instance):
@@ -9,7 +10,9 @@ def extract_serializer_input_fields(serializer_class, instance):
 
     result = {}
     for key, value in serializer.data.items():
-        if isinstance(value, dict):
+        field = serializer.fields[key]
+
+        if isinstance(field, fields.JSONField):
             value = json.dumps(value)
         result[to_camel_case(key)] = value
 


### PR DESCRIPTION
Fixes #31 

As this is the default of `graphene-django` removed `Id` prefixes of all id input fields. Id prefix is also not needed as GraphQL is type safe and the type explicitly states that an id is needed.