### PR TITLE
Remove snapshot tests in erroneous cases

### DIFF
--- a/caluma/conftest.py
+++ b/caluma/conftest.py
@@ -6,9 +6,7 @@ from django.core.cache import cache
 from factory import Faker
 from factory.base import FactoryMetaClass
 from graphene import ResolveInfo
-from graphql.error import format_error
 from pytest_factoryboy import register
-from snapshottest.pytest import PyTestSnapshotTest
 
 from .core.faker import MultilangProvider
 from .form import factories as form_factories
@@ -32,21 +30,6 @@ register_module(workflow_factories)
 @pytest.fixture(scope="function", autouse=True)
 def _autoclear_cache():
     cache.clear()
-
-
-@pytest.fixture
-def snapshot(request):
-    class GraphQlSnapshotTest(PyTestSnapshotTest):
-        def assert_execution_result(self, result):
-            self.assert_match(
-                {
-                    "data": result.data,
-                    "errors": [format_error(e) for e in result.errors or []],
-                }
-            )
-
-    with GraphQlSnapshotTest(request) as snapshot_test:
-        yield snapshot_test
 
 
 @pytest.fixture

--- a/caluma/form/tests/snapshots/snap_test_document.py
+++ b/caluma/form/tests/snapshots/snap_test_document.py
@@ -111,10 +111,29 @@ snapshots["test_query_all_documents[table-None] 1"] = {
     }
 }
 
-snapshots["test_save_document 1"] = {
-    "saveDocument": {
-        "clientMutationId": "testid",
-        "document": {"form": {"slug": "effort-meet"}},
+snapshots["test_query_all_documents[multiple_choice-answer__value3] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "ListAnswer",
+                                    "list_value": ["somevalue", "anothervalue"],
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
     }
 }
 
@@ -219,50 +238,6 @@ snapshots[
 }
 
 snapshots[
-    "test_save_document_answer[choice-question__configuration11-option-slug-SaveDocumentStringAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "option-slug"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[choice-question__configuration11-option-slug-SaveDocumentStringAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "option-slug"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots["test_query_all_documents[multiple_choice-answer__value3] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "ListAnswer",
-                                    "list_value": ["somevalue", "anothervalue"],
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
-                }
-            }
-        ]
-    }
-}
-
-snapshots[
     "test_save_document_answer[multiple_choice-question__configuration9-answer__value9-SaveDocumentListAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentListAnswer": {
@@ -276,6 +251,24 @@ snapshots[
 ] = {
     "saveDocumentListAnswer": {
         "answer": {"listValue": ["option-slug"]},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[choice-question__configuration11-option-slug-SaveDocumentStringAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"stringValue": "option-slug"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[choice-question__configuration11-option-slug-SaveDocumentStringAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"stringValue": "option-slug"},
         "clientMutationId": "testid",
     }
 }

--- a/caluma/form/tests/snapshots/snap_test_form.py
+++ b/caluma/form/tests/snapshots/snap_test_form.py
@@ -8,13 +8,10 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_remove_form_question 1"] = {
-    "data": {
-        "removeFormQuestion": {
-            "clientMutationId": None,
-            "form": {"questions": {"edges": []}},
-        }
-    },
-    "errors": [],
+    "removeFormQuestion": {
+        "clientMutationId": None,
+        "form": {"questions": {"edges": []}},
+    }
 }
 
 snapshots["test_save_form[some description text-en] 1"] = {

--- a/caluma/form/tests/snapshots/snap_test_question.py
+++ b/caluma/form/tests/snapshots/snap_test_question.py
@@ -43,170 +43,6 @@ snapshots["test_query_all_questions[float-question__configuration1] 1"] = {
     }
 }
 
-snapshots["test_save_question[true-SaveTextQuestion] 1"] = {
-    "data": {
-        "saveTextQuestion": {
-            "clientMutationId": "testid",
-            "question": {
-                "__typename": "TextQuestion",
-                "id": "VGV4dFF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
-                "label": "Thomas Johnson",
-                "meta": "{}",
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
-}
-
-snapshots["test_save_question[true-SaveTextareaQuestion] 1"] = {
-    "data": {
-        "saveTextareaQuestion": {
-            "clientMutationId": "testid",
-            "question": {
-                "__typename": "TextareaQuestion",
-                "id": "VGV4dGFyZWFRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
-                "label": "Thomas Johnson",
-                "meta": "{}",
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
-}
-
-snapshots["test_save_question[true-SaveIntegerQuestion] 1"] = {
-    "data": {
-        "saveIntegerQuestion": {
-            "clientMutationId": "testid",
-            "question": {
-                "__typename": "IntegerQuestion",
-                "id": "SW50ZWdlclF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
-                "label": "Thomas Johnson",
-                "meta": "{}",
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
-}
-
-snapshots["test_save_question[true-SaveFloatQuestion] 1"] = {
-    "data": {
-        "saveFloatQuestion": {
-            "clientMutationId": "testid",
-            "question": {
-                "__typename": "FloatQuestion",
-                "id": "RmxvYXRRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
-                "label": "Thomas Johnson",
-                "meta": "{}",
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
-}
-
-snapshots["test_save_question[true|invalid-SaveTextQuestion] 1"] = {
-    "data": {"saveTextQuestion": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'is_required': [ErrorDetail(string='The `invalid` transform is undefined.', code='invalid')]}",
-            "path": ["saveTextQuestion"],
-        }
-    ],
-}
-
-snapshots["test_save_question[true|invalid-SaveTextareaQuestion] 1"] = {
-    "data": {"saveTextareaQuestion": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'is_required': [ErrorDetail(string='The `invalid` transform is undefined.', code='invalid')]}",
-            "path": ["saveTextareaQuestion"],
-        }
-    ],
-}
-
-snapshots["test_save_question[true|invalid-SaveIntegerQuestion] 1"] = {
-    "data": {"saveIntegerQuestion": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'is_required': [ErrorDetail(string='The `invalid` transform is undefined.', code='invalid')]}",
-            "path": ["saveIntegerQuestion"],
-        }
-    ],
-}
-
-snapshots["test_save_question[true|invalid-SaveFloatQuestion] 1"] = {
-    "data": {"saveFloatQuestion": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'is_required': [ErrorDetail(string='The `invalid` transform is undefined.', code='invalid')]}",
-            "path": ["saveFloatQuestion"],
-        }
-    ],
-}
-
-snapshots["test_save_float_question[float-question__configuration0] 1"] = {
-    "data": {
-        "saveFloatQuestion": {
-            "clientMutationId": "testid",
-            "question": {
-                "__typename": "FloatQuestion",
-                "id": "RmxvYXRRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
-                "label": "Thomas Johnson",
-                "maxValue": 10.0,
-                "meta": "{}",
-                "minValue": 0.0,
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
-}
-
-snapshots["test_save_float_question[float-question__configuration1] 1"] = {
-    "data": {"saveFloatQuestion": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'non_field_errors': [ErrorDetail(string='max_value 1.0 is smaller than 10.0', code='invalid')]}",
-            "path": ["saveFloatQuestion"],
-        }
-    ],
-}
-
-snapshots["test_save_integer_question[integer-question__configuration0] 1"] = {
-    "data": {
-        "saveIntegerQuestion": {
-            "clientMutationId": "testid",
-            "question": {
-                "__typename": "IntegerQuestion",
-                "id": "SW50ZWdlclF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
-                "label": "Thomas Johnson",
-                "meta": "{}",
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
-}
-
-snapshots["test_save_integer_question[integer-question__configuration1] 1"] = {
-    "data": {"saveIntegerQuestion": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'non_field_errors': [ErrorDetail(string='max_value 1 is smaller than 10', code='invalid')]}",
-            "path": ["saveIntegerQuestion"],
-        }
-    ],
-}
-
 snapshots["test_query_all_questions[float-question__configuration2] 1"] = {
     "allQuestions": {
         "edges": [
@@ -330,6 +166,86 @@ snapshots["test_save_multiple_choice_question[multiple_choice] 1"] = {
                     {"node": {"label": "Daniel Mann", "slug": "live-by-itself"}},
                 ]
             },
+            "slug": "sound-air-mission",
+        },
+    }
+}
+
+snapshots["test_save_question[true-True-SaveTextQuestion] 1"] = {
+    "saveTextQuestion": {
+        "clientMutationId": "testid",
+        "question": {
+            "__typename": "TextQuestion",
+            "id": "VGV4dFF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
+            "label": "Thomas Johnson",
+            "meta": "{}",
+            "slug": "sound-air-mission",
+        },
+    }
+}
+
+snapshots["test_save_question[true-True-SaveTextareaQuestion] 1"] = {
+    "saveTextareaQuestion": {
+        "clientMutationId": "testid",
+        "question": {
+            "__typename": "TextareaQuestion",
+            "id": "VGV4dGFyZWFRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
+            "label": "Thomas Johnson",
+            "meta": "{}",
+            "slug": "sound-air-mission",
+        },
+    }
+}
+
+snapshots["test_save_question[true-True-SaveIntegerQuestion] 1"] = {
+    "saveIntegerQuestion": {
+        "clientMutationId": "testid",
+        "question": {
+            "__typename": "IntegerQuestion",
+            "id": "SW50ZWdlclF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
+            "label": "Thomas Johnson",
+            "meta": "{}",
+            "slug": "sound-air-mission",
+        },
+    }
+}
+
+snapshots["test_save_question[true-True-SaveFloatQuestion] 1"] = {
+    "saveFloatQuestion": {
+        "clientMutationId": "testid",
+        "question": {
+            "__typename": "FloatQuestion",
+            "id": "RmxvYXRRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
+            "label": "Thomas Johnson",
+            "meta": "{}",
+            "slug": "sound-air-mission",
+        },
+    }
+}
+
+snapshots["test_save_float_question[float-question__configuration0-True] 1"] = {
+    "saveFloatQuestion": {
+        "clientMutationId": "testid",
+        "question": {
+            "__typename": "FloatQuestion",
+            "id": "RmxvYXRRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
+            "label": "Thomas Johnson",
+            "maxValue": 10.0,
+            "meta": "{}",
+            "minValue": 0.0,
+            "slug": "sound-air-mission",
+        },
+    }
+}
+
+snapshots["test_save_integer_question[integer-question__configuration0-True] 1"] = {
+    "saveIntegerQuestion": {
+        "clientMutationId": "testid",
+        "question": {
+            "__typename": "IntegerQuestion",
+            "id": "SW50ZWdlclF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
+            "label": "Thomas Johnson",
+            "meta": "{}",
             "slug": "sound-air-mission",
         },
     }

--- a/caluma/form/tests/test_document.py
+++ b/caluma/form/tests/test_document.py
@@ -194,7 +194,7 @@ def test_complex_document_query_performance(
 
 
 def test_query_all_documents_filter_answers_by_question(
-    db, snapshot, document, answer, question, answer_factory, schema_executor
+    db, document, answer, question, answer_factory, schema_executor
 ):
     answer_factory(document=document)
 
@@ -225,13 +225,13 @@ def test_query_all_documents_filter_answers_by_question(
     assert extract_global_id(result_answer["id"]) == str(answer.id)
 
 
-def test_save_document(db, snapshot, document, schema_executor):
+def test_save_document(db, document, schema_executor):
     query = """
         mutation SaveDocument($input: SaveDocumentInput!) {
           saveDocument(input: $input) {
             document {
                 form {
-                    slug
+                  slug
                 }
             }
             clientMutationId
@@ -247,7 +247,7 @@ def test_save_document(db, snapshot, document, schema_executor):
     result = schema_executor(query, variables=inp)
 
     assert not result.errors
-    snapshot.assert_match(result.data)
+    assert result.data["saveDocument"]["document"]["form"]["slug"] == document.form.slug
 
 
 @pytest.mark.parametrize("delete_answer", [True, False])

--- a/caluma/form/tests/test_form.py
+++ b/caluma/form/tests/test_form.py
@@ -79,9 +79,7 @@ def test_save_form(db, snapshot, form, settings, schema_executor, language_code)
     snapshot.assert_match(result.data)
 
 
-def test_save_form_created_as_admin_user(
-    db, snapshot, form, admin_schema_executor, admin_user
-):
+def test_save_form_created_as_admin_user(db, form, admin_schema_executor, admin_user):
     query = """
         mutation SaveForm($input: SaveFormInput!) {
           saveForm(input: $input) {
@@ -101,7 +99,7 @@ def test_save_form_created_as_admin_user(
 
 
 @pytest.mark.parametrize("form__meta", [{"meta": "set"}])
-def test_copy_form(db, snapshot, form, form_question_factory, schema_executor):
+def test_copy_form(db, form, form_question_factory, schema_executor):
     form_question_factory.create_batch(5, form=form)
     query = """
         mutation CopyForm($input: CopyFormInput!) {
@@ -130,9 +128,7 @@ def test_copy_form(db, snapshot, form, form_question_factory, schema_executor):
     ) == list(models.FormQuestion.objects.filter(form=form).values("question"))
 
 
-def test_add_form_question(
-    db, form, question, form_question_factory, snapshot, schema_executor
-):
+def test_add_form_question(db, form, question, form_question_factory, schema_executor):
     form_question_factory.create_batch(5, form=form)
 
     query = """
@@ -198,7 +194,8 @@ def test_remove_form_question(
         },
     )
 
-    snapshot.assert_execution_result(result)
+    assert not result.errors
+    snapshot.assert_match(result.data)
 
 
 def test_reorder_form_questions(db, form, form_question_factory, schema_executor):

--- a/caluma/form/tests/test_option.py
+++ b/caluma/form/tests/test_option.py
@@ -43,7 +43,7 @@ def test_remove_option(db, option, schema_executor):
 
 
 @pytest.mark.parametrize("option__meta", [{"meta": "set"}])
-def test_copy_option(db, option, snapshot, schema_executor):
+def test_copy_option(db, option, schema_executor):
     query = """
         mutation CopyOption($input: CopyOptionInput!) {
           copyOption(input: $input) {

--- a/caluma/workflow/tests/snapshots/snap_test_task.py
+++ b/caluma/workflow/tests/snapshots/snap_test_task.py
@@ -8,33 +8,27 @@ from snapshottest import Snapshot
 snapshots = Snapshot()
 
 snapshots["test_save_task[SaveSimpleTask] 1"] = {
-    "data": {
-        "saveSimpleTask": {
-            "clientMutationId": "testid",
-            "task": {
-                "__typename": "SimpleTask",
-                "meta": "{}",
-                "name": "Thomas Johnson",
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
+    "saveSimpleTask": {
+        "clientMutationId": "testid",
+        "task": {
+            "__typename": "SimpleTask",
+            "meta": "{}",
+            "name": "Thomas Johnson",
+            "slug": "sound-air-mission",
+        },
+    }
 }
 
 snapshots["test_save_task[SaveCompleteWorkflowFormTask] 1"] = {
-    "data": {
-        "saveCompleteWorkflowFormTask": {
-            "clientMutationId": "testid",
-            "task": {
-                "__typename": "CompleteWorkflowFormTask",
-                "meta": "{}",
-                "name": "Thomas Johnson",
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
+    "saveCompleteWorkflowFormTask": {
+        "clientMutationId": "testid",
+        "task": {
+            "__typename": "CompleteWorkflowFormTask",
+            "meta": "{}",
+            "name": "Thomas Johnson",
+            "slug": "sound-air-mission",
+        },
+    }
 }
 
 snapshots["test_query_all_tasks[simple] 1"] = {
@@ -54,16 +48,13 @@ snapshots["test_query_all_tasks[simple] 1"] = {
 }
 
 snapshots["test_save_comlete_task_form_task 1"] = {
-    "data": {
-        "saveCompleteTaskFormTask": {
-            "clientMutationId": "testid",
-            "task": {
-                "__typename": "CompleteTaskFormTask",
-                "meta": "{}",
-                "name": "Thomas Johnson",
-                "slug": "sound-air-mission",
-            },
-        }
-    },
-    "errors": [],
+    "saveCompleteTaskFormTask": {
+        "clientMutationId": "testid",
+        "task": {
+            "__typename": "CompleteTaskFormTask",
+            "meta": "{}",
+            "name": "Thomas Johnson",
+            "slug": "sound-air-mission",
+        },
+    }
 }

--- a/caluma/workflow/tests/snapshots/snap_test_workflow.py
+++ b/caluma/workflow/tests/snapshots/snap_test_workflow.py
@@ -7,62 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['test_add_workflow_flow[task-slug-"task-slug"|task] 1'] = {
-    "data": {
-        "addWorkflowFlow": {
-            "clientMutationId": None,
-            "workflow": {
-                "flows": {
-                    "edges": [
-                        {
-                            "node": {
-                                "createdByGroup": "admin",
-                                "createdByUser": "admin",
-                                "next": '"task-slug"|task',
-                                "tasks": [{"slug": "task-slug"}],
-                            }
-                        }
-                    ]
-                }
-            },
-        }
-    },
-    "errors": [],
-}
-
-snapshots['test_add_workflow_flow[task-slug-"not-av-task-slug"|task] 1'] = {
-    "data": {"addWorkflowFlow": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'next': [ErrorDetail(string='jexl `\"not-av-task-slug\"|task` contains invalid tasks [not-av-task-slug]', code='invalid')]}",
-            "path": ["addWorkflowFlow"],
-        }
-    ],
-}
-
-snapshots['test_add_workflow_flow[task-slug-"not-av-task-slug"|invalid] 1'] = {
-    "data": {"addWorkflowFlow": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'next': [ErrorDetail(string='The `invalid` transform is undefined.', code='invalid')]}",
-            "path": ["addWorkflowFlow"],
-        }
-    ],
-}
-
-snapshots['test_add_workflow_flow[task-slug-""] 1'] = {
-    "data": {"addWorkflowFlow": None},
-    "errors": [
-        {
-            "locations": [{"column": 11, "line": 3}],
-            "message": "{'next': [ErrorDetail(string='jexl `\"\"` does not contain any tasks as return value', code='invalid')]}",
-            "path": ["addWorkflowFlow"],
-        }
-    ],
-}
-
 snapshots["test_save_workflow 1"] = {
     "saveWorkflow": {
         "clientMutationId": "testid",
@@ -102,5 +46,25 @@ Kid avoid player relationship to range whose. Draw free property consider.""",
                 }
             }
         ]
+    }
+}
+
+snapshots['test_add_workflow_flow[task-slug-"task-slug"|task-True] 1'] = {
+    "addWorkflowFlow": {
+        "clientMutationId": None,
+        "workflow": {
+            "flows": {
+                "edges": [
+                    {
+                        "node": {
+                            "createdByGroup": "admin",
+                            "createdByUser": "admin",
+                            "next": '"task-slug"|task',
+                            "tasks": [{"slug": "task-slug"}],
+                        }
+                    }
+                ]
+            }
+        },
     }
 }

--- a/caluma/workflow/tests/test_case.py
+++ b/caluma/workflow/tests/test_case.py
@@ -73,7 +73,7 @@ def test_start_case(
     snapshot.assert_match(result.data)
 
 
-def test_start_sub_case(db, snapshot, workflow, work_item, schema_executor):
+def test_start_sub_case(db, workflow, work_item, schema_executor):
     query = """
         mutation StartCase($input: StartCaseInput!) {
           startCase(input: $input) {
@@ -95,7 +95,7 @@ def test_start_sub_case(db, snapshot, workflow, work_item, schema_executor):
     assert case.parent_work_item.pk == work_item.pk
 
 
-def test_start_case_invalid_form(db, snapshot, workflow, form, schema_executor):
+def test_start_case_invalid_form(db, workflow, form, schema_executor):
     query = """
         mutation StartCase($input: StartCaseInput!) {
           startCase(input: $input) {

--- a/caluma/workflow/tests/test_task.py
+++ b/caluma/workflow/tests/test_task.py
@@ -50,7 +50,7 @@ def test_save_task(db, snapshot, task, mutation, schema_executor):
     }
     result = schema_executor(query, variables=inp)
     assert not result.errors
-    snapshot.assert_execution_result(result)
+    snapshot.assert_match(result.data)
 
 
 def test_save_comlete_task_form_task(db, snapshot, task, schema_executor):
@@ -75,4 +75,4 @@ def test_save_comlete_task_form_task(db, snapshot, task, schema_executor):
     }
     result = schema_executor(query, variables=inp)
     assert not result.errors
-    snapshot.assert_execution_result(result)
+    snapshot.assert_match(result.data)

--- a/caluma/workflow/tests/test_work_item.py
+++ b/caluma/workflow/tests/test_work_item.py
@@ -89,7 +89,6 @@ def test_complete_work_item_last(db, snapshot, work_item, success, schema_execut
 )
 def test_complete_workflow_form_work_item(
     db,
-    snapshot,
     work_item,
     answer,
     question_factory,
@@ -149,7 +148,7 @@ def test_complete_workflow_form_work_item(
     [(Question.TYPE_INTEGER, 1, True), (Question.TYPE_CHOICE, "", False)],
 )
 def test_complete_task_form_work_item(
-    db, snapshot, work_item, answer, form_question, success, schema_executor
+    db, work_item, answer, form_question, success, schema_executor
 ):
     query = """
         mutation CompleteWorkItem($input: CompleteWorkItemInput!) {
@@ -235,7 +234,6 @@ def test_complete_work_item_with_next(
 )
 def test_complete_work_item_with_next_multiple_tasks(
     db,
-    snapshot,
     case,
     work_item,
     task,
@@ -288,7 +286,6 @@ def test_complete_work_item_with_next_multiple_tasks(
 )
 def test_complete_work_item_with_merge(
     db,
-    snapshot,
     case,
     work_item,
     work_item_factory,
@@ -347,7 +344,7 @@ def test_complete_work_item_with_merge(
     assert ready_workitem.document_id is not None
 
 
-def test_set_work_item_assigned_users(db, snapshot, work_item, schema_executor):
+def test_set_work_item_assigned_users(db, work_item, schema_executor):
     query = """
         mutation SetWorkItemAssignedUsers($input: SetWorkItemAssignedUsersInput!) {
           setWorkItemAssignedUsers(input: $input) {

--- a/caluma/workflow/tests/test_workflow.py
+++ b/caluma/workflow/tests/test_workflow.py
@@ -94,15 +94,17 @@ def test_save_workflow(
 
 
 @pytest.mark.parametrize(
-    "task__slug,next",
+    "task__slug,next,success",
     [
-        ("task-slug", '"task-slug"|task'),
-        ("task-slug", '"not-av-task-slug"|task'),
-        ("task-slug", '"not-av-task-slug"|invalid'),
-        ("task-slug", '""'),
+        ("task-slug", '"task-slug"|task', True),
+        ("task-slug", '"not-av-task-slug"|task', False),
+        ("task-slug", '"not-av-task-slug"|invalid', False),
+        ("task-slug", '""', False),
     ],
 )
-def test_add_workflow_flow(db, workflow, task, snapshot, next, admin_schema_executor):
+def test_add_workflow_flow(
+    db, workflow, task, snapshot, success, next, admin_schema_executor
+):
     query = """
         mutation AddWorkflowFlow($input: AddWorkflowFlowInput!) {
           addWorkflowFlow(input: $input) {
@@ -135,10 +137,12 @@ def test_add_workflow_flow(db, workflow, task, snapshot, next, admin_schema_exec
             }
         },
     )
-    snapshot.assert_execution_result(result)
+    assert not bool(result.errors) == success
+    if success:
+        snapshot.assert_match(result.data)
 
 
-def test_remove_flow(db, workflow, task_flow, flow, snapshot, schema_executor):
+def test_remove_flow(db, workflow, task_flow, flow, schema_executor):
     query = """
         mutation RemoveFlow($input: RemoveFlowInput!) {
           removeFlow(input: $input) {


### PR DESCRIPTION
Fixes #85 

Sometimes ordering of snapshots can be odd, hence it is difficult to rely
on snapshot to check whether a test was successful or not
it can be simply overlooked that a test actually failed even though
it should not have.