### PR TITLE
Allow plain primary keys instead of global id when filtering

### DIFF
--- a/caluma/filters.py
+++ b/caluma/filters.py
@@ -3,16 +3,37 @@ from functools import reduce
 from django.contrib.postgres.fields import JSONField
 from django.contrib.postgres.fields.hstore import KeyTransform
 from django.contrib.postgres.search import SearchVector
-from django.db.models import TextField
+from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.functions import Cast
 from django.utils import translation
-from django_filters import Filter, FilterSet
 from django_filters.constants import EMPTY_VALUES
+from django_filters.rest_framework import Filter, FilterSet, MultipleChoiceFilter
 from graphene.types.utils import get_type
 from graphene_django import filter
 from graphene_django.filter.filterset import GrapheneFilterSetMixin
 from localized_fields.fields import LocalizedField
+
+from .forms import GlobalIDFormField, GlobalIDMultipleChoiceField
+from .relay import extract_global_id
+
+
+class GlobalIDFilter(Filter):
+    field_class = GlobalIDFormField
+
+    def filter(self, qs, value):
+        _id = None
+        if value is not None:
+            _id = extract_global_id(value)
+        return super(GlobalIDFilter, self).filter(qs, _id)
+
+
+class GlobalIDMultipleChoiceFilter(MultipleChoiceFilter):
+    field_class = GlobalIDMultipleChoiceField
+
+    def filter(self, qs, value):
+        gids = [extract_global_id(v) for v in value]
+        return super(GlobalIDMultipleChoiceFilter, self).filter(qs, gids)
 
 
 class LocalizedFilter(Filter):
@@ -26,7 +47,15 @@ class LocalizedFilter(Filter):
 
 
 GrapheneFilterSetMixin.FILTER_DEFAULTS.update(
-    {LocalizedField: {"filter_class": LocalizedFilter}}
+    {
+        LocalizedField: {"filter_class": LocalizedFilter},
+        models.AutoField: {"filter_class": GlobalIDFilter},
+        models.OneToOneField: {"filter_class": GlobalIDFilter},
+        models.ForeignKey: {"filter_class": GlobalIDFilter},
+        models.ManyToManyField: {"filter_class": GlobalIDMultipleChoiceFilter},
+        models.ManyToOneRel: {"filter_class": GlobalIDMultipleChoiceFilter},
+        models.ManyToManyRel: {"filter_class": GlobalIDMultipleChoiceFilter},
+    }
 )
 
 
@@ -57,7 +86,7 @@ class SearchFilter(Filter):
             lang = translation.get_language()
             return KeyTransform(lang, field_lookup)
         elif isinstance(model_field, JSONField):
-            return Cast(field_lookup, TextField())
+            return Cast(field_lookup, models.TextField())
 
         return field_lookup
 

--- a/caluma/form/filters.py
+++ b/caluma/form/filters.py
@@ -1,10 +1,10 @@
-from graphene_django.filter.filterset import (
+from . import models
+from ..filters import (
+    FilterSet,
     GlobalIDFilter,
     GlobalIDMultipleChoiceFilter,
+    SearchFilter,
 )
-
-from . import models
-from ..filters import FilterSet, SearchFilter
 
 
 class FormFilterSet(FilterSet):
@@ -48,4 +48,4 @@ class AnswerFilterSet(FilterSet):
 
     class Meta:
         model = models.Answer
-        fields = ("question",)
+        fields = ("question", "search")

--- a/caluma/forms.py
+++ b/caluma/forms.py
@@ -1,0 +1,25 @@
+from graphene_django import forms
+
+
+class GlobalIDFormField(forms.GlobalIDFormField):
+    """
+    Global id form field which allows plain primary keys.
+
+    Disable cleaning as input may be an actual relay global id
+    or plain primary key.
+    """
+
+    def clean(self, value):
+        return value
+
+
+class GlobalIDMultipleChoiceField(forms.GlobalIDMultipleChoiceField):
+    """
+    Global id multiple choice field which allows plain primary keys.
+
+    Disable cleaning as input may be an actual relay global id
+    or plain primary key.
+    """
+
+    def valid_value(self, value):
+        return True

--- a/caluma/relay.py
+++ b/caluma/relay.py
@@ -6,8 +6,7 @@ def extract_global_id(id):
     Extract id from global id throwing away type.
 
     In case it is not a base64 encoded value it will return id as is.
-    This simplifies usage of. This way it can be used as input type
-    by simply defining id without its specific type.
+    This way it can be used as input type by simply defining id without its specific type.
     """
 
     try:


### PR DESCRIPTION
Fixes #109 

Current question filter expected id to be base64 encoded and ignored input when not valid. Adjusted that base64 encoded ids and plain primary keys are allowed when filtering ids or multiple choice ids.