### PR TITLE
Allow overwriting of get_queryset on DjangoObjectType

### DIFF
--- a/caluma/form/filters.py
+++ b/caluma/form/filters.py
@@ -37,3 +37,11 @@ class DocumentFilterSet(FilterSet):
     class Meta:
         model = models.Document
         fields = ("form", "search")
+
+
+class AnswerFilterSet(FilterSet):
+    search = SearchFilter(fields=("value",))
+
+    class Meta:
+        model = models.Answer
+        fields = ("question",)

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -1,14 +1,13 @@
 import graphene
 from graphene import relay
 from graphene.relay.mutation import ClientIDMutation
-from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.rest_framework import serializer_converter
-from graphene_django.types import DjangoObjectType
 
 from . import filters, models, serializers
-from ..filters import DjangoFilterSetConnectionField
+from ..filters import DjangoFilterConnectionField, DjangoFilterSetConnectionField
 from ..mutation import SerializerMutation, UserDefinedPrimaryKeyMixin
 from ..relay import extract_global_id
+from ..types import DjangoObjectType
 
 
 class QuestionJexl(graphene.String):

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -231,15 +231,11 @@ class SaveOption(UserDefinedPrimaryKeyMixin, SerializerMutation):
         serializer_class = serializers.SaveOptionSerializer
 
 
-class RemoveOption(ClientIDMutation):
-    class Input:
-        option = graphene.ID()
-
-    @classmethod
-    def mutate_and_get_payload(cls, root, info, **input):
-        option_id = extract_global_id(input["option"])
-        models.Option.objects.filter(pk=option_id).delete()
-        return cls()
+class RemoveOption(UserDefinedPrimaryKeyMixin, SerializerMutation):
+    class Meta:
+        lookup_input_kwarg = "option"
+        serializer_class = serializers.RemoveOptionSerializer
+        return_field_name = False
 
 
 class Answer(graphene.Interface):

--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -243,6 +243,18 @@ class SaveOptionSerializer(serializers.ModelSerializer):
         model = models.Option
 
 
+class RemoveOptionSerializer(serializers.ModelSerializer):
+    option = serializers.GlobalIDField(source="slug")
+
+    def update(self, instance, validated_data):
+        models.Option.objects.filter(pk=instance).delete()
+        return instance
+
+    class Meta:
+        fields = ("option",)
+        model = models.Option
+
+
 class ArchiveQuestionSerializer(serializers.ModelSerializer):
     id = serializers.GlobalIDField(source="slug")
 

--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -2,7 +2,7 @@ import sys
 
 from django.db import transaction
 from rest_framework import exceptions
-from rest_framework.serializers import FloatField, IntegerField
+from rest_framework.serializers import CharField, FloatField, IntegerField, ListField
 
 from . import models
 from .. import serializers
@@ -274,7 +274,7 @@ class DocumentSerializer(serializers.ModelSerializer):
         fields = ("form", "meta")
 
 
-class AnswerSerializer(serializers.ModelSerializer):
+class SaveAnswerSerializer(serializers.ModelSerializer):
     def validate_question_text(self, question, value):
         max_length = (
             question.max_length if question.max_length is not None else sys.maxsize
@@ -344,4 +344,32 @@ class AnswerSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Answer
-        fields = ("question", "meta", "document", "value")
+        fields = ("question", "document", "value", "meta")
+
+
+class SaveDocumentStringAnswerSerializer(SaveAnswerSerializer):
+    value = CharField()
+
+    class Meta(SaveAnswerSerializer.Meta):
+        pass
+
+
+class SaveDocumentListAnswerSerializer(SaveAnswerSerializer):
+    value = ListField(child=CharField())
+
+    class Meta(SaveAnswerSerializer.Meta):
+        pass
+
+
+class SaveDocumentIntegerAnswerSerializer(SaveAnswerSerializer):
+    value = IntegerField()
+
+    class Meta(SaveAnswerSerializer.Meta):
+        pass
+
+
+class SaveDocumentFloatAnswerSerializer(SaveAnswerSerializer):
+    value = FloatField()
+
+    class Meta(SaveAnswerSerializer.Meta):
+        pass

--- a/caluma/form/tests/snapshots/snap_test_form.py
+++ b/caluma/form/tests/snapshots/snap_test_form.py
@@ -66,7 +66,7 @@ Kid avoid player relationship to range whose. Draw free property consider.""",
                         "edges": [
                             {
                                 "node": {
-                                    "id": "UmFkaW9RdWVzdGlvbjpOb25l",
+                                    "id": "UmFkaW9RdWVzdGlvbjpmbHktZXZlbi15b3Vyc2VsZg==",
                                     "label": "Amanda Boyd",
                                     "slug": "fly-even-yourself",
                                 }

--- a/caluma/form/tests/snapshots/snap_test_question.py
+++ b/caluma/form/tests/snapshots/snap_test_question.py
@@ -13,7 +13,7 @@ snapshots["test_query_all_questions[integer-question__configuration0] 1"] = {
             {
                 "node": {
                     "__typename": "IntegerQuestion",
-                    "id": "SW50ZWdlclF1ZXN0aW9uOk5vbmU=",
+                    "id": "SW50ZWdlclF1ZXN0aW9uOm1ycy1zaGFrZS1yZWNlbnQ=",
                     "integerMaxValue": 10,
                     "integerMinValue": 0,
                     "label": "Jordan Mccarthy",
@@ -33,7 +33,7 @@ snapshots["test_query_all_questions[float-question__configuration1] 1"] = {
                     "__typename": "FloatQuestion",
                     "floatMaxValue": 1.0,
                     "floatMinValue": 0.0,
-                    "id": "RmxvYXRRdWVzdGlvbjpOb25l",
+                    "id": "RmxvYXRRdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
                     "label": "Jordan Mccarthy",
                     "meta": "{}",
                     "slug": "mrs-shake-recent",
@@ -49,7 +49,7 @@ snapshots["test_save_question[true-SaveTextQuestion] 1"] = {
             "clientMutationId": "testid",
             "question": {
                 "__typename": "TextQuestion",
-                "id": "VGV4dFF1ZXN0aW9uOk5vbmU=",
+                "id": "VGV4dFF1ZXN0aW9uOm1ycy1zaGFrZS1yZWNlbnQ=",
                 "label": "Jordan Mccarthy",
                 "meta": "{}",
                 "slug": "mrs-shake-recent",
@@ -65,7 +65,7 @@ snapshots["test_save_question[true-SaveTextareaQuestion] 1"] = {
             "clientMutationId": "testid",
             "question": {
                 "__typename": "TextareaQuestion",
-                "id": "VGV4dGFyZWFRdWVzdGlvbjpOb25l",
+                "id": "VGV4dGFyZWFRdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
                 "label": "Jordan Mccarthy",
                 "meta": "{}",
                 "slug": "mrs-shake-recent",
@@ -81,7 +81,7 @@ snapshots["test_save_question[true-SaveIntegerQuestion] 1"] = {
             "clientMutationId": "testid",
             "question": {
                 "__typename": "IntegerQuestion",
-                "id": "SW50ZWdlclF1ZXN0aW9uOk5vbmU=",
+                "id": "SW50ZWdlclF1ZXN0aW9uOm1ycy1zaGFrZS1yZWNlbnQ=",
                 "label": "Jordan Mccarthy",
                 "meta": "{}",
                 "slug": "mrs-shake-recent",
@@ -97,7 +97,7 @@ snapshots["test_save_question[true-SaveFloatQuestion] 1"] = {
             "clientMutationId": "testid",
             "question": {
                 "__typename": "FloatQuestion",
-                "id": "RmxvYXRRdWVzdGlvbjpOb25l",
+                "id": "RmxvYXRRdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
                 "label": "Jordan Mccarthy",
                 "meta": "{}",
                 "slug": "mrs-shake-recent",
@@ -157,7 +157,7 @@ snapshots["test_save_float_question[float-question__configuration0] 1"] = {
             "clientMutationId": "testid",
             "question": {
                 "__typename": "FloatQuestion",
-                "id": "RmxvYXRRdWVzdGlvbjpOb25l",
+                "id": "RmxvYXRRdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
                 "label": "Jordan Mccarthy",
                 "maxValue": 10.0,
                 "meta": "{}",
@@ -186,7 +186,7 @@ snapshots["test_save_integer_question[integer-question__configuration0] 1"] = {
             "clientMutationId": "testid",
             "question": {
                 "__typename": "IntegerQuestion",
-                "id": "SW50ZWdlclF1ZXN0aW9uOk5vbmU=",
+                "id": "SW50ZWdlclF1ZXN0aW9uOm1ycy1zaGFrZS1yZWNlbnQ=",
                 "label": "Jordan Mccarthy",
                 "meta": "{}",
                 "slug": "mrs-shake-recent",
@@ -212,7 +212,7 @@ snapshots["test_save_checkbox_question[checkbox] 1"] = {
         "clientMutationId": "testid",
         "question": {
             "__typename": "CheckboxQuestion",
-            "id": "Q2hlY2tib3hRdWVzdGlvbjpOb25l",
+            "id": "Q2hlY2tib3hRdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
             "label": "Jordan Mccarthy",
             "meta": "{}",
             "options": {
@@ -231,7 +231,7 @@ snapshots["test_save_radio_question[radio] 1"] = {
         "clientMutationId": "testid",
         "question": {
             "__typename": "RadioQuestion",
-            "id": "UmFkaW9RdWVzdGlvbjpOb25l",
+            "id": "UmFkaW9RdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
             "label": "Jordan Mccarthy",
             "meta": "{}",
             "options": {
@@ -252,7 +252,7 @@ snapshots["test_query_all_questions[float-question__configuration2] 1"] = {
                     "__typename": "FloatQuestion",
                     "floatMaxValue": None,
                     "floatMinValue": None,
-                    "id": "RmxvYXRRdWVzdGlvbjpOb25l",
+                    "id": "RmxvYXRRdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
                     "label": "Jordan Mccarthy",
                     "meta": "{}",
                     "slug": "mrs-shake-recent",
@@ -268,7 +268,7 @@ snapshots["test_query_all_questions[text-question__configuration3] 1"] = {
             {
                 "node": {
                     "__typename": "TextQuestion",
-                    "id": "VGV4dFF1ZXN0aW9uOk5vbmU=",
+                    "id": "VGV4dFF1ZXN0aW9uOm1ycy1zaGFrZS1yZWNlbnQ=",
                     "label": "Jordan Mccarthy",
                     "maxLength": 10,
                     "meta": "{}",
@@ -285,7 +285,7 @@ snapshots["test_query_all_questions[textarea-question__configuration4] 1"] = {
             {
                 "node": {
                     "__typename": "TextareaQuestion",
-                    "id": "VGV4dGFyZWFRdWVzdGlvbjpOb25l",
+                    "id": "VGV4dGFyZWFRdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
                     "label": "Jordan Mccarthy",
                     "maxLength": 10,
                     "meta": "{}",
@@ -302,7 +302,7 @@ snapshots["test_query_all_questions[radio-question__configuration5] 1"] = {
             {
                 "node": {
                     "__typename": "RadioQuestion",
-                    "id": "UmFkaW9RdWVzdGlvbjpOb25l",
+                    "id": "UmFkaW9RdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
                     "label": "Jordan Mccarthy",
                     "meta": "{}",
                     "options": {"edges": [{"node": {"slug": "enter-them-his-half"}}]},
@@ -319,7 +319,7 @@ snapshots["test_query_all_questions[checkbox-question__configuration6] 1"] = {
             {
                 "node": {
                     "__typename": "CheckboxQuestion",
-                    "id": "Q2hlY2tib3hRdWVzdGlvbjpOb25l",
+                    "id": "Q2hlY2tib3hRdWVzdGlvbjptcnMtc2hha2UtcmVjZW50",
                     "label": "Jordan Mccarthy",
                     "meta": "{}",
                     "options": {"edges": [{"node": {"slug": "enter-them-his-half"}}]},

--- a/caluma/form/tests/test_document.py
+++ b/caluma/form/tests/test_document.py
@@ -163,7 +163,9 @@ def test_save_document_answer(db, snapshot, answer, mutation, question_option, s
     """
 
     inp = {
-        "input": extract_serializer_input_fields(serializers.AnswerSerializer, answer)
+        "input": extract_serializer_input_fields(
+            serializers.SaveAnswerSerializer, answer
+        )
     }
     result = schema.execute(query, variables=inp)
 

--- a/caluma/form/tests/test_question.py
+++ b/caluma/form/tests/test_question.py
@@ -261,9 +261,7 @@ def test_save_integer_question(db, snapshot, question):
 def test_save_checkbox_question(db, snapshot, question, question_option_factory):
     question_option_factory.create_batch(2, question=question)
 
-    option_ids = (
-        question.options.order_by("slug").reverse().values_list("slug", flat=True)
-    )
+    option_ids = question.options.order_by("-slug").values_list("slug", flat=True)
 
     query = """
         mutation SaveCheckboxQuestion($input: SaveCheckboxQuestionInput!) {
@@ -295,7 +293,7 @@ def test_save_checkbox_question(db, snapshot, question, question_option_factory)
             serializers.SaveCheckboxQuestionSerializer, question
         )
     }
-    inp["input"]["options"] == option_ids
+    inp["input"]["options"] = option_ids
     result = schema.execute(query, variables=inp)
     assert not result.errors
     snapshot.assert_match(result.data)

--- a/caluma/mutation.py
+++ b/caluma/mutation.py
@@ -150,10 +150,10 @@ class SerializerMutation(ClientIDMutation):
             return {
                 "instance": instance,
                 "data": input,
-                "context": {"request": info.context},
+                "context": {"request": info.context, "info": info},
             }
 
-        return {"data": input, "context": {"request": info.context}}
+        return {"data": input, "context": {"request": info.context, "info": info}}
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
@@ -202,5 +202,5 @@ class UserDefinedPrimaryKeyMixin(object):
         return {
             "instance": instance,
             "data": input,
-            "context": {"request": info.context},
+            "context": {"request": info.context, "info": info},
         }

--- a/caluma/serializers.py
+++ b/caluma/serializers.py
@@ -12,6 +12,19 @@ from .relay import extract_global_id
 
 
 class GlobalIDPrimaryKeyRelatedField(relations.PrimaryKeyRelatedField):
+    """
+    References a global id primary key.
+
+    This class ensures that only primary keys may be looked up which are visible
+    by corresponding DjangoObjectType.
+    """
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        registry = get_global_registry()
+        node_type = registry.get_type_for_model(queryset.model)
+        return node_type.get_queryset(queryset, self.context.get("info"))
+
     def to_internal_value(self, data):
         data = extract_global_id(data)
         return super().to_internal_value(data)

--- a/caluma/tests/fake_model.py
+++ b/caluma/tests/fake_model.py
@@ -1,0 +1,49 @@
+import uuid
+
+from django.contrib.postgres.operations import HStoreExtension
+from django.db import connection, migrations, models
+from django.db.migrations.executor import MigrationExecutor
+
+
+def define_fake_model(fields={}, model_base=models.Model, options={}):
+    name = str(uuid.uuid4()).replace("-", "")[:8]
+
+    # app label needs to be any installed app name e.g. user
+    meta_options = {"app_label": "user"}
+    meta_options.update(options)
+
+    attributes = {
+        "__module__": __name__,
+        "__name__": name,
+        "Meta": type("Meta", (object,), meta_options),
+    }
+
+    attributes.update(fields)
+    model = type(name, (model_base,), attributes)
+
+    return model
+
+
+def get_fake_model(fields={}, model_base=models.Model, options={}):
+    """Create fake model to use during unit tests."""
+
+    model = define_fake_model(fields, model_base, options)
+
+    class TestProject:
+        def clone(self, *_args, **_kwargs):
+            return self
+
+    class TestMigration(migrations.Migration):
+        operations = [HStoreExtension()]
+
+    with connection.schema_editor() as schema_editor:
+        migration_executor = MigrationExecutor(schema_editor.connection)
+        migration_executor.apply_migration(
+            TestProject(),
+            # app label needs to be any installed app name e.g. user
+            TestMigration("caluma_extra", "user"),
+        )
+
+        schema_editor.create_model(model)
+
+    return model

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -42,7 +42,7 @@ interface Answer {
   created: DateTime!
   modified: DateTime!
   question: Question!
-  meta: JSONString
+  meta: JSONString!
 }
 
 type AnswerConnection {
@@ -129,7 +129,7 @@ type CheckboxQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString
+  meta: JSONString!
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   options(before: String, after: String, first: Int, last: Int, slug: String, label: String, search: String): OptionConnection
   id: ID!
@@ -172,7 +172,7 @@ type FloatAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: Float!
-  meta: JSONString
+  meta: JSONString!
 }
 
 type FloatQuestion implements Question, Node {
@@ -183,7 +183,7 @@ type FloatQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString
+  meta: JSONString!
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   id: ID!
   minValue: Float
@@ -237,7 +237,7 @@ type IntegerAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: Int!
-  meta: JSONString
+  meta: JSONString!
 }
 
 type IntegerQuestion implements Question, Node {
@@ -248,7 +248,7 @@ type IntegerQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString
+  meta: JSONString!
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   id: ID!
   maxValue: Int
@@ -263,7 +263,7 @@ type ListAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: [String]!
-  meta: JSONString
+  meta: JSONString!
 }
 
 type Mutation {
@@ -368,7 +368,7 @@ interface Question {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString
+  meta: JSONString!
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
 }
 
@@ -392,7 +392,7 @@ type RadioQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString
+  meta: JSONString!
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   options(before: String, after: String, first: Int, last: Int, slug: String, label: String, search: String): OptionConnection
   id: ID!
@@ -458,8 +458,8 @@ type SaveCheckboxQuestionPayload {
 input SaveDocumentFloatAnswerInput {
   question: ID!
   document: ID!
-  meta: JSONString!
   value: Float!
+  meta: JSONString
   clientMutationId: String
 }
 
@@ -477,8 +477,8 @@ input SaveDocumentInput {
 input SaveDocumentIntegerAnswerInput {
   question: ID!
   document: ID!
-  meta: JSONString!
   value: Int!
+  meta: JSONString
   clientMutationId: String
 }
 
@@ -490,8 +490,8 @@ type SaveDocumentIntegerAnswerPayload {
 input SaveDocumentListAnswerInput {
   question: ID!
   document: ID!
-  meta: JSONString!
   value: [String]!
+  meta: JSONString
   clientMutationId: String
 }
 
@@ -508,8 +508,8 @@ type SaveDocumentPayload {
 input SaveDocumentStringAnswerInput {
   question: ID!
   document: ID!
-  meta: JSONString!
   value: String!
+  meta: JSONString
   clientMutationId: String
 }
 
@@ -665,7 +665,7 @@ type StringAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: String!
-  meta: JSONString
+  meta: JSONString!
 }
 
 type Task implements Node {
@@ -702,7 +702,7 @@ type TextQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString
+  meta: JSONString!
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   id: ID!
   maxLength: Int
@@ -716,7 +716,7 @@ type TextareaQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString
+  meta: JSONString!
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   id: ID!
   maxLength: Int

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -122,7 +122,6 @@ enum CaseStatus {
 }
 
 type CheckboxQuestion implements Question, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
   slug: String!
@@ -133,6 +132,7 @@ type CheckboxQuestion implements Question, Node {
   meta: JSONString
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   options(before: String, after: String, first: Int, last: Int, slug: String, label: String, search: String): OptionConnection
+  id: ID!
 }
 
 input CompleteWorkItemInput {
@@ -152,7 +152,7 @@ type Document implements Node {
   modified: DateTime!
   form: Form!
   meta: JSONString!
-  answers(before: String, after: String, first: Int, last: Int): AnswerConnection
+  answers(before: String, after: String, first: Int, last: Int, question: ID, search: String): AnswerConnection
   id: ID!
 }
 
@@ -167,16 +167,15 @@ type DocumentEdge {
 }
 
 type FloatAnswer implements Answer, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
+  id: ID!
   question: Question!
-  meta: JSONString
   value: Float!
+  meta: JSONString
 }
 
 type FloatQuestion implements Question, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
   slug: String!
@@ -186,6 +185,7 @@ type FloatQuestion implements Question, Node {
   isArchived: Boolean!
   meta: JSONString
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
+  id: ID!
   minValue: Float
   maxValue: Float
 }
@@ -217,8 +217,8 @@ type Form implements Node {
   meta: JSONString!
   isPublished: Boolean!
   isArchived: Boolean!
-  id: ID!
   questions(before: String, after: String, first: Int, last: Int, slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, excludeForms: [ID], search: String): QuestionConnection
+  id: ID!
 }
 
 type FormConnection {
@@ -232,16 +232,15 @@ type FormEdge {
 }
 
 type IntegerAnswer implements Answer, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
+  id: ID!
   question: Question!
-  meta: JSONString
   value: Int!
+  meta: JSONString
 }
 
 type IntegerQuestion implements Question, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
   slug: String!
@@ -251,6 +250,7 @@ type IntegerQuestion implements Question, Node {
   isArchived: Boolean!
   meta: JSONString
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
+  id: ID!
   maxValue: Int
   minValue: Int
 }
@@ -258,12 +258,12 @@ type IntegerQuestion implements Question, Node {
 scalar JSONString
 
 type ListAnswer implements Answer, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
+  id: ID!
   question: Question!
-  meta: JSONString
   value: [String]!
+  meta: JSONString
 }
 
 type Mutation {
@@ -385,7 +385,6 @@ type QuestionEdge {
 scalar QuestionJexl
 
 type RadioQuestion implements Question, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
   slug: String!
@@ -396,6 +395,7 @@ type RadioQuestion implements Question, Node {
   meta: JSONString
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   options(before: String, after: String, first: Int, last: Int, slug: String, label: String, search: String): OptionConnection
+  id: ID!
 }
 
 input RemoveFormQuestionInput {
@@ -660,12 +660,12 @@ type StartCasePayload {
 }
 
 type StringAnswer implements Answer, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
+  id: ID!
   question: Question!
-  meta: JSONString
   value: String!
+  meta: JSONString
 }
 
 type Task implements Node {
@@ -695,7 +695,6 @@ enum TaskType {
 }
 
 type TextQuestion implements Question, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
   slug: String!
@@ -705,11 +704,11 @@ type TextQuestion implements Question, Node {
   isArchived: Boolean!
   meta: JSONString
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
+  id: ID!
   maxLength: Int
 }
 
 type TextareaQuestion implements Question, Node {
-  id: ID!
   created: DateTime!
   modified: DateTime!
   slug: String!
@@ -719,6 +718,7 @@ type TextareaQuestion implements Question, Node {
   isArchived: Boolean!
   meta: JSONString
   forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
+  id: ID!
   maxLength: Int
 }
 

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -410,7 +410,7 @@ type RemoveFormQuestionPayload {
 }
 
 input RemoveOptionInput {
-  option: ID
+  option: ID!
   clientMutationId: String
 }
 

--- a/caluma/tests/test_mutation.py
+++ b/caluma/tests/test_mutation.py
@@ -1,0 +1,110 @@
+import pytest
+from django.http import Http404
+from graphene import ResolveInfo
+from rest_framework import serializers
+
+from .. import models, mutation, types
+from .fake_model import get_fake_model
+
+
+@pytest.fixture
+def mock_info():
+    return ResolveInfo(
+        None,
+        None,
+        None,
+        None,
+        schema=None,
+        fragments=None,
+        root_value=None,
+        operation=None,
+        variable_values=None,
+        context=None,
+    )
+
+
+def test_missing_serializer_mutation_serializer_class():
+    with pytest.raises(Exception) as exc:
+
+        class MyMutation(mutation.SerializerMutation):
+            pass
+
+    assert str(exc.value) == "serializer_class is required for the SerializerMutation"
+
+
+def test_invalid_serializer_mutation_model_operations(db):
+    class MySerializer(serializers.ModelSerializer):
+        class Meta:
+            model = get_fake_model()
+            fields = "__all__"
+
+    with pytest.raises(Exception) as exc:
+
+        class MyMutation(mutation.SerializerMutation):
+            class Meta:
+                serializer_class = MySerializer
+                model_operations = ["Add"]
+
+    assert "model_operations" in str(exc.value)
+
+
+def test_invalid_serializer_mutation_update_mutate_and_get_payload(db, mock_info):
+    class MySerializer(serializers.ModelSerializer):
+        class Meta:
+            model = get_fake_model()
+            fields = "__all__"
+
+    class InvalidModelMutation(mutation.SerializerMutation):
+        class Meta:
+            serializer_class = MySerializer
+            model_operations = ["update"]
+
+    with pytest.raises(Exception) as exc:
+        InvalidModelMutation.mutate_and_get_payload(None, mock_info)
+
+    assert '"id" required' in str(exc.value)
+
+
+def test_serializer_mutation_mutate_and_get_payload_without_model(mock_info):
+    class MySerializer(serializers.Serializer):
+        name = serializers.CharField()
+
+        def create(self, validated_data):
+            return validated_data
+
+    class NoModelMutation(mutation.SerializerMutation):
+        class Meta:
+            return_field_name = "test"
+            serializer_class = MySerializer
+
+    result = NoModelMutation.mutate_and_get_payload(None, mock_info, name="test")
+    assert type(result) == NoModelMutation
+
+
+def test_user_defined_primary_key_get_serializer_kwargs_not_allowed(db, mock_info):
+    """Test that user may not overwrite existing instance which is not visible."""
+    FakeModel = get_fake_model(model_base=models.SlugModel)
+
+    class FakeModelObjectType(types.DjangoObjectType):
+        class Meta:
+            model = FakeModel
+
+        @classmethod
+        def get_queryset(cls, queryset, info):
+            # enforce that nothing is visible
+            return queryset.none()
+
+    class MySerializer(serializers.ModelSerializer):
+        class Meta:
+            model = FakeModel
+            fields = "__all__"
+
+    class MyMutation(mutation.UserDefinedPrimaryKeyMixin, mutation.SerializerMutation):
+        class Meta:
+            serializer_class = MySerializer
+            return_field_type = FakeModelObjectType
+
+    FakeModel.objects.create(slug="test")
+
+    with pytest.raises(Http404):
+        MyMutation.get_serializer_kwargs(None, mock_info, slug="test")

--- a/caluma/tests/test_mutation.py
+++ b/caluma/tests/test_mutation.py
@@ -49,6 +49,17 @@ def test_invalid_serializer_mutation_model_operations(db):
 
 
 def test_invalid_serializer_mutation_update_mutate_and_get_payload(db, mock_info):
+    FakeModel = get_fake_model(model_base=models.UUIDModel)
+
+    class FakeModelObjectType(types.DjangoObjectType):
+        class Meta:
+            model = FakeModel
+
+        @classmethod
+        def get_queryset(cls, queryset, info):
+            # enforce that nothing is visible
+            return queryset.none()
+
     class MySerializer(serializers.ModelSerializer):
         class Meta:
             model = get_fake_model()
@@ -57,6 +68,7 @@ def test_invalid_serializer_mutation_update_mutate_and_get_payload(db, mock_info
     class InvalidModelMutation(mutation.SerializerMutation):
         class Meta:
             serializer_class = MySerializer
+            return_field_type = FakeModelObjectType
             model_operations = ["update"]
 
     with pytest.raises(Exception) as exc:

--- a/caluma/types.py
+++ b/caluma/types.py
@@ -1,0 +1,22 @@
+from graphene_django import types
+
+
+class DjangoObjectType(types.DjangoObjectType):
+    """
+    Django object type with overwriting get_queryset support.
+
+    Inspired by https://github.com/graphql-python/graphene-django/pull/528/files
+    and might be removed once merged.
+    """
+
+    @classmethod
+    def get_queryset(cls, queryset, info):
+        return queryset
+
+    @classmethod
+    def get_node(cls, info, id):
+        queryset = cls.get_queryset(cls._meta.model.objects, info)
+        return queryset.filter(pk=id).first()
+
+    class Meta:
+        abstract = True

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -1,11 +1,11 @@
 import graphene
 from graphene import relay
-from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.rest_framework import serializer_converter
-from graphene_django.types import DjangoObjectType
 
 from . import filters, models, serializers
+from ..filters import DjangoFilterConnectionField
 from ..mutation import SerializerMutation, UserDefinedPrimaryKeyMixin
+from ..types import DjangoObjectType
 
 
 class FlowJexl(graphene.String):


### PR DESCRIPTION
Fixes #99 

* Add specific `DjangoObjectType` implementing a default `get_queryset` and a custom `get_node`
* Add specific `DjangoFilterConnectionField` using `get_queryset` of DjangoObjectType to resolve connection
* Add `get_object` method in `SerializerMutation` based on DjangoObjectType `get_queryset`
* GlobalIDPrimaryKeyRelatedField only allows referencing objects allowed by `get_queryset` of object type
* Convert all mutations to use `SerializerMutation`