### PR TITLE
Allow saving of meta data on work item

### DIFF
--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -419,7 +419,7 @@ type Mutation {
   startCase(input: StartCaseInput!): StartCasePayload
   cancelCase(input: CancelCaseInput!): CancelCasePayload
   completeWorkItem(input: CompleteWorkItemInput!): CompleteWorkItemPayload
-  setWorkItemAssignedUsers(input: SetWorkItemAssignedUsersInput!): SetWorkItemAssignedUsersPayload
+  saveWorkItem(input: SaveWorkItemInput!): SaveWorkItemPayload
   saveForm(input: SaveFormInput!): SaveFormPayload
   copyForm(input: CopyFormInput!): CopyFormPayload
   addFormQuestion(input: AddFormQuestionInput!): AddFormQuestionPayload
@@ -846,6 +846,18 @@ type SaveTextareaQuestionPayload {
   clientMutationId: String
 }
 
+input SaveWorkItemInput {
+  workItem: ID!
+  assignedUsers: [String]
+  meta: JSONString
+  clientMutationId: String
+}
+
+type SaveWorkItemPayload {
+  workItem: WorkItem
+  clientMutationId: String
+}
+
 input SaveWorkflowInput {
   slug: String!
   name: String!
@@ -861,17 +873,6 @@ input SaveWorkflowInput {
 
 type SaveWorkflowPayload {
   workflow: Workflow
-  clientMutationId: String
-}
-
-input SetWorkItemAssignedUsersInput {
-  workItem: ID!
-  assignedUsers: [String]!
-  clientMutationId: String
-}
-
-type SetWorkItemAssignedUsersPayload {
-  workItem: WorkItem
   clientMutationId: String
 }
 

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -224,9 +224,9 @@ class CompleteWorkItem(Mutation):
         model_operations = ["update"]
 
 
-class SetWorkItemAssignedUsers(Mutation):
+class SaveWorkItem(Mutation):
     class Meta:
-        serializer_class = serializers.SetWorkItemAssignedUsersSerializer
+        serializer_class = serializers.SaveWorkItemSerializer
         lookup_input_kwarg = "work_item"
         model_operations = ["update"]
 
@@ -243,7 +243,7 @@ class Mutation(object):
     start_case = StartCase().Field()
     cancel_case = CancelCase().Field()
     complete_work_item = CompleteWorkItem().Field()
-    set_work_item_assigned_users = SetWorkItemAssignedUsers().Field()
+    save_work_item = SaveWorkItem().Field()
 
 
 class Query(object):

--- a/caluma/workflow/serializers.py
+++ b/caluma/workflow/serializers.py
@@ -1,6 +1,5 @@
 from django.db import transaction
 from rest_framework import exceptions
-from rest_framework.serializers import ListField
 
 from . import models, validators
 from ..core import serializers
@@ -305,10 +304,9 @@ class CompleteWorkItemSerializer(serializers.ModelSerializer):
         fields = ("id",)
 
 
-class SetWorkItemAssignedUsersSerializer(serializers.ModelSerializer):
+class SaveWorkItemSerializer(serializers.ModelSerializer):
     work_item = serializers.GlobalIDField(source="id")
-    assigned_users = ListField(required=True)
 
     class Meta:
         model = models.WorkItem
-        fields = ("work_item", "assigned_users")
+        fields = ("work_item", "assigned_users", "meta")

--- a/caluma/workflow/tests/test_work_item.py
+++ b/caluma/workflow/tests/test_work_item.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from graphene.utils.str_converters import to_const
 
@@ -344,19 +346,26 @@ def test_complete_work_item_with_merge(
     assert ready_workitem.document_id is not None
 
 
-def test_set_work_item_assigned_users(db, work_item, schema_executor):
+def test_save_work_item(db, work_item, schema_executor):
     query = """
-        mutation SetWorkItemAssignedUsers($input: SetWorkItemAssignedUsersInput!) {
-          setWorkItemAssignedUsers(input: $input) {
+        mutation SaveWorkItem($input: SaveWorkItemInput!) {
+          saveWorkItem(input: $input) {
             clientMutationId
           }
         }
     """
 
     assigned_users = ["user1", "user2"]
-    inp = {"input": {"workItem": str(work_item.pk), "assignedUsers": assigned_users}}
+    inp = {
+        "input": {
+            "workItem": str(work_item.pk),
+            "assignedUsers": assigned_users,
+            "meta": json.dumps({"test": "test"}),
+        }
+    }
     result = schema_executor(query, variables=inp)
 
     assert not result.errors
     work_item.refresh_from_db()
     assert work_item.assigned_users == assigned_users
+    assert work_item.meta == {"test": "test"}


### PR DESCRIPTION
Fixes #272 

To not multiple mutations changed SetWorkItemAssigned to SaveWorkItem which additionally allows changing of meta.

With validation extension point in the future it will still be possible to differ between allowing to change meta or assigned_users.