### PR TITLE
Rename get_queryset to filter_queryset on visibility classess

### DIFF
--- a/caluma/core/tests/test_visibility.py
+++ b/caluma/core/tests/test_visibility.py
@@ -7,7 +7,7 @@ from ..visibilities import BaseVisibility, filter_queryset_for
 from .fake_model import get_fake_model
 
 
-def test_custom_visibility_override_get_queryset_for_custom_node(db):
+def test_custom_visibility_override_filter_queryset_for_custom_node(db):
     FakeModel = get_fake_model(model_base=models.UUIDModel)
     FakeModel.objects.create()
 
@@ -22,11 +22,11 @@ def test_custom_visibility_override_get_queryset_for_custom_node(db):
 
     queryset = FakeModel.objects
     assert queryset.count() == 1
-    queryset = CustomVisibility().get_queryset(CustomNode, queryset, None)
+    queryset = CustomVisibility().filter_queryset(CustomNode, queryset, None)
     assert queryset.count() == 0
 
 
-def test_custom_visibility_override_get_queryset_with_duplicates(db):
+def test_custom_visibility_override_filter_queryset_with_duplicates(db):
     FakeModel = get_fake_model(model_base=models.UUIDModel)
     FakeModel.objects.create()
 
@@ -51,7 +51,7 @@ def test_custom_visibility_override_get_queryset_with_duplicates(db):
         CustomVisibility()
 
 
-def test_custom_node_get_queryset_improperly_configured(db):
+def test_custom_node_filter_queryset_improperly_configured(db):
     FakeModel = get_fake_model(model_base=models.UUIDModel)
     FakeModel.objects.create()
 

--- a/caluma/core/types.py
+++ b/caluma/core/types.py
@@ -18,7 +18,7 @@ class Node(object):
             )
 
         for visibility_class in cls.visibility_classes:
-            queryset = visibility_class().get_queryset(cls, queryset, info)
+            queryset = visibility_class().filter_queryset(cls, queryset, info)
 
         return queryset
 

--- a/caluma/core/visibilities.py
+++ b/caluma/core/visibilities.py
@@ -56,7 +56,7 @@ class BaseVisibility(object):
             fn._filter_queryset_for: fn for _, fn in queryset_fns
         }
 
-    def get_queryset(self, node, queryset, info):
+    def filter_queryset(self, node, queryset, info):
         for cls in node.mro():
             if cls in self._filter_querysets_for:
                 queryset = self._filter_querysets_for[cls](node, queryset, info)

--- a/caluma/user/tests/test_visibility.py
+++ b/caluma/user/tests/test_visibility.py
@@ -17,7 +17,7 @@ def test_authenticated_visibility(db, info_fixture, size, request):
 
     FakeModel.objects.create()
 
-    queryset = Authenticated().get_queryset(CustomNode, FakeModel.objects, info)
+    queryset = Authenticated().filter_queryset(CustomNode, FakeModel.objects, info)
     assert queryset.count() == size
 
 
@@ -32,5 +32,7 @@ def test_created_by_group_visibility(db, admin_info, group, admin_user, size, re
 
     FakeModel.objects.create(created_by_group="group")
 
-    queryset = CreatedByGroup().get_queryset(CustomNode, FakeModel.objects, admin_info)
+    queryset = CreatedByGroup().filter_queryset(
+        CustomNode, FakeModel.objects, admin_info
+    )
     assert queryset.count() == size


### PR DESCRIPTION
This makes api more consistent as decorator is called filter_queryset_for. It is also possible to define more then one visibilty class so it doesn't simply get a queryset but filters it through the list of classes.