### PR TITLE
Do not exclude documents in form schema

### DIFF
--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -176,7 +176,7 @@ class Form(DjangoObjectType):
     class Meta:
         model = models.Form
         interfaces = (relay.Node,)
-        exclude_fields = ("documents", "workflows", "tasks")
+        exclude_fields = ("workflows", "tasks")
 
 
 class SaveForm(UserDefinedPrimaryKeyMixin, Mutation):

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -344,6 +344,7 @@ type Form implements Node {
   isArchived: Boolean!
   questions(before: String, after: String, first: Int, last: Int, slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, excludeForms: [ID], search: String, orderBy: [QuestionOrdering]): QuestionConnection
   source: Form
+  documents(before: String, after: String, first: Int, last: Int): DocumentConnection
   id: ID!
 }
 


### PR DESCRIPTION
This change allows to have access to documents and even cases from
forms.

This is useful for triggering cases based on form properties (e.g.
meta).