### PR TITLE
Fix filtering on union visibility class

### DIFF
--- a/caluma/core/visibilities.py
+++ b/caluma/core/visibilities.py
@@ -84,4 +84,7 @@ class Union(BaseVisibility):
             else:
                 result_queryset = result_queryset.union(class_result)
 
-        return result_queryset or queryset
+        if result_queryset:
+            queryset = queryset.filter(pk__in=result_queryset)
+
+        return queryset


### PR DESCRIPTION
Django querysets don't support `filter` after `union`
(see https://docs.djangoproject.com/en/2.1/ref/models/querysets/#union),
which breaks simple "get by ID" queries ("get() returned more than one
Workflow -- it returned 2!").

We're fixing this by filtering our main queryset with the result of the union query.