### PR TITLE
Use docker-compose.yml as full deployment example

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,10 @@
 version: "3.4"
 services:
+  db:
+    environment:
+      - POSTGRES_PASSWORD=caluma
+    ports:
+      - "5432:5432"
   caluma:
     build:
       context: .
@@ -8,4 +13,11 @@ services:
     user: "${UID:?Set UID env variable to your user id}"
     volumes:
       - ./:/app
-    command: /bin/sh -c "wait-for-it.sh db:5432 -- ./manage.py migrate && ./manage.py runserver 0.0.0.0:8000"
+    command:
+      [
+        "/bin/sh",
+        "-c",
+        "wait-for-it.sh db:5432 -- ./manage.py migrate && ./manage.py runserver 0.0.0.0:8000",
+      ]
+    environment:
+      - ENV=dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "3.4"
 services:
   db:
-    image: postgres:9.6
-    ports:
-      - "5432:5432"
+    image: postgres:9.6-alpine
     environment:
       - POSTGRES_USER=caluma
-      - POSTGRES_PASSWORD=caluma
+      # following option is a must to configure on production system:
+      # https://hub.docker.com/_/postgres
+      # - POSTGRES_PASSWORD=
     volumes:
       - dbdata:/var/lib/postgresq
   caluma:
@@ -21,7 +21,18 @@ services:
     #   - ./permissions.py:/app/caluma/extensions/permissions.py
     environment:
       - DATABASE_HOST=db
-      - ENV=docker
+      # following options are a must to configure on production system:
+      # https://docs.djangoproject.com/en/2.1/ref/settings/#std:setting-SECRET_KEY
+      # - SECRET_KEY=
+      # https://docs.djangoproject.com/en/2.1/ref/settings/#allowed-hosts
+      # - ALLOWED_HOSTS=
+      # https://docs.djangoproject.com/en/2.1/ref/settings/#password
+      # same as postgres password above
+      # - DATABASE_PASSWORD=
+      # https://github.com/projectcaluma/caluma#visibility-classes
+      # - VISIBILITY_CLASSES=
+      # https://github.com/projectcaluma/caluma#permission-classes
+      # - PERMISSION_CLASSES=
 
 volumes:
   dbdata:


### PR DESCRIPTION
docker-compose.yml is already referenced on README.md to be used as an deployment example.

This change makes `docker-compose.yml` a self explaining example.