### PR TITLE
Add CORS header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Caluma expects a bearer token to be passed on as [Authorization Request Header F
 * `CACHE_LOCATION`: [location](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CACHES-LOCATION) of cache to use
 * `CACHE_TIMEOUT`: number of seconds before a cache entry is considered stale. (default: 300)
 
+#### CORS headers
+
+Per default no CORS headers are set but can be configured with following options.
+
+* `CORS_ORIGIN_ALLOW_ALL`: If True, the whitelist will not be used and all origins will be accepted. (default: False)
+* `CORS_ORIGIN_WHITELIST`: A list of origin hostnames that are authorized to make cross-site HTTP requests.
+
 #### Extension points
 
 Caluma is meant to be used as a service with a clean API hence it doesn't provide a Django app.

--- a/caluma/settings.py
+++ b/caluma/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.locale.LocaleMiddleware",
 ]
@@ -145,3 +146,9 @@ VISIBILITY_CLASSES = env.list(
 PERMISSION_CLASSES = env.list(
     "PERMISSION_CLASSES", default=default(["caluma.core.permissions.AllowAny"])
 )
+
+
+# Cors headers
+
+CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL", default=False)
+CORS_ORIGIN_WHITELIST = env.list("CORS_ORIGIN_WHITELIST", default=[])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 django==1.11.18 # pyup: >=1.11,<1.12
+django-cors-headers==2.4.0
 django-environ==0.4.5
 django-filter==2.0.0
 # move back to PyPi version once following PRs are merged:


### PR DESCRIPTION
Helpful when no proxy is being used which could set such.
Especially for development setup but might also be helpful
in production.