### PR TITLE
Fix Union visibility when queryset is empty

### DIFF
--- a/caluma/core/visibilities.py
+++ b/caluma/core/visibilities.py
@@ -84,7 +84,7 @@ class Union(BaseVisibility):
             else:
                 result_queryset = result_queryset.union(class_result)
 
-        if result_queryset:
+        if result_queryset is not None:
             queryset = queryset.filter(pk__in=result_queryset)
 
         return queryset


### PR DESCRIPTION
Since empty querysets are treated as falsy the union filtering was not
applied if one class returned an empty queryset.