### PR TITLE
Improve performance of complex Graphql queries

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -194,6 +194,14 @@ class DjangoFilterConnectionField(filter.DjangoFilterConnectionField):
         return connection._meta.node.get_queryset(queryset, info)
 
     @classmethod
+    def merge_querysets(cls, default_queryset, queryset):
+        queryset = super().merge_querysets(default_queryset, queryset)
+        # avoid query explosion of single relationships
+        # may be removed once following issue is fixed:
+        # https://github.com/graphql-python/graphene-django/issues/57
+        return queryset.select_related()
+
+    @classmethod
     def connection_resolver(
         cls,
         resolver,

--- a/caluma/core/types.py
+++ b/caluma/core/types.py
@@ -20,7 +20,7 @@ class Node(object):
         for visibility_class in cls.visibility_classes:
             queryset = visibility_class().filter_queryset(cls, queryset, info)
 
-        return queryset
+        return queryset.select_related()
 
 
 class DjangoObjectType(Node, types.DjangoObjectType):

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -375,7 +375,6 @@ class Document(DjangoObjectType):
         model = models.Document
         exclude_fields = ("family",)
         interfaces = (graphene.Node,)
-        filter_fields = ("form",)
 
 
 class TableAnswer(AnswerQuerysetMixin, DjangoObjectType):

--- a/caluma/form/tests/test_document.py
+++ b/caluma/form/tests/test_document.py
@@ -76,6 +76,123 @@ def test_query_all_documents(
     snapshot.assert_match(result.data)
 
 
+def test_complex_document_query_performance(
+    db,
+    schema_executor,
+    document,
+    form,
+    form_question_factory,
+    question_factory,
+    answer_factory,
+    question_option_factory,
+    django_assert_num_queries,
+):
+    answers = answer_factory.create_batch(5, document=document)
+    for answer in answers:
+        form_question_factory(question=answer.question, form=form)
+    checkbox_question = question_factory(type=Question.TYPE_CHECKBOX)
+    form_question_factory(question=checkbox_question, form=form)
+    question_option_factory.create_batch(10, question=checkbox_question)
+    answer_factory(question=checkbox_question)
+
+    query = """
+        query ($id: ID!) {
+          allDocuments(id: $id) {
+            edges {
+              node {
+                ...FormDocument
+              }
+            }
+          }
+        }
+
+        fragment FormDocument on Document {
+          id
+          answers {
+            edges {
+              node {
+                ...FieldAnswer
+              }
+            }
+          }
+          form {
+            slug
+            questions {
+              edges {
+                node {
+                  ...FieldQuestion
+                }
+              }
+            }
+          }
+        }
+
+        fragment FieldAnswer on Answer {
+          id
+          question {
+            slug
+          }
+          ... on StringAnswer {
+            stringValue: value
+          }
+          ... on IntegerAnswer {
+            integerValue: value
+          }
+          ... on FloatAnswer {
+            floatValue: value
+          }
+          ... on ListAnswer {
+            listValue: value
+          }
+        }
+
+        fragment FieldQuestion on Question {
+          slug
+          label
+          isRequired
+          isHidden
+          ... on TextQuestion {
+            textMaxLength: maxLength
+          }
+          ... on TextareaQuestion {
+            textareaMaxLength: maxLength
+          }
+          ... on IntegerQuestion {
+            integerMinValue: minValue
+            integerMaxValue: maxValue
+          }
+          ... on FloatQuestion {
+            floatMinValue: minValue
+            floatMaxValue: maxValue
+          }
+          ... on RadioQuestion {
+            radioOptions: options {
+              edges {
+                node {
+                  slug
+                  label
+                }
+              }
+            }
+          }
+          ... on CheckboxQuestion {
+            checkboxOptions: options {
+              edges {
+                node {
+                  slug
+                  label
+                }
+              }
+            }
+          }
+        }
+    """
+
+    with django_assert_num_queries(6):
+        result = schema_executor(query, variables={"id": str(document.pk)})
+    assert not result.errors
+
+
 def test_query_all_documents_filter_answers_by_question(
     db, snapshot, document, answer, question, answer_factory, schema_executor
 ):

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -130,7 +130,6 @@ class Workflow(DjangoObjectType):
 
     class Meta:
         model = models.Workflow
-        filter_fields = ("slug", "name", "description", "is_published", "is_archived")
         exclude_fields = ("cases", "task_flows")
         interfaces = (relay.Node,)
 

--- a/caluma/workflow/tests/test_workflow.py
+++ b/caluma/workflow/tests/test_workflow.py
@@ -11,7 +11,7 @@ from ...core.tests import (
 def test_query_all_workflows(db, snapshot, workflow, task_flow, flow, schema_executor):
     query = """
         query AllWorkflows($name: String!) {
-          allWorkflows(name: $name) {
+          allWorkflows(first: 1, name: $name) {
             edges {
               node {
                 slug


### PR DESCRIPTION
Fixes #219 

* Avoid count queries when no pagination is enabled
* Select related on all nodes to avoid query explosions when retrieving single children
* Avoid calling of filterset class when there are not filtering args