### PR TITLE
Allow restricting of languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A list of configuration options which you might need to configure to get Caluma 
 * `DATABASE_USER`: Username to use when connecting to the database (default: caluma)
 * `DATABASE_PASSWORD`: Password to use when connecting to database
 * `LANGUAGE_CODE`: Default language defined as fallback (default: en)
+* `LANGUAGES`: List of supported language codes (default: all available)
 
 #### Authentication and authorization
 

--- a/caluma/settings.py
+++ b/caluma/settings.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import environ
+from django.conf import global_settings
 
 env = environ.Env()
 django_root = environ.Path(__file__) - 2
@@ -93,7 +94,16 @@ CACHES = {
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/
 
+
+def parse_languages(languages):
+    return [(language, language) for language in languages]
+
+
 LANGUAGE_CODE = env.str("LANGUAGE_CODE", "en")
+LANGUAGES = (
+    parse_languages(env.list("LANGUAGES", default=[])) or global_settings.LANGUAGES
+)
+
 TIME_ZONE = env.str("TIME_ZONE", "UTC")
 USE_I18N = True
 USE_L10N = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ DJANGO_SETTINGS_MODULE = caluma.settings
 env =
     OIDC_USERINFO_ENDPOINT=mock://caluma.io/openid/userinfo
     OIDC_BEARER_TOKEN_REVALIDATION_TIME=60
+    LANGUAGES=en,de,fr
 filterwarnings =
     error::DeprecationWarning
     error::PendingDeprecationWarning


### PR DESCRIPTION
Fixes #201 

Per default all languages are supported and api user (e.g frontend)
decides what languages are supported.