### PR TITLE
Make api of visibility and permission extensions more robust

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,3 +24,4 @@ ignore =
 max-line-length = 80
 exclude = migrations snapshots
 max-complexity = 10
+doctests = True

--- a/caluma/collections.py
+++ b/caluma/collections.py
@@ -1,0 +1,6 @@
+from collections import Counter
+
+
+def list_duplicates(iterable):
+    """Return a set of duplicates in given iterator."""
+    return {key for key, count in Counter(iterable).items() if count > 1}

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -6,7 +6,7 @@ from . import filters, models, serializers
 from ..filters import DjangoFilterConnectionField, DjangoFilterSetConnectionField
 from ..mutation import Mutation, UserDefinedPrimaryKeyMixin
 from ..relay import extract_global_id
-from ..types import DjangoObjectType, QuerysetMixin
+from ..types import DjangoObjectType, Node
 
 
 class QuestionJexl(graphene.String):
@@ -20,7 +20,7 @@ serializer_converter.get_graphene_type_from_serializer_field.register(
 )
 
 
-class Question(QuerysetMixin, graphene.Interface):
+class Question(Node, graphene.Interface):
     id = graphene.ID(required=True)
     created_at = graphene.DateTime(required=True)
     modified_at = graphene.DateTime(required=True)
@@ -263,7 +263,7 @@ class RemoveOption(UserDefinedPrimaryKeyMixin, Mutation):
         return_field_name = False
 
 
-class Answer(QuerysetMixin, graphene.Interface):
+class Answer(Node, graphene.Interface):
     id = graphene.ID()
     created_at = graphene.DateTime(required=True)
     created_by_user = graphene.String()

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -4,7 +4,7 @@ from graphene_django.rest_framework import serializer_converter
 
 from . import filters, models, serializers
 from ..filters import DjangoFilterConnectionField, DjangoFilterSetConnectionField
-from ..mutation import SerializerMutation, UserDefinedPrimaryKeyMixin
+from ..mutation import Mutation, UserDefinedPrimaryKeyMixin
 from ..relay import extract_global_id
 from ..types import DjangoObjectType, QuerysetMixin
 
@@ -157,18 +157,18 @@ class Form(DjangoObjectType):
         exclude_fields = ("documents", "workflows")
 
 
-class SaveForm(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveForm(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveFormSerializer
 
 
-class ArchiveForm(SerializerMutation):
+class ArchiveForm(Mutation):
     class Meta:
         lookup_input_kwarg = "id"
         serializer_class = serializers.ArchiveFormSerializer
 
 
-class AddFormQuestion(SerializerMutation):
+class AddFormQuestion(Mutation):
     """Add question at the end of form."""
 
     class Meta:
@@ -176,73 +176,73 @@ class AddFormQuestion(SerializerMutation):
         serializer_class = serializers.AddFormQuestionSerializer
 
 
-class RemoveFormQuestion(SerializerMutation):
+class RemoveFormQuestion(Mutation):
     class Meta:
         lookup_input_kwarg = "form"
         serializer_class = serializers.RemoveFormQuestionSerializer
 
 
-class ReorderFormQuestions(SerializerMutation):
+class ReorderFormQuestions(Mutation):
     class Meta:
         lookup_input_kwarg = "form"
         serializer_class = serializers.ReorderFormQuestionsSerializer
 
 
-class PublishForm(SerializerMutation):
+class PublishForm(Mutation):
     class Meta:
         lookup_input_kwarg = "id"
         serializer_class = serializers.PublishFormSerializer
 
 
-class ArchiveQuestion(SerializerMutation):
+class ArchiveQuestion(Mutation):
     class Meta:
         lookup_input_kwarg = "id"
         serializer_class = serializers.ArchiveQuestionSerializer
         return_field_type = Question
 
 
-class SaveTextQuestion(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveTextQuestion(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveTextQuestionSerializer
         return_field_type = Question
 
 
-class SaveTextareaQuestion(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveTextareaQuestion(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveTextareaQuestionSerializer
         return_field_type = Question
 
 
-class SaveRadioQuestion(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveRadioQuestion(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveRadioQuestionSerializer
         return_field_type = Question
 
 
-class SaveCheckboxQuestion(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveCheckboxQuestion(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveCheckboxQuestionSerializer
         return_field_type = Question
 
 
-class SaveIntegerQuestion(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveIntegerQuestion(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveIntegerQuestionSerializer
         return_field_type = Question
 
 
-class SaveFloatQuestion(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveFloatQuestion(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveFloatQuestionSerializer
         return_field_type = Question
 
 
-class SaveOption(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveOption(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveOptionSerializer
 
 
-class RemoveOption(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class RemoveOption(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         lookup_input_kwarg = "option"
         serializer_class = serializers.RemoveOptionSerializer
@@ -335,12 +335,12 @@ class Document(DjangoObjectType):
         filter_fields = ("form",)
 
 
-class SaveDocument(SerializerMutation):
+class SaveDocument(Mutation):
     class Meta:
         serializer_class = serializers.DocumentSerializer
 
 
-class SaveDocumentAnswer(SerializerMutation):
+class SaveDocumentAnswer(Mutation):
     @classmethod
     def get_object(cls, root, info, queryset, **input):
         question_id = extract_global_id(input["question"])

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -201,37 +201,51 @@ class ArchiveQuestion(Mutation):
         return_field_type = Question
 
 
-class SaveTextQuestion(UserDefinedPrimaryKeyMixin, Mutation):
+class SaveQuestion(UserDefinedPrimaryKeyMixin, Mutation):
+    """
+    Base class of all save question mutations.
+
+    Defined so it is easy to set a permission for all different types
+    of questions.
+
+    See `caluma.permissions.BasePermission` for more details.
+    """
+
+    class Meta:
+        abstract = True
+
+
+class SaveTextQuestion(SaveQuestion):
     class Meta:
         serializer_class = serializers.SaveTextQuestionSerializer
         return_field_type = Question
 
 
-class SaveTextareaQuestion(UserDefinedPrimaryKeyMixin, Mutation):
+class SaveTextareaQuestion(SaveQuestion):
     class Meta:
         serializer_class = serializers.SaveTextareaQuestionSerializer
         return_field_type = Question
 
 
-class SaveRadioQuestion(UserDefinedPrimaryKeyMixin, Mutation):
+class SaveRadioQuestion(SaveQuestion):
     class Meta:
         serializer_class = serializers.SaveRadioQuestionSerializer
         return_field_type = Question
 
 
-class SaveCheckboxQuestion(UserDefinedPrimaryKeyMixin, Mutation):
+class SaveCheckboxQuestion(SaveQuestion):
     class Meta:
         serializer_class = serializers.SaveCheckboxQuestionSerializer
         return_field_type = Question
 
 
-class SaveIntegerQuestion(UserDefinedPrimaryKeyMixin, Mutation):
+class SaveIntegerQuestion(SaveQuestion):
     class Meta:
         serializer_class = serializers.SaveIntegerQuestionSerializer
         return_field_type = Question
 
 
-class SaveFloatQuestion(UserDefinedPrimaryKeyMixin, Mutation):
+class SaveFloatQuestion(SaveQuestion):
     class Meta:
         serializer_class = serializers.SaveFloatQuestionSerializer
         return_field_type = Question

--- a/caluma/mutation.py
+++ b/caluma/mutation.py
@@ -4,6 +4,7 @@ import graphene
 from django.conf import settings
 from django.http import Http404
 from django.shortcuts import get_object_or_404
+from django.utils.module_loading import import_string
 from graphene.relay.mutation import ClientIDMutation
 from graphene.types import Field, InputField
 from graphene.types.mutation import MutationOptions
@@ -66,6 +67,8 @@ class Mutation(ClientIDMutation):
 
     class Meta:
         abstract = True
+
+    permission_classes = [import_string(cls) for cls in settings.PERMISSION_CLASSES]
 
     @classmethod
     def __init_subclass_with_meta__(
@@ -171,13 +174,13 @@ class Mutation(ClientIDMutation):
 
     @classmethod
     def check_permissions(cls, root, info):
-        for permission_class in settings.PERMISSION_CLASSES:
+        for permission_class in cls.permission_classes:
             if not permission_class().has_permission(cls, info):
                 raise exceptions.PermissionDenied()
 
     @classmethod
     def check_object_permissions(cls, root, info, instance):
-        for permission_class in settings.PERMISSION_CLASSES:
+        for permission_class in cls.permission_classes:
             if not permission_class().has_object_permission(cls, info, instance):
                 raise exceptions.PermissionDenied()
 

--- a/caluma/mutation.py
+++ b/caluma/mutation.py
@@ -19,7 +19,7 @@ from .relay import extract_global_id
 convert_django_field.register(LocalizedField, convert_field_to_string)
 
 
-class SerializerMutationOptions(MutationOptions):
+class MutationOptions(MutationOptions):
     lookup_field = None
     lookup_input_kwarg = None
     model_class = None
@@ -29,9 +29,9 @@ class SerializerMutationOptions(MutationOptions):
     return_field_type = None
 
 
-class SerializerMutation(ClientIDMutation):
+class Mutation(ClientIDMutation):
     """
-    Caluma specific SerializerMutation solving following upstream issues.
+    Caluma specific Mutation solving following upstream issues.
 
     1. Expose node instead of attributes directly.
 
@@ -82,7 +82,7 @@ class SerializerMutation(ClientIDMutation):
         **options
     ):
         if not serializer_class:
-            raise Exception("serializer_class is required for the SerializerMutation")
+            raise Exception("serializer_class is required for the Mutation")
 
         if "update" not in model_operations and "create" not in model_operations:
             raise Exception('model_operations must contain "create" and/or "update"')
@@ -114,7 +114,7 @@ class SerializerMutation(ClientIDMutation):
         if return_field_name:
             output_fields[return_field_name] = graphene.Field(return_field_type)
 
-        _meta = SerializerMutationOptions(cls)
+        _meta = MutationOptions(cls)
         _meta.lookup_field = lookup_field
         _meta.lookup_input_kwarg = lookup_input_kwarg
         _meta.model_operations = model_operations
@@ -125,7 +125,7 @@ class SerializerMutation(ClientIDMutation):
         _meta.return_field_type = return_field_type
 
         input_fields = yank_fields_from_attrs(input_fields, _as=InputField)
-        super(SerializerMutation, cls).__init_subclass_with_meta__(
+        super(Mutation, cls).__init_subclass_with_meta__(
             _meta=_meta, input_fields=input_fields, **options
         )
 

--- a/caluma/mutation.py
+++ b/caluma/mutation.py
@@ -128,7 +128,7 @@ class Mutation(ClientIDMutation):
         _meta.return_field_type = return_field_type
 
         input_fields = yank_fields_from_attrs(input_fields, _as=InputField)
-        super(Mutation, cls).__init_subclass_with_meta__(
+        super().__init_subclass_with_meta__(
             _meta=_meta, input_fields=input_fields, **options
         )
 

--- a/caluma/permissions.py
+++ b/caluma/permissions.py
@@ -1,39 +1,89 @@
-from graphene.utils.str_converters import to_snake_case
+import inspect
+from functools import wraps
+
+from .mutation import Mutation
+
+
+def permission_for(mutation):
+    """Decorate function to overwriting permission of specific mutation."""
+
+    def decorate(fn):
+        @wraps(fn)
+        def _decorated(self, mutation, info):
+            return fn(self, mutation, info)
+
+        _decorated._permission = mutation
+        return _decorated
+
+    return decorate
+
+
+def object_permission_for(mutation):
+    """Decorate function to overwriting object permission of specific mutation."""
+
+    def decorate(fn):
+        @wraps(fn)
+        def _decorated(self, mutation, info, instance):
+            return fn(self, mutation, info, instance)
+
+        _decorated._object_permission = mutation
+        return _decorated
+
+    return decorate
 
 
 class BasePermission(object):
-    """Basic permission class to be extended by any permission implementation."""
+    """Basic permission class to be extended by any permission implementation.
+
+    In combination with the decorators `@permission_for` and `@object_permission_for` a custom
+    permission class can define permission on basis of mutations and its subclasses.
+
+    Per default it returns True but default can be overwritten to define a permission for
+    `Mutation`
+
+    A custom permission class could look like this:
+    ```
+    >>> from caluma.form.schema import SaveForm
+    ...
+    ... class CustomPermission(BasePermission):
+    ...     @permission_for(Mutation)
+    ...     def has_permission_default(self, mutation, info):
+    ...         # change default permission to False when no more specifc
+    ...         # permission is defined.
+    ...         return False
+    ...
+    ...     @permission_for(SaveForm)
+    ...     def has_permission_for_save_form(self, mutation, info):
+    ...         return True
+    ...
+    ...     @object_permission_for(SaveForm)
+    ...     def has_object_permission_for_save_form(self, mutation, info, instance):
+    ...         return instance.slug != 'protected-form'
+    """
+
+    def __init__(self):
+        perms = inspect.getmembers(self, lambda m: hasattr(m, "_permission"))
+        self._permissions = {fn._permission: fn for _, fn in perms}
+
+        perms = inspect.getmembers(self, lambda m: hasattr(m, "_object_permission"))
+        self._object_permissions = {fn._object_permission: fn for _, fn in perms}
 
     def has_permission(self, mutation, info):
-        """
-        Check permission of specific mutation or otherwise return True.
-
-        Checks for mutation specific implementations by its snake name.
-
-        e.g. for mutation SaveDocument it will call `has_permission_for_save_document` if available.
-        """
-        method_name = f"has_permission_for_{to_snake_case(mutation.__name__)}"
-        has_permission_for_mutation = getattr(self, method_name, None)
-        if has_permission_for_mutation is not None:
-            return has_permission_for_mutation(mutation, info)
+        for cls in mutation.mro():
+            if cls in self._permissions:
+                return self._permissions[cls](mutation, info)
 
         return True
 
     def has_object_permission(self, mutation, info, instance):
-        """
-        Check object permission of specific mutation or otherwise return True.
-
-        Checks for mutation specific implementations by its snake name.
-
-        e.g. for mutation SaveDocument it will call `has_object_permission_for_save_document` if available.
-        """
-        method_name = f"has_object_permission_for_{to_snake_case(mutation.__name__)}"
-        has_object_permission_for_mutation = getattr(self, method_name, None)
-        if has_object_permission_for_mutation is not None:
-            return has_object_permission_for_mutation(mutation, info, instance)
+        for cls in mutation.mro():
+            if cls in self._object_permissions:
+                return self._object_permissions[cls](mutation, info, instance)
 
         return True
 
 
 class AllowAny(BasePermission):
-    pass
+    @permission_for(Mutation)
+    def has_permission_default(self, mutation, info):
+        return True

--- a/caluma/permissions.py
+++ b/caluma/permissions.py
@@ -1,6 +1,8 @@
 import inspect
 from functools import wraps
 
+from .collections import list_duplicates
+
 
 def permission_for(mutation):
     """Decorate function to overwriting permission of specific mutation."""
@@ -62,14 +64,24 @@ class BasePermission(object):
 
     def __init__(self):
         perm_fns = inspect.getmembers(self, lambda m: hasattr(m, "_permission"))
+        perm_muts = [str(fn._permission) for _, fn in perm_fns]
+        perm_muts_dups = list_duplicates(perm_muts)
+        assert not perm_muts_dups, (
+            f"`permission_for` defined multiple times for "
+            f"{', '.join(perm_muts_dups)} in {str(self)}"
+        )
         self._permissions = {fn._permission: fn for _, fn in perm_fns}
 
-        object_perm_fns = inspect.getmembers(
+        obj_perm_fns = inspect.getmembers(
             self, lambda m: hasattr(m, "_object_permission")
         )
-        self._object_permissions = {
-            fn._object_permission: fn for _, fn in object_perm_fns
-        }
+        obj_perm_muts = [str(fn._object_permission) for _, fn in obj_perm_fns]
+        obj_perm_muts_dups = list_duplicates(obj_perm_muts)
+        assert not obj_perm_muts_dups, (
+            f"`object_permission_for` defined multiple times for "
+            f"{', '.join(obj_perm_muts_dups)} in {str(self)}"
+        )
+        self._object_permissions = {fn._object_permission: fn for _, fn in obj_perm_fns}
 
     def has_permission(self, mutation, info):
         for cls in mutation.mro():

--- a/caluma/permissions.py
+++ b/caluma/permissions.py
@@ -62,11 +62,15 @@ class BasePermission(object):
     """
 
     def __init__(self):
-        perms = inspect.getmembers(self, lambda m: hasattr(m, "_permission"))
-        self._permissions = {fn._permission: fn for _, fn in perms}
+        perm_fns = inspect.getmembers(self, lambda m: hasattr(m, "_permission"))
+        self._permissions = {fn._permission: fn for _, fn in perm_fns}
 
-        perms = inspect.getmembers(self, lambda m: hasattr(m, "_object_permission"))
-        self._object_permissions = {fn._object_permission: fn for _, fn in perms}
+        object_perm_fns = inspect.getmembers(
+            self, lambda m: hasattr(m, "_object_permission")
+        )
+        self._object_permissions = {
+            fn._object_permission: fn for _, fn in object_perm_fns
+        }
 
     def has_permission(self, mutation, info):
         for cls in mutation.mro():

--- a/caluma/permissions.py
+++ b/caluma/permissions.py
@@ -1,8 +1,6 @@
 import inspect
 from functools import wraps
 
-from .mutation import Mutation
-
 
 def permission_for(mutation):
     """Decorate function to overwriting permission of specific mutation."""
@@ -44,6 +42,7 @@ class BasePermission(object):
     A custom permission class could look like this:
     ```
     >>> from caluma.form.schema import SaveForm
+    ... from caluma.mutation import Mutation
     ...
     ... class CustomPermission(BasePermission):
     ...     @permission_for(Mutation)
@@ -88,6 +87,4 @@ class BasePermission(object):
 
 
 class AllowAny(BasePermission):
-    @permission_for(Mutation)
-    def has_permission_default(self, mutation, info):
-        return True
+    pass

--- a/caluma/settings.py
+++ b/caluma/settings.py
@@ -2,7 +2,6 @@ import os
 import re
 
 import environ
-from django.utils.module_loading import import_string
 
 env = environ.Env()
 django_root = environ.Path(__file__) - 2
@@ -131,17 +130,11 @@ OIDC_GROUPS_CLAIM = env.str("OIDC_GROUPS_CLAIM", default="caluma_groups")
 
 # Extensions
 
-VISIBILITY_CLASSES = [
-    import_string(cls)
-    for cls in env.list(
-        "VISIBILITY_CLASSES", default=default(["caluma.visibilities.Any"])
-    )
-]
+VISIBILITY_CLASSES = env.list(
+    "VISIBILITY_CLASSES", default=default(["caluma.visibilities.Any"])
+)
 
 
-PERMISSION_CLASSES = [
-    import_string(cls)
-    for cls in env.list(
-        "PERMISSION_CLASSES", default=default(["caluma.permissions.AllowAny"])
-    )
-]
+PERMISSION_CLASSES = env.list(
+    "PERMISSION_CLASSES", default=default(["caluma.permissions.AllowAny"])
+)

--- a/caluma/tests/test_collections.py
+++ b/caluma/tests/test_collections.py
@@ -1,0 +1,8 @@
+import pytest
+
+from ..collections import list_duplicates
+
+
+@pytest.mark.parametrize("iterator,expected", [([1, 2, 3], set()), ([1, 1, 2, 3], {1})])
+def test_list_duplicates(iterator, expected):
+    assert list_duplicates(iterator) == expected

--- a/caluma/tests/test_mutation.py
+++ b/caluma/tests/test_mutation.py
@@ -9,10 +9,10 @@ from .fake_model import get_fake_model
 def test_missing_serializer_mutation_serializer_class():
     with pytest.raises(Exception) as exc:
 
-        class MyMutation(mutation.SerializerMutation):
+        class MyMutation(mutation.Mutation):
             pass
 
-    assert str(exc.value) == "serializer_class is required for the SerializerMutation"
+    assert str(exc.value) == "serializer_class is required for the Mutation"
 
 
 def test_invalid_serializer_mutation_model_operations(db):
@@ -23,7 +23,7 @@ def test_invalid_serializer_mutation_model_operations(db):
 
     with pytest.raises(Exception) as exc:
 
-        class MyMutation(mutation.SerializerMutation):
+        class MyMutation(mutation.Mutation):
             class Meta:
                 serializer_class = MySerializer
                 model_operations = ["Add"]
@@ -48,7 +48,7 @@ def test_invalid_serializer_mutation_update_mutate_and_get_payload(db, info):
             model = get_fake_model()
             fields = "__all__"
 
-    class InvalidModelMutation(mutation.SerializerMutation):
+    class InvalidModelMutation(mutation.Mutation):
         class Meta:
             serializer_class = MySerializer
             return_field_type = FakeModelObjectType
@@ -67,7 +67,7 @@ def test_serializer_mutation_mutate_and_get_payload_without_model(info):
         def create(self, validated_data):
             return validated_data
 
-    class NoModelMutation(mutation.SerializerMutation):
+    class NoModelMutation(mutation.Mutation):
         class Meta:
             return_field_name = "test"
             serializer_class = MySerializer
@@ -84,7 +84,7 @@ def test_serializer_mutation_mutate_and_get_payload_without_permission(
             model = get_fake_model()
             fields = "__all__"
 
-    class MyMutation(mutation.SerializerMutation):
+    class MyMutation(mutation.Mutation):
         class Meta:
             serializer_class = MySerializer
 
@@ -113,7 +113,7 @@ def test_serializer_mutation_mutate_and_get_payload_without_object_permission(
             model = FakeModel
             fields = "__all__"
 
-    class MyMutation(mutation.SerializerMutation):
+    class MyMutation(mutation.Mutation):
         class Meta:
             serializer_class = MySerializer
             return_field_type = FakeModelObjectType
@@ -146,7 +146,7 @@ def test_user_defined_primary_key_get_serializer_kwargs_not_allowed(db, info):
             model = FakeModel
             fields = "__all__"
 
-    class MyMutation(mutation.UserDefinedPrimaryKeyMixin, mutation.SerializerMutation):
+    class MyMutation(mutation.UserDefinedPrimaryKeyMixin, mutation.Mutation):
         class Meta:
             serializer_class = MySerializer
             return_field_type = FakeModelObjectType

--- a/caluma/tests/test_permissions.py
+++ b/caluma/tests/test_permissions.py
@@ -1,3 +1,4 @@
+import pytest
 from rest_framework import serializers
 
 from .. import models
@@ -30,3 +31,61 @@ def test_custom_permission_override_has_permission_for_custom_node(db, info):
 
     assert not CustomPermission().has_permission(CustomMutation, info)
     assert not CustomPermission().has_object_permission(CustomMutation, info, instance)
+
+
+def test_custom_permission_override_has_permission_with_duplicates(db, info):
+    FakeModel = get_fake_model(model_base=models.UUIDModel)
+
+    class Serializer(serializers.ModelSerializer):
+        class Meta:
+            model = FakeModel
+            fields = "__all__"
+
+    class CustomMutation(Mutation):
+        class Meta:
+            serializer_class = Serializer
+
+    class CustomPermission(BasePermission):
+        @permission_for(CustomMutation)
+        def has_permission_for_custom_mutation(
+            self, mutation, info
+        ):  # pragma: no cover
+            return False
+
+        @permission_for(CustomMutation)
+        def has_permission_for_custom_mutation_2(
+            self, mutation, info
+        ):  # pragma: no cover
+            return False
+
+    with pytest.raises(AssertionError):
+        CustomPermission()
+
+
+def test_custom_permission_override_has_object_permission_with_duplicates(db, info):
+    FakeModel = get_fake_model(model_base=models.UUIDModel)
+
+    class Serializer(serializers.ModelSerializer):
+        class Meta:
+            model = FakeModel
+            fields = "__all__"
+
+    class CustomMutation(Mutation):
+        class Meta:
+            serializer_class = Serializer
+
+    class CustomPermission(BasePermission):
+        @object_permission_for(CustomMutation)
+        def has_object_permission_for_custom_mutation(
+            self, mutation, info, instance
+        ):  # pragma: no cover
+            return False
+
+        @object_permission_for(CustomMutation)
+        def has_object_permission_for_custom_mutation_2(
+            self, mutation, info, instance
+        ):  # pragma: no cover
+            return False
+
+    with pytest.raises(AssertionError):
+        CustomPermission()

--- a/caluma/tests/test_permissions.py
+++ b/caluma/tests/test_permissions.py
@@ -1,6 +1,8 @@
+from rest_framework import serializers
+
 from .. import models
-from ..permissions import BasePermission
-from ..types import DjangoObjectType
+from ..mutation import Mutation
+from ..permissions import BasePermission, object_permission_for, permission_for
 from .fake_model import get_fake_model
 
 
@@ -8,16 +10,23 @@ def test_custom_permission_override_has_permission_for_custom_node(db, info):
     FakeModel = get_fake_model(model_base=models.UUIDModel)
     instance = FakeModel.objects.create()
 
-    class CustomNode(DjangoObjectType):
+    class Serializer(serializers.ModelSerializer):
         class Meta:
             model = FakeModel
+            fields = "__all__"
+
+    class CustomMutation(Mutation):
+        class Meta:
+            serializer_class = Serializer
 
     class CustomPermission(BasePermission):
-        def has_permission_for_custom_node(self, mutation, info):
+        @permission_for(CustomMutation)
+        def has_permission_for_custom_mutation(self, mutation, info):
             return False
 
-        def has_object_permission_for_custom_node(self, mutation, info, instance):
+        @object_permission_for(CustomMutation)
+        def has_object_permission_for_custom_mutation(self, mutation, info, instance):
             return False
 
-    assert not CustomPermission().has_permission(CustomNode, info)
-    assert not CustomPermission().has_object_permission(CustomNode, info, instance)
+    assert not CustomPermission().has_permission(CustomMutation, info)
+    assert not CustomPermission().has_object_permission(CustomMutation, info, instance)

--- a/caluma/tests/test_visibility.py
+++ b/caluma/tests/test_visibility.py
@@ -1,6 +1,6 @@
 from .. import models
 from ..types import DjangoObjectType
-from ..visibilities import BaseVisibility
+from ..visibilities import BaseVisibility, filter_queryset_for
 from .fake_model import get_fake_model
 
 
@@ -13,7 +13,8 @@ def test_custom_visibility_override_get_queryset_for_custom_node(db):
             model = FakeModel
 
     class CustomVisibility(BaseVisibility):
-        def get_queryset_for_custom_node(self, node, queryset, info):
+        @filter_queryset_for(CustomNode)
+        def filter_queryset_for_custom_node(self, node, queryset, info):
             return queryset.none()
 
     queryset = FakeModel.objects

--- a/caluma/types.py
+++ b/caluma/types.py
@@ -2,7 +2,13 @@ from django.conf import settings
 from graphene_django import types
 
 
-class QuerysetMixin(object):
+class Node(object):
+    """Base class to define queryset filters for all nodes."""
+
+    pass
+
+
+class QuerysetMixin(Node):
     """Filter queryset by configured visibility classes."""
 
     @classmethod

--- a/caluma/types.py
+++ b/caluma/types.py
@@ -1,25 +1,22 @@
 from django.conf import settings
+from django.utils.module_loading import import_string
 from graphene_django import types
 
 
 class Node(object):
     """Base class to define queryset filters for all nodes."""
 
-    pass
-
-
-class QuerysetMixin(Node):
-    """Filter queryset by configured visibility classes."""
+    visibility_classes = [import_string(cls) for cls in settings.VISIBILITY_CLASSES]
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        for visibility_class in settings.VISIBILITY_CLASSES:
+        for visibility_class in cls.visibility_classes:
             queryset = visibility_class().get_queryset(cls, queryset, info)
 
         return queryset
 
 
-class DjangoObjectType(QuerysetMixin, types.DjangoObjectType):
+class DjangoObjectType(Node, types.DjangoObjectType):
     """
     Django object type with overwriting get_queryset support.
 

--- a/caluma/user/visibilities.py
+++ b/caluma/user/visibilities.py
@@ -1,10 +1,12 @@
-from ..visibilities import BaseVisibility
+from ..types import Node
+from ..visibilities import BaseVisibility, filter_queryset_for
 
 
 class Authenticated(BaseVisibility):
     """Only allow authenticated users to read nodes."""
 
-    def get_base_queryset(self, node, queryset, info):
+    @filter_queryset_for(Node)
+    def filter_queryset_for_all(self, node, queryset, info):
         if info.context.user.is_authenticated:
             return queryset
         return queryset.none()
@@ -13,6 +15,7 @@ class Authenticated(BaseVisibility):
 class CreatedByGroup(BaseVisibility):
     """User may only read nodes of created by group it belongs to."""
 
-    def get_base_queryset(self, node, queryset, info):
+    @filter_queryset_for(Node)
+    def filter_queryset_for_all(self, node, queryset, info):
         groups = info.context.user.groups
         return queryset.filter(created_by_group__in=groups)

--- a/caluma/visibilities.py
+++ b/caluma/visibilities.py
@@ -21,7 +21,7 @@ def filter_queryset_for(node):
 class BaseVisibility(object):
     """Basic visibility classes to be extended by any visibility implementation.
 
-    In combination with the decorator `@queryset_for` a custom visibility class
+    In combination with the decorator `@filter_queryset_for` a custom visibility class
     can define filtering on basis of nodes and its subclasses.
 
     A custom visibility class could look like this:

--- a/caluma/visibilities.py
+++ b/caluma/visibilities.py
@@ -1,6 +1,8 @@
 import inspect
 from functools import wraps
 
+from .collections import list_duplicates
+
 
 def filter_queryset_for(node):
     """Decorate function to define filtering of queryset of specific node."""
@@ -40,6 +42,12 @@ class BaseVisibility(object):
     def __init__(self):
         queryset_fns = inspect.getmembers(
             self, lambda m: hasattr(m, "_filter_queryset_for")
+        )
+        queryset_nodes = [str(fn._filter_queryset_for) for _, fn in queryset_fns]
+        queryset_nodes_dups = list_duplicates(queryset_nodes)
+        assert not queryset_nodes_dups, (
+            f"`filter_queryset_for` defined multiple times for "
+            f"{', '.join(queryset_nodes_dups)} in {str(self)}"
         )
         self._filter_querysets_for = {
             fn._filter_queryset_for: fn for _, fn in queryset_fns

--- a/caluma/visibilities.py
+++ b/caluma/visibilities.py
@@ -54,7 +54,7 @@ class BaseVisibility(object):
         }
 
     def get_queryset(self, node, queryset, info):
-        for cls in reversed(node.mro()):
+        for cls in node.mro():
             if cls in self._filter_querysets_for:
                 queryset = self._filter_querysets_for[cls](node, queryset, info)
 

--- a/caluma/visibilities.py
+++ b/caluma/visibilities.py
@@ -1,31 +1,54 @@
-from graphene.utils.str_converters import to_snake_case
+import inspect
+from functools import wraps
+
+
+def filter_queryset_for(node):
+    """Decorate function to define filtering of queryset of specific node."""
+
+    def decorate(fn):
+        @wraps(fn)
+        def _decorated(self, node, queryset, info):
+            return fn(self, node, queryset, info)
+
+        _decorated._filter_queryset_for = node
+        return _decorated
+
+    return decorate
 
 
 class BaseVisibility(object):
-    """Basic visibility classes to be extended by any visibility implementation."""
+    """Basic visibility classes to be extended by any visibility implementation.
 
-    def get_base_queryset(self, node, queryset, info):
-        """
-        Get base queryset.
+    In combination with the decorator `@queryset_for` a custom visibility class
+    can define filtering on basis of nodes and its subclasses.
 
-        Override to implement default visiblity filters for all nodes.
-        """
-        return queryset
+    A custom visibility class could look like this:
+    ```
+    >>> from caluma.types import Node
+    ... from caluma.form.schema import Form
+    ...
+    ... class CustomVisibility(BaseVisibility):
+    ...     @filter_queryset_for(Node)
+    ...     def filter_queryset_for_all(self, node, queryset, info):
+    ...         return queryset.filter(created_by_user=info.context.request.user.username)
+    ...
+    ...     @filter_queryset_for(Form)
+    ...     def filter_queryset_for_form(self, node, queryset, info):
+    ...         return queryset.exclude(slug='protected-form')
+    """
+
+    def __init__(self):
+        queryset_fns = inspect.getmembers(
+            self, lambda m: hasattr(m, "_filter_queryset_for")
+        )
+        self._filter_querysets_for = {
+            fn._filter_queryset_for: fn for _, fn in queryset_fns
+        }
 
     def get_queryset(self, node, queryset, info):
-        """
-        Get queryset of specific node.
-
-        Checks for node specific implement by its snake name.
-
-        e.g. for Node WorkItem it will call `get_queryset_for_work_item` if available.
-        """
-        queryset = self.get_base_queryset(node, queryset, info)
-
-        method_name = f"get_queryset_for_{to_snake_case(node.__name__)}"
-        get_queryset_for_node = getattr(self, method_name, None)
-        if get_queryset_for_node is not None:
-            queryset = get_queryset_for_node(node, queryset, info)
+        for cls in reversed(node.mro()):
+            if cls in self._filter_querysets_for:
+                queryset = self._filter_querysets_for[cls](node, queryset, info)
 
         return queryset
 

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -4,7 +4,7 @@ from graphene_django.rest_framework import serializer_converter
 
 from . import filters, models, serializers
 from ..filters import DjangoFilterConnectionField
-from ..mutation import SerializerMutation, UserDefinedPrimaryKeyMixin
+from ..mutation import Mutation, UserDefinedPrimaryKeyMixin
 from ..types import DjangoObjectType
 
 
@@ -58,53 +58,53 @@ class WorkItem(DjangoObjectType):
         interfaces = (relay.Node,)
 
 
-class SaveWorkflow(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveWorkflow(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveWorkflowSerializer
 
 
-class PublishWorkflow(SerializerMutation):
+class PublishWorkflow(Mutation):
     class Meta:
         serializer_class = serializers.PublishWorkflowSerializer
         lookup_input_kwarg = "id"
 
 
-class ArchiveWorkflow(SerializerMutation):
+class ArchiveWorkflow(Mutation):
     class Meta:
         serializer_class = serializers.ArchiveWorkflowSerializer
         lookup_input_kwarg = "id"
 
 
-class AddWorkflowFlow(SerializerMutation):
+class AddWorkflowFlow(Mutation):
     class Meta:
         serializer_class = serializers.AddWorkflowFlowSerializer
         lookup_input_kwarg = "workflow"
 
 
-class RemoveWorkflowFlow(SerializerMutation):
+class RemoveWorkflowFlow(Mutation):
     class Meta:
         serializer_class = serializers.RemoveWorkflowFlowSerializer
         lookup_input_kwarg = "workflow"
 
 
-class SaveTask(UserDefinedPrimaryKeyMixin, SerializerMutation):
+class SaveTask(UserDefinedPrimaryKeyMixin, Mutation):
     class Meta:
         serializer_class = serializers.SaveTaskSerializer
 
 
-class ArchiveTask(SerializerMutation):
+class ArchiveTask(Mutation):
     class Meta:
         serializer_class = serializers.ArchiveTaskSerializer
         lookup_input_kwarg = "id"
 
 
-class StartCase(SerializerMutation):
+class StartCase(Mutation):
     class Meta:
         serializer_class = serializers.StartCaseSerializer
         model_operations = ["create"]
 
 
-class CompleteWorkItem(SerializerMutation):
+class CompleteWorkItem(Mutation):
     class Meta:
         serializer_class = serializers.CompleteWorkItemSerializer
         model_operations = ["update"]


### PR DESCRIPTION
Instead of relying on naming rather use decorator with referencing import directly. This way typos can be noticed during import.