### PR TITLE
Suppress wget from writing to stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:3.6
 
-
-# TODO: do not write to stderr
-RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -P /usr/local/bin \
+RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -P /usr/local/bin \
   && chmod +x /usr/local/bin/wait-for-it.sh \
   && mkdir -p /app \
   && groupadd -r caluma -g 901 && useradd -u 901 -r -g 901 caluma


### PR DESCRIPTION
This lead to read output in docker build which is simply confusing.