### PR TITLE
Allow ordering field values to be a python list

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -122,7 +122,12 @@ class OrderingField(ChoiceField):
     See `convert_ordering_field_to_enum`
     """
 
-    pass
+    def validate(self, value):
+        invalid = set(value or []) - {choice[0] for choice in self.choices}
+        return not bool(invalid)
+
+    def to_python(self, value):
+        return value
 
 
 class ListField(forms.Field):

--- a/caluma/form/tests/snapshots/snap_test_form.py
+++ b/caluma/form/tests/snapshots/snap_test_form.py
@@ -27,43 +27,6 @@ snapshots["test_remove_form_question 1"] = {
     "errors": [],
 }
 
-snapshots["test_query_all_forms[First result] 1"] = {
-    "allForms": {
-        "edges": [
-            {
-                "node": {
-                    "description": "First result",
-                    "id": "Rm9ybTplZmZvcnQtbWVldA==",
-                    "meta": "{}",
-                    "name": "Brian Williams",
-                    "questions": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "id": "VGV4dGFyZWFRdWVzdGlvbjpzdWdnZXN0LXRyYWRpdGlvbmFs",
-                                    "label": "John Thomas",
-                                    "slug": "suggest-traditional",
-                                }
-                            }
-                        ]
-                    },
-                    "slug": "effort-meet",
-                }
-            },
-            {
-                "node": {
-                    "description": "Seconds result",
-                    "id": "Rm9ybTpzZXJ2aWNlLWJhbmstYXJt",
-                    "meta": "{}",
-                    "name": "Brian Williams",
-                    "questions": {"edges": []},
-                    "slug": "service-bank-arm",
-                }
-            },
-        ]
-    }
-}
-
 snapshots["test_save_form[some description text-en] 1"] = {
     "saveForm": {
         "clientMutationId": "testid",
@@ -109,5 +72,52 @@ snapshots["test_save_form[de] 1"] = {
             "name": "Brian Williams",
             "slug": "effort-meet",
         },
+    }
+}
+
+snapshots["test_query_all_forms[First result-1st] 1"] = {
+    "allForms": {
+        "edges": [
+            {
+                "node": {
+                    "description": "First result",
+                    "id": "Rm9ybTplZmZvcnQtbWVldA==",
+                    "meta": "{}",
+                    "name": "1st",
+                    "questions": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "id": "RmxvYXRRdWVzdGlvbjphY3Jvc3MtZW52aXJvbm1lbnQ=",
+                                    "label": "Tyler Valencia",
+                                    "slug": "across-environment",
+                                }
+                            }
+                        ]
+                    },
+                    "slug": "effort-meet",
+                }
+            },
+            {
+                "node": {
+                    "description": "Second result",
+                    "id": "Rm9ybTpraXRjaGVuLWRldmVsb3A=",
+                    "meta": "{}",
+                    "name": "2nd",
+                    "questions": {"edges": []},
+                    "slug": "kitchen-develop",
+                }
+            },
+            {
+                "node": {
+                    "description": "Second result",
+                    "id": "Rm9ybTpzZXJ2aWNlLWJhbmstYXJt",
+                    "meta": "{}",
+                    "name": "3rd",
+                    "questions": {"edges": []},
+                    "slug": "service-bank-arm",
+                }
+            },
+        ]
     }
 }

--- a/caluma/form/tests/test_form.py
+++ b/caluma/form/tests/test_form.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timedelta
-
 import pytest
 from django.utils import translation
 from graphql_relay import to_global_id
@@ -12,15 +10,12 @@ from ...core.tests import (
 from ..serializers import SaveFormSerializer
 
 
-@pytest.mark.parametrize("form__description", ["First result"])
+@pytest.mark.parametrize("form__description,form__name", [("First result", "1st")])
 def test_query_all_forms(
     db, snapshot, form, form_factory, form_question, question, schema_executor
 ):
-    form_factory(
-        name=form.name,
-        description="Seconds result",
-        created_at=datetime.now() + timedelta(2),
-    )
+    form_factory(name="3rd", description="Second result")
+    form_factory(name="2nd", description="Second result")
 
     query = """
         query AllFormsQuery($name: String, $question: String, $orderBy: [FormOrdering]) {
@@ -50,7 +45,6 @@ def test_query_all_forms(
     result = schema_executor(
         query,
         variables={
-            "name": form.name,
             "question": question.label,
             "orderBy": ["NAME_ASC", "CREATED_AT_ASC"],
         },


### PR DESCRIPTION
Default django_filter.OrderingFilter expects value to be a comma separated
which doesn't work in our case as we have actual lists from GraphQL.