### PR TITLE
Add union visibility class

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Visibility classes are configured as `VISIBILITY_CLASSES`.
 
 Following pre-defined classes are available:
 * `caluma.core.visibilities.Any`: Allow any user without any filtering
+* `caluma.core.visibilities.Union`: Union result of a list of configured visibility classes. May only be used as base class.
 * `caluma.user.visibilities.Authenticated`: Only show data to authenticated users
 * `caluma.user.visibilities.CreatedByGroup`: Only show data that belongs to the same group as the current user
 * `caluma.workflow.visibilities.AddressedGroups`: Only show case, work item and document to addressed users through group

--- a/caluma/core/visibilities.py
+++ b/caluma/core/visibilities.py
@@ -68,3 +68,20 @@ class Any(BaseVisibility):
     """No restrictions, all nodes are exposed."""
 
     pass
+
+
+class Union(BaseVisibility):
+    """Union result of a list of configured visibility classes."""
+
+    visibility_classes = []
+
+    def filter_queryset(self, node, queryset, info):
+        result_queryset = None
+        for visibility_class in self.visibility_classes:
+            class_result = visibility_class().filter_queryset(node, queryset, info)
+            if result_queryset is None:
+                result_queryset = class_result
+            else:
+                result_queryset = result_queryset.union(class_result)
+
+        return result_queryset or queryset


### PR DESCRIPTION
Fixes #216 

This allows creator of extension points to union different visibility classes (e.g. CreatedByGroup and AddressedGroups)