### PR TITLE
Use OpenID connect userinfo endpoint to validate bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,18 @@ A list of configuration options which you might need to configure to get Caluma 
 
 #### Authentication and authorization
 
-If you want connect Caluma you need a [IAM](https://en.wikipedia.org/wiki/Identity_management) supporting OpenID Connect. If not available you might want to consider using [Keycloak](https://www.keycloak.org/).
+If you want to connect to Caluma you need an [IAM](https://en.wikipedia.org/wiki/Identity_management) supporting OpenID Connect. If not available you might want to consider using [Keycloak](https://www.keycloak.org/).
 
-* `OIDC_VERIFY_ALGORITHM`: Token verification algorithm (default: HS256)
-* `OIDC_CLIENT`: Client name
-* `OIDC_JWKS_ENDPOINT`: End point of JWKS in case a asymentric algorithm is used.
-* `OIDC_SECRET_KEY`: Secret key when symmetric algorithm is used (defaults to `SECRET_KEY`)
-* `OIDC_VALIDATE_CLAIMS_OPTIONS` dict of verify signature options. See [options parameter](https://python-jose.readthedocs.io/en/latest/jwt/api.html?highlight=decode_token#jose.jwt.decode) for details.
+Caluma expects a bearer token to be passed on as [Authorization Request Header Field](https://tools.ietf.org/html/rfc6750#section-2.1)
+
+* `OIDC_USERINFO_ENDPOINT`: Url of userinfo endpoint as [described](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
 * `OIDC_GROUPS_CLAIM`: Name of claim to be used to represent groups (default: caluma_groups)
+
+#### Cache
+
+* `CACHE_BACKEND`: [cache backend](https://docs.djangoproject.com/en/1.11/ref/settings/#backend) to use (default: django.core.cache.backends.locmem.LocMemCache)
+* `CACHE_LOCATION`: [location](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CACHES-LOCATION) of cache to use
+* `CACHE_TIMEOUT`: number of seconds before a cache entry is considered stale. (default: 300)
 
 #### Extension points
 

--- a/caluma/conftest.py
+++ b/caluma/conftest.py
@@ -2,6 +2,7 @@ import functools
 import inspect
 
 import pytest
+from django.core.cache import cache
 from factory import Faker
 from factory.base import FactoryMetaClass
 from graphene import ResolveInfo
@@ -26,6 +27,11 @@ def register_module(module):
 
 register_module(form_factories)
 register_module(workflow_factories)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def _autoclear_cache():
+    cache.clear()
 
 
 @pytest.fixture

--- a/caluma/settings.py
+++ b/caluma/settings.py
@@ -77,6 +77,19 @@ DATABASES = {
     }
 }
 
+# Cache
+# https://docs.djangoproject.com/en/1.11/ref/settings/#caches
+
+CACHES = {
+    "default": {
+        "BACKEND": env.str(
+            "CACHE_BACKEND", default="django.core.cache.backends.locmem.LocMemCache"
+        ),
+        "LOCATION": env.str("CACHE_LOCATION", ""),
+        "TIMEOUT": env.int("CACHE_TIMEOUT", 300),
+    }
+}
+
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
@@ -118,15 +131,8 @@ GRAPHENE = {
 
 # OpenID connect
 
-OIDC_VERIFY_ALGORITHM = env.list("OIDC_VERIFY_ALGORITHM", default="HS256")
-OIDC_CLIENT = env.str("OIDC_CLIENT", default=None)
-OIDC_JWKS_ENDPOINT = env.str("OIDC_JWKS_ENDPOINT", default=None)
-OIDC_SECRET_KEY = env.str("OIDC_SECRET_KEY", default=SECRET_KEY)
+OIDC_USERINFO_ENDPOINT = env.str("OIDC_USERINFO_ENDPOINT", default=None)
 OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
-OIDC_VALIDATE_CLAIMS_OPTIONS = env.dict(
-    "OIDC_VALIDATE_CLAIMS_OPTIONS", cast={"value": bool}, default=None
-)
-
 OIDC_GROUPS_CLAIM = env.str("OIDC_GROUPS_CLAIM", default="caluma_groups")
 
 # Extensions

--- a/caluma/user/middleware.py
+++ b/caluma/user/middleware.py
@@ -1,7 +1,10 @@
+import functools
+
 import requests
 from django.conf import settings
+from django.core.cache import cache
 from django.utils.encoding import smart_text
-from jose import ExpiredSignatureError, JWTError, jwt
+from rest_framework import exceptions
 from rest_framework.authentication import get_authorization_header
 
 from . import models
@@ -16,7 +19,9 @@ class OIDCAuthenticationMiddleware(object):
     def __init__(self):
         self._keys = None
 
-    def get_jwt_value(self, request):
+    def get_bearer_token(self, request):
+        # TODO: status code of AuthenticationFailed error should be 401
+        # https://github.com/graphql-python/graphene-django/issues/252
         auth = get_authorization_header(request).split()
         header_prefix = "Bearer"
 
@@ -24,61 +29,40 @@ class OIDCAuthenticationMiddleware(object):
             return None
 
         if smart_text(auth[0].lower()) != header_prefix.lower():
-            raise JWTError("No Bearer Authorization header")
+            raise exceptions.AuthenticationFailed("No Bearer Authorization header")
 
         if len(auth) == 1:
             msg = "Invalid Authorization header. No credentials provided"
-            raise JWTError(msg)
+            raise exceptions.AuthenticationFailed(msg)
         elif len(auth) > 2:
             msg = (
                 "Invalid Authorization header. Credentials string should "
                 "not contain spaces."
             )
-            raise JWTError(msg)
+            raise exceptions.AuthenticationFailed(msg)
 
         return auth[1]
 
-    def get_json(self, url):
-        response = requests.get(url, verify=settings.OIDC_VERIFY_SSL)
+    def get_userinfo(self, token):
+        response = requests.get(
+            settings.OIDC_USERINFO_ENDPOINT,
+            verify=settings.OIDC_VERIFY_SSL,
+            headers={"Authorization": f"Bearer {smart_text(token)}"},
+        )
         response.raise_for_status()
         return response.json()
 
-    def decode_token(self, token, key):
-        return jwt.decode(
-            token=token,
-            key=key,
-            options=settings.OIDC_VALIDATE_CLAIMS_OPTIONS,
-            algorithms=[settings.OIDC_VERIFY_ALGORITHM],
-            audience=settings.OIDC_CLIENT,
-        )
-
-    def keys(self):
-        if settings.OIDC_VERIFY_ALGORITHM.startswith("RS"):
-            if self._keys is None:
-                self._keys = self.get_json(settings.OIDC_JWKS_ENDPOINT)
-        else:
-            self._keys = settings.OIDC_SECRET_KEY
-
-        return self._keys
-
     def resolve(self, next, root, info, **args):
         request = info.context
-        jwt_value = self.get_jwt_value(request)
+        token = self.get_bearer_token(request)
 
-        if jwt_value is None:
+        if token is None:
             request.user = models.AnonymousUser()
             return next(root, info, **args)
 
-        # TODO: status code of jwt error should be 401
-        # https://github.com/graphql-python/graphene-django/issues/252
-        try:
-            decoded_token = self.decode_token(jwt_value, self.keys())
-        except ExpiredSignatureError:
-            raise
-        except JWTError:
-            # try again with refreshed keys
-            self._keys = None
-            decoded_token = self.decode_token(jwt_value, self.keys())
-
-        request.user = models.OIDCUser(jwt_value, decoded_token)
+        userinfo_method = functools.partial(self.get_userinfo, token=token)
+        userinfo = cache.get_or_set(
+            f"authentication.userinfo.{smart_text(token)}", userinfo_method
+        )
+        request.user = models.OIDCUser(token, userinfo)
         return next(root, info, **args)

--- a/caluma/user/models.py
+++ b/caluma/user/models.py
@@ -6,7 +6,7 @@ class AnonymousUser(object):
         self.username = None
         self.groups = []
         self.token = None
-        self.decoded_token = {}
+        self.userinfo = {}
         self.group = None
 
     @property
@@ -18,11 +18,11 @@ class AnonymousUser(object):
 
 
 class OIDCUser(object):
-    def __init__(self, token, decoded_token):
+    def __init__(self, token, userinfo):
         self.token = token
-        self.username = decoded_token["sub"]
-        self.decoded_token = decoded_token
-        self.groups = decoded_token.get(settings.OIDC_GROUPS_CLAIM) or []
+        self.username = userinfo["sub"]
+        self.userinfo = userinfo
+        self.groups = userinfo.get(settings.OIDC_GROUPS_CLAIM) or []
 
     @property
     def group(self):

--- a/caluma/user/tests/test_middleware.py
+++ b/caluma/user/tests/test_middleware.py
@@ -1,59 +1,28 @@
 import json
-import time
 
 import pytest
-from django.conf import settings
-from jose import jwt
+from django.core.cache import cache
 
 from .. import middleware
 from ...schema import schema
 
-EXPIRED_TOKEN = "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjNlNTJhNzdiZDFiNDgwZDE0ZTA3MGZjZDQwNTU0Zjc5In0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwMDAvb3BlbmlkIiwic3ViIjoiMSIsImF1ZCI6IjcwNjQ1MyIsImV4cCI6MTUzOTE4MjU3MCwiaWF0IjoxNTM5MTgxOTcwLCJhdXRoX3RpbWUiOjE1MzkxNjQ1ODgsIm5vbmNlIjoiMWtqdmM2biIsImF0X2hhc2giOiJCV2ZaR0dnWGlBMW5jbk5jeF90bHN3In0.emdEmsN6S9QEBc7fStxHEc_0lYPpY-G2c953gutyy70EfnltLt_GGMDKUY1NDM4ZeKUQP-vp6cAW7dcNHSrgg8xPkp65nPuRUBUVo68lEENG-EyrDG6AnQj5w474meALPch-peZgpPjR0zvj4LFJCi4KuWOBtBaiuFe7n3thWog"
-
-KEYS = {
-    "keys": [
-        {
-            "kty": "RSA",
-            "alg": "RS256",
-            "use": "sig",
-            "kid": "3e52a77bd1b480d14e070fcd40554f79",
-            "n": "7P5mh6TCYUPFPAeig-3ZqaqGgXnQuNcRGNowCgAUg8XJ2mfL0F07M27hTOmJIv15j68s3tkk1MEOy4xq436ArgKfy7utrTzOf9kC9maVg1w1RwXiprVzRAR0yM3gfn3hAlQ2TBaI7_ICasJgXpM1BC6q-baLUy9DqobhoprqpvE",
-            "e": "AQAB",
-        }
-    ]
-}
-
-
-def valid_token():
-    token = {
-        "iss": settings.OIDC_JWKS_ENDPOINT,
-        "sub": "1",
-        "aud": settings.OIDC_CLIENT,
-        "exp": time.time() + 60 * 60 * 24,
-    }
-
-    return f'Bearer {jwt.encode(token, settings.OIDC_SECRET_KEY, algorithm="HS256")}'
-
 
 @pytest.mark.parametrize(
-    "token,algorithm,authenticated,error",
+    "authentication_header,authenticated,error",
     [
-        ("", "", False, False),
-        ("Bearer", "RS256", False, True),
-        ("Bearer Too many params", "RS256", False, True),
-        ("Basic Auth", "", False, True),
-        ("Bearer InvalidToken", "RS256", False, True),
-        (EXPIRED_TOKEN, "RS256", False, True),
-        (valid_token(), "HS256", True, False),
+        ("", False, False),
+        ("Bearer", False, True),
+        ("Bearer Too many params", False, True),
+        ("Basic Auth", False, True),
+        ("Bearer Token", True, False),
     ],
 )
 def test_oidc_authentication_middleware(
-    rf, token, algorithm, error, authenticated, requests_mock, settings
+    rf, authentication_header, authenticated, error, requests_mock, settings
 ):
-    settings.OIDC_VERIFY_ALGORITHM = algorithm
-    requests_mock.get(settings.OIDC_JWKS_ENDPOINT, text=json.dumps(KEYS))
-
-    request = rf.get("/graphql", HTTP_AUTHORIZATION=token)
+    userinfo = {"sub": "1"}
+    requests_mock.get(settings.OIDC_USERINFO_ENDPOINT, text=json.dumps(userinfo))
+    request = rf.get("/graphql", HTTP_AUTHORIZATION=authentication_header)
 
     query = """
     {
@@ -72,3 +41,5 @@ def test_oidc_authentication_middleware(
     assert bool(result.errors) == error
     if not error:
         assert request.user.is_authenticated == authenticated
+        if authenticated:
+            assert cache.get("authentication.userinfo.Token") == userinfo

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,9 +2,7 @@
 addopts = --reuse-db --randomly-seed=1521188766 --randomly-dont-reorganize
 DJANGO_SETTINGS_MODULE = caluma.settings
 env =
-    OIDC_JWKS_ENDPOINT=mock://caluma.io/openid/jwks
-    OIDC_CLIENT=706453
-    OIDC_VALIDATE_CLAIMS_OPTIONS=verify_at_hash=False
+    OIDC_USERINFO_ENDPOINT=mock://caluma.io/openid/userinfo
 filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-cryptography==2.4.2
 django==1.11.18 # pyup: >=1.11,<1.12
 django-environ==0.4.5
 django-filter==2.0.0
@@ -18,7 +17,5 @@ graphql-relay==0.4.5
 idna==2.8
 psycopg2-binary==2.7.6.1
 pyjexl==0.2.3
-python-jose==3.0.1
-python-jose[cryptography]==3.0.1
 requests==2.21.0
 uwsgi==2.0.17.1


### PR DESCRIPTION
Invalid assumptions has been made that access_token is always a JWT
token. The OpenID specification doesn't require it and only a few
IAM actually implement it that way.

This change has the additional advantage that no crypthography library
is needed within Caluma context which could have vulnerabilities.