### PR TITLE
Move to upstream django posgres extra version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,8 @@ django==1.11.20
 django-cors-headers==2.4.0
 django-environ==0.4.5
 django-filter==2.1.0
-# move back to PyPi version once following PRs are merged:
-# https://github.com/SectorLabs/django-postgres-extra/pull/73
-git+https://github.com/adfinis-forks/django-postgres-extra.git@v1.21a12+adsy1#egg=django-postgres-extra
 django-localized-fields==5.0a7
+django-postgres-extra==1.21a16
 djangorestframework==3.9.1
 graphene==2.1.3
 graphene-django==2.2.0


### PR DESCRIPTION
This is possible as https://github.com/SectorLabs/django-postgres-extra/pull/73
has been merged.