### PR TITLE
Set created by user and group on all nodes

### DIFF
--- a/caluma/form/models.py
+++ b/caluma/form/models.py
@@ -97,9 +97,14 @@ class Option(SlugModel):
 
 
 class DocumentManager(models.Manager):
-    def create_document_for_task(self, task):
+    def create_document_for_task(self, task, user):
         if task.form_id is not None:
-            return Document.objects.create(form_id=task.form_id)
+            return Document.objects.create(
+                form_id=task.form_id,
+                created_by_user=user.username,
+                created_by_group=user.group,
+            )
+
         return None
 
 

--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -144,8 +144,15 @@ class SaveTextareaQuestionSerializer(SaveQuestionSerializer):
 
 class SaveQuestionOptionsMixin(object):
     def create_question_options(self, question, options):
+        user = self.context["request"].user
         question_option = [
-            models.QuestionOption(sort=sort, question=question, option=option)
+            models.QuestionOption(
+                sort=sort,
+                question=question,
+                option=option,
+                created_by_user=user.username,
+                created_by_group=user.group,
+            )
             for sort, option in enumerate(reversed(options))
         ]
         models.QuestionOption.objects.bulk_create(question_option)

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -283,8 +283,12 @@ type FloatQuestion implements Question, Node {
 }
 
 type Flow implements Node {
-  next: FlowJexl!
+  createdAt: DateTime!
+  modifiedAt: DateTime!
+  createdByUser: String
+  createdByGroup: String
   id: ID!
+  next: FlowJexl!
   tasks: [Task]!
 }
 

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -118,7 +118,6 @@ class Flow(DjangoObjectType):
 
     class Meta:
         model = models.Flow
-        only_fields = ("tasks", "next")
         interfaces = (relay.Node,)
 
 

--- a/caluma/workflow/tests/snapshots/snap_test_workflow.py
+++ b/caluma/workflow/tests/snapshots/snap_test_workflow.py
@@ -33,6 +33,13 @@ Hot morning future throughout guess language drive.""",
     }
 }
 
+snapshots["test_save_workflow 1"] = {
+    "saveWorkflow": {
+        "clientMutationId": "testid",
+        "workflow": {"meta": "{}", "name": "Renee Ayala", "slug": "few-list-tax"},
+    }
+}
+
 snapshots['test_add_workflow_flow[task-slug-"task-slug"|task] 1'] = {
     "data": {
         "addWorkflowFlow": {
@@ -42,6 +49,8 @@ snapshots['test_add_workflow_flow[task-slug-"task-slug"|task] 1'] = {
                     "edges": [
                         {
                             "node": {
+                                "createdByGroup": "admin",
+                                "createdByUser": "admin",
                                 "next": '"task-slug"|task',
                                 "tasks": [{"slug": "task-slug"}],
                             }
@@ -85,11 +94,4 @@ snapshots['test_add_workflow_flow[task-slug-""] 1'] = {
             "path": ["addWorkflowFlow"],
         }
     ],
-}
-
-snapshots["test_save_workflow 1"] = {
-    "saveWorkflow": {
-        "clientMutationId": "testid",
-        "workflow": {"meta": "{}", "name": "Renee Ayala", "slug": "few-list-tax"},
-    }
 }

--- a/caluma/workflow/tests/test_workflow.py
+++ b/caluma/workflow/tests/test_workflow.py
@@ -120,7 +120,7 @@ def test_archive_workflow(db, workflow, schema_executor):
         ("task-slug", '""'),
     ],
 )
-def test_add_workflow_flow(db, workflow, task, snapshot, next, schema_executor):
+def test_add_workflow_flow(db, workflow, task, snapshot, next, admin_schema_executor):
     query = """
         mutation AddWorkflowFlow($input: AddWorkflowFlowInput!) {
           addWorkflowFlow(input: $input) {
@@ -128,6 +128,8 @@ def test_add_workflow_flow(db, workflow, task, snapshot, next, schema_executor):
               flows {
                 edges {
                   node {
+                    createdByUser
+                    createdByGroup
                     next
                     tasks {
                       slug
@@ -141,7 +143,7 @@ def test_add_workflow_flow(db, workflow, task, snapshot, next, schema_executor):
         }
     """
 
-    result = schema_executor(
+    result = admin_schema_executor(
         query,
         variables={
             "input": {


### PR DESCRIPTION
Some cases where serializers is not used to create instance
did not properly set user and group.

However no generic solution on base model used as it would involve
thread local and only visible model classes are actually affected.