### PR TITLE
Visibility filters: First function "wins"

### DIFF
--- a/caluma/core/visibilities.py
+++ b/caluma/core/visibilities.py
@@ -59,7 +59,7 @@ class BaseVisibility(object):
     def filter_queryset(self, node, queryset, info):
         for cls in node.mro():
             if cls in self._filter_querysets_for:
-                queryset = self._filter_querysets_for[cls](node, queryset, info)
+                return self._filter_querysets_for[cls](node, queryset, info)
 
         return queryset
 


### PR DESCRIPTION
Before, we we're running _all_ matching visibility functions. Running
only the first (most specific) function allows overriding a generic
`Node` visibility function for specific models.

This is a backwards-incompatible change. Call your `Node`s visibility
function directly if you want to emulate previous behavior.