### PR TITLE
Create work item mutation: Create new document for work items

### DIFF
--- a/caluma/workflow/serializers.py
+++ b/caluma/workflow/serializers.py
@@ -380,6 +380,7 @@ class CreateWorkItemSerializer(serializers.ModelSerializer):
         return task
 
     def validate(self, data):
+        user = self.context["request"].user
         case = data["case"]
         task = data["task"]
 
@@ -390,6 +391,7 @@ class CreateWorkItemSerializer(serializers.ModelSerializer):
                 f"The given case {case.pk} does not have any running work items corresponding to the task {task.pk}. A new instance of a `MultipleInstanceTask` can only be created when there is at least one running sibling work item."
             )
 
+        data["document"] = Document.objects.create_document_for_task(task, user)
         data["status"] = models.WorkItem.STATUS_READY
         return super().validate(data)
 

--- a/caluma/workflow/tests/test_work_item.py
+++ b/caluma/workflow/tests/test_work_item.py
@@ -546,3 +546,4 @@ def test_create_work_item(db, work_item, success, schema_executor):
         assert new_work_item.assigned_users == assigned_users
         assert new_work_item.status == models.WorkItem.STATUS_READY
         assert new_work_item.meta == meta
+        assert new_work_item.document is not None


### PR DESCRIPTION
When we create a new new instance of a "multiple instance work item", we
also have to attach a new document to it (provided the work item is
linked to a form).