### PR TITLE
Use enum type for choices arguments

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -11,6 +11,7 @@ from django.utils import translation
 from django_filters.constants import EMPTY_VALUES
 from django_filters.fields import ChoiceField
 from django_filters.rest_framework import (
+    ChoiceFilter,
     Filter,
     FilterSet,
     MultipleChoiceFilter,
@@ -164,7 +165,16 @@ class OrderingFilter(OrderingFilter):
 
 
 class FilterSet(GrapheneFilterSetMixin, FilterSet):
-    pass
+    @classmethod
+    def filter_for_lookup(cls, field, lookup_type):
+        filter_class, params = super().filter_for_lookup(field, lookup_type)
+        if issubclass(filter_class, ChoiceFilter):
+            meta = field.model._meta
+            # Prefixing newly created filter with Argument to avoid conflicts
+            # with query nodes
+            name = to_camel_case(f"{meta.object_name}_{field.name}_argument")
+            params["label"] = name
+        return filter_class, params
 
 
 class DjangoFilterConnectionField(filter.DjangoFilterConnectionField):
@@ -174,6 +184,10 @@ class DjangoFilterConnectionField(filter.DjangoFilterConnectionField):
     Inspired by https://github.com/graphql-python/graphene-django/pull/528/files
     and might be removed once merged.
     """
+
+    @property
+    def filterset_class(self):
+        return self._provided_filterset_class
 
     @classmethod
     def resolve_queryset(cls, connection, queryset, info, **args):
@@ -214,10 +228,6 @@ class DjangoFilterConnectionField(filter.DjangoFilterConnectionField):
 
 
 class DjangoFilterSetConnectionField(DjangoFilterConnectionField):
-    @property
-    def filterset_class(self):
-        return self._provided_filterset_class
-
     @property
     def model(self):
         return self.filterset_class._meta.model
@@ -260,6 +270,43 @@ def convert_ordering_field_to_enum(field):
 
     enum = Enum(name, list(named_choices), type=EnumWithDescriptionsType)
     converted = List(enum, description=field.help_text, required=field.required)
+
+    registry.register_converted_field(field, converted)
+    return converted
+
+
+@convert_form_field.register(ChoiceField)
+def convert_choice_field_to_enum(field):
+    """
+    Add support to convert ordering choices to Graphql enum.
+
+    Label is used as enum name.
+    """
+
+    registry = get_global_registry()
+    converted = registry.get_converted_field(field)
+    if converted:
+        return converted
+
+    def get_choices(choices):
+        for value, help_text in choices:
+            if value:
+                name = convert_choice_name(value)
+                description = help_text
+                yield name, value, description
+
+    name = to_camel_case(field.label)
+    choices = list(get_choices(field.choices))
+    named_choices = [(c[0], c[1]) for c in choices]
+    named_choices_descriptions = {c[0]: c[2] for c in choices}
+
+    class EnumWithDescriptionsType(object):
+        @property
+        def description(self):
+            return named_choices_descriptions[self.name]
+
+    enum = Enum(name, list(named_choices), type=EnumWithDescriptionsType)
+    converted = enum(description=field.help_text, required=field.required)
 
     registry.register_converted_field(field, converted)
     return converted

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -128,7 +128,7 @@ type Case implements Node {
   status: CaseStatus!
   meta: JSONString!
   document: Document
-  workItems(before: String, after: String, first: Int, last: Int, status: String, task: ID, case: ID, orderBy: [WorkItemOrdering]): WorkItemConnection
+  workItems(before: String, after: String, first: Int, last: Int, status: WorkItemStatusArgument, task: ID, case: ID, orderBy: [WorkItemOrdering]): WorkItemConnection
   parentWorkItem: WorkItem
 }
 
@@ -156,6 +156,12 @@ enum CaseOrdering {
 }
 
 enum CaseStatus {
+  RUNNING
+  COMPLETED
+  CANCELED
+}
+
+enum CaseStatusArgument {
   RUNNING
   COMPLETED
   CANCELED
@@ -490,9 +496,9 @@ type PublishWorkflowPayload {
 
 type Query {
   allWorkflows(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String, orderBy: [WorkflowOrdering]): WorkflowConnection
-  allTasks(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, type: String, isArchived: Boolean, search: String, orderBy: [TaskOrdering]): TaskConnection
-  allCases(before: String, after: String, first: Int, last: Int, workflow: ID, status: String, orderBy: [CaseOrdering]): CaseConnection
-  allWorkItems(before: String, after: String, first: Int, last: Int, orderBy: [WorkItemOrdering], status: String, task: ID, case: ID): WorkItemConnection
+  allTasks(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, search: String, orderBy: [TaskOrdering]): TaskConnection
+  allCases(before: String, after: String, first: Int, last: Int, workflow: ID, status: CaseStatusArgument, orderBy: [CaseOrdering]): CaseConnection
+  allWorkItems(before: String, after: String, first: Int, last: Int, status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], task: ID, case: ID): WorkItemConnection
   allForms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, search: String): FormConnection
   allQuestions(before: String, after: String, first: Int, last: Int, orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, excludeForms: [ID], search: String): QuestionConnection
   allDocuments(before: String, after: String, first: Int, last: Int, form: ID, search: String, id: ID, orderBy: [DocumentOrdering]): DocumentConnection
@@ -986,6 +992,12 @@ enum TaskType {
   COMPLETE_TASK_FORM
 }
 
+enum TaskTypeArgument {
+  SIMPLE
+  COMPLETE_WORKFLOW_FORM
+  COMPLETE_TASK_FORM
+}
+
 type TextQuestion implements Question, Node {
   createdAt: DateTime!
   modifiedAt: DateTime!
@@ -1058,6 +1070,12 @@ enum WorkItemOrdering {
 }
 
 enum WorkItemStatus {
+  READY
+  COMPLETED
+  CANCELED
+}
+
+enum WorkItemStatusArgument {
   READY
   COMPLETED
   CANCELED

--- a/caluma/workflow/tests/snapshots/snap_test_work_item.py
+++ b/caluma/workflow/tests/snapshots/snap_test_work_item.py
@@ -7,10 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots["test_query_all_work_items 1"] = {
-    "allWorkItems": {"edges": [{"node": {"status": "READY"}}]}
-}
-
 snapshots["test_complete_work_item_last[ready-completed-True-simple-None] 1"] = {
     "completeWorkItem": {
         "clientMutationId": None,


### PR DESCRIPTION
This change makes api more consistent that arguments and query node types use the same uppercase naming. It additionally allows also autocompletion for argument filters.