### PR TITLE
Allow memcache to be configured as cache backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ graphql-relay==0.4.5
 idna==2.8
 psycopg2-binary==2.7.6.1
 pyjexl==0.2.3
+python-memcached==1.59
 requests==2.21.0
 uwsgi==2.0.17.1


### PR DESCRIPTION
This way someone can use default Caluma serivce with a memcache backend without having a custom `Dockerfile`.