### PR TITLE
Make caching of userinfo optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ Caluma expects a bearer token to be passed on as [Authorization Request Header F
 
 * `OIDC_USERINFO_ENDPOINT`: Url of userinfo endpoint as [described](https://openid.net/specs/openid-connect-core-1_0.html#UserInfo)
 * `OIDC_GROUPS_CLAIM`: Name of claim to be used to represent groups (default: caluma_groups)
+* `OIDC_BEARER_TOKEN_REVALIDATION_TIME`: Time in seconds before bearer token validity is verified again. For best security token is validated on each request per default. It might be helpful though in case of slow Open ID Connect provider to cache it. It uses [cache](#cache) mechanism for memorizing userinfo result. Number has to be lower than access token expiration time. (default: 0)
 
 #### Cache
 
 * `CACHE_BACKEND`: [cache backend](https://docs.djangoproject.com/en/1.11/ref/settings/#backend) to use (default: django.core.cache.backends.locmem.LocMemCache)
 * `CACHE_LOCATION`: [location](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CACHES-LOCATION) of cache to use
-* `CACHE_TIMEOUT`: number of seconds before a cache entry is considered stale. (default: 300)
 
 #### Extension points
 

--- a/caluma/settings.py
+++ b/caluma/settings.py
@@ -86,7 +86,6 @@ CACHES = {
             "CACHE_BACKEND", default="django.core.cache.backends.locmem.LocMemCache"
         ),
         "LOCATION": env.str("CACHE_LOCATION", ""),
-        "TIMEOUT": env.int("CACHE_TIMEOUT", 300),
     }
 }
 
@@ -134,6 +133,9 @@ GRAPHENE = {
 OIDC_USERINFO_ENDPOINT = env.str("OIDC_USERINFO_ENDPOINT", default=None)
 OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
 OIDC_GROUPS_CLAIM = env.str("OIDC_GROUPS_CLAIM", default="caluma_groups")
+OIDC_BEARER_TOKEN_REVALIDATION_TIME = env.int(
+    "OIDC_BEARER_TOKEN_REVALIDATION_TIME", default=0
+)
 
 # Extensions
 

--- a/caluma/user/middleware.py
+++ b/caluma/user/middleware.py
@@ -62,7 +62,9 @@ class OIDCAuthenticationMiddleware(object):
 
         userinfo_method = functools.partial(self.get_userinfo, token=token)
         userinfo = cache.get_or_set(
-            f"authentication.userinfo.{smart_text(token)}", userinfo_method
+            f"authentication.userinfo.{smart_text(token)}",
+            userinfo_method,
+            timeout=settings.OIDC_BEARER_TOKEN_REVALIDATION_TIME,
         )
         request.user = models.OIDCUser(token, userinfo)
         return next(root, info, **args)

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ addopts = --reuse-db --randomly-seed=1521188766 --randomly-dont-reorganize
 DJANGO_SETTINGS_MODULE = caluma.settings
 env =
     OIDC_USERINFO_ENDPOINT=mock://caluma.io/openid/userinfo
+    OIDC_BEARER_TOKEN_REVALIDATION_TIME=60
 filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning


### PR DESCRIPTION
This could be a security issue if in case access token expires before
cache expires. Hence disabled by default but might still be helpful
to cache in case OpenID Connect provider is slow.