### PR TITLE
Avoid invalidly caused duplication errors

### DIFF
--- a/caluma/core/permissions.py
+++ b/caluma/core/permissions.py
@@ -66,7 +66,7 @@ class BasePermission(object):
 
     def __init__(self):
         perm_fns = inspect.getmembers(self, lambda m: hasattr(m, "_permission"))
-        perm_muts = [str(fn._permission) for _, fn in perm_fns]
+        perm_muts = [fn._permission.__name__ for _, fn in perm_fns]
         perm_muts_dups = list_duplicates(perm_muts)
         if perm_muts_dups:
             raise ImproperlyConfigured(
@@ -78,7 +78,7 @@ class BasePermission(object):
         obj_perm_fns = inspect.getmembers(
             self, lambda m: hasattr(m, "_object_permission")
         )
-        obj_perm_muts = [str(fn._object_permission) for _, fn in obj_perm_fns]
+        obj_perm_muts = [fn._object_permission.__name__ for _, fn in obj_perm_fns]
         obj_perm_muts_dups = list_duplicates(obj_perm_muts)
         if obj_perm_muts_dups:
             raise ImproperlyConfigured(

--- a/caluma/core/visibilities.py
+++ b/caluma/core/visibilities.py
@@ -45,7 +45,7 @@ class BaseVisibility(object):
         queryset_fns = inspect.getmembers(
             self, lambda m: hasattr(m, "_filter_queryset_for")
         )
-        queryset_nodes = [str(fn._filter_queryset_for) for _, fn in queryset_fns]
+        queryset_nodes = [fn._filter_queryset_for.__name__ for _, fn in queryset_fns]
         queryset_nodes_dups = list_duplicates(queryset_nodes)
         if queryset_nodes_dups:
             raise ImproperlyConfigured(


### PR DESCRIPTION
For abstract classes such as `SaveDocumentAnswer` the str name is same
as base class. Hence it leads to a duplication when `Mutation` is also
overridden. It makes much more sense to check for the class name to
check for duplicates.