### PR TITLE
Use hashsum of token for userinfo caching

### DIFF
--- a/caluma/user/tests/test_middleware.py
+++ b/caluma/user/tests/test_middleware.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 import pytest
@@ -42,4 +43,9 @@ def test_oidc_authentication_middleware(
     if not error:
         assert request.user.is_authenticated == authenticated
         if authenticated:
-            assert cache.get("authentication.userinfo.Token") == userinfo
+            assert (
+                cache.get(
+                    f"authentication.userinfo.{hashlib.sha256(b'Token').hexdigest()}"
+                )
+                == userinfo
+            )


### PR DESCRIPTION
Some token especially of providers which use JWT also for access tokens
are too long for memcache key limit of 250 so the need to be hashed.