### PR TITLE
Pin idna to avoid dependency issue with requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ graphene==2.1.3
 graphene-django==2.2.0
 graphql-core==2.1
 graphql-relay==0.4.5
+# pin dependencies till requests allows idna 2.8
+idna==2.7  # pyup: >=2.7,<2.8
 psycopg2-binary==2.7.6.1
 pyjexl==0.2.3
 python-jose==3.0.1


### PR DESCRIPTION
pip resolves idna to version 2.8 but should actually only resolve it to 2.7 as:
* cryptography requires idna >=2.1
* requests requires idna >=2.5,<2.8

Pinning works around this issue.