### PR TITLE
Validate input questions when reordering to be the same then on form

### DIFF
--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -79,6 +79,15 @@ class ReorderFormQuestionsSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         questions = validated_data["questions"]
+        curr_questions = set(instance.questions.all())
+
+        if len(questions) != len(curr_questions) or set(questions) - set(
+            instance.questions.all()
+        ):
+            raise exceptions.ValidationError(
+                "Input questions are not the same as current form questions"
+            )
+
         for sort, question in enumerate(reversed(questions)):
             models.FormQuestion.objects.filter(form=instance, question=question).update(
                 sort=sort

--- a/caluma/form/tests/test_form.py
+++ b/caluma/form/tests/test_form.py
@@ -254,3 +254,35 @@ def test_reorder_form_questions_invalid_question(db, form, question_factory):
     )
 
     assert result.errors
+
+
+def test_reorder_form_questions_duplicated_question(db, form, question, form_question):
+
+    query = """
+        mutation ReorderFormQuestions($input: ReorderFormQuestionsInput!) {
+          reorderFormQuestions(input: $input) {
+            form {
+              questions {
+                edges {
+                  node {
+                    slug
+                  }
+                }
+              }
+            }
+            clientMutationId
+          }
+        }
+    """
+
+    result = schema.execute(
+        query,
+        variables={
+            "input": {
+                "form": to_global_id(type(form).__name__, form.pk),
+                "questions": [question.slug, question.slug],
+            }
+        },
+    )
+
+    assert result.errors

--- a/caluma/form/tests/test_question.py
+++ b/caluma/form/tests/test_question.py
@@ -295,7 +295,7 @@ def test_save_checkbox_question(db, snapshot, question, question_option_factory)
             serializers.SaveCheckboxQuestionSerializer, question
         )
     }
-    inp["input"]["options"] == option_ids
+    inp["input"]["options"] = option_ids
     result = schema.execute(query, variables=inp)
     assert not result.errors
     snapshot.assert_match(result.data)


### PR DESCRIPTION
Fixes #100 

Validate input questions when reordering to be the same then on form