### PR TITLE
Allow configuring log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ A list of configuration options which you might need to configure to get Caluma 
 * `DATABASE_PASSWORD`: Password to use when connecting to database
 * `LANGUAGE_CODE`: Default language defined as fallback (default: en)
 * `LANGUAGES`: List of supported language codes (default: all available)
+* `LOG_LEVEL`: [Log level](https://docs.djangoproject.com/en/1.11/topics/logging/#loggers) of messages to write to output (default: INFO)
 
 #### Authentication and authorization
 

--- a/caluma/settings.py
+++ b/caluma/settings.py
@@ -164,3 +164,15 @@ VALIDATION_CLASSES = env.list("VALIDATION_CLASSES", default=[])
 
 CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL", default=False)
 CORS_ORIGIN_WHITELIST = env.list("CORS_ORIGIN_WHITELIST", default=[])
+
+
+# Logging
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "loggers": {
+        "": {"handlers": ["console"], "level": env.str("LOG_LEVEL", default="INFO")}
+    },
+}


### PR DESCRIPTION
Default Django Logging only logs info message if DEBUG is set to False.

This way we set default level to INFO in any case but user can change it with an environment variable.