### PR TITLE
Implement meta-field key filtering

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -183,6 +183,10 @@ class FilterSet(GrapheneFilterSetMixin, FilterSet):
         return filter_class, params
 
 
+class MetaFilterSet(FilterSet):
+    meta_has_key = CharFilter(lookup_expr="has_key", field_name="meta")
+
+
 class DjangoFilterConnectionField(filter.DjangoFilterConnectionField):
     """
     Django connection filter field with object type get_queryset support.

--- a/caluma/form/filters.py
+++ b/caluma/form/filters.py
@@ -1,14 +1,14 @@
 from . import models
 from ..core.filters import (
-    FilterSet,
     GlobalIDFilter,
     GlobalIDMultipleChoiceFilter,
+    MetaFilterSet,
     OrderingFilter,
     SearchFilter,
 )
 
 
-class FormFilterSet(FilterSet):
+class FormFilterSet(MetaFilterSet):
     search = SearchFilter(fields=("slug", "name", "description"))
     order_by = OrderingFilter(label="FormOrdering", fields=("name",))
 
@@ -17,7 +17,7 @@ class FormFilterSet(FilterSet):
         fields = ("slug", "name", "description", "is_published", "is_archived")
 
 
-class OptionFilterSet(FilterSet):
+class OptionFilterSet(MetaFilterSet):
     search = SearchFilter(fields=("slug", "label"))
     order_by = OrderingFilter(label="OptionOrdering", fields=("label",))
 
@@ -26,7 +26,7 @@ class OptionFilterSet(FilterSet):
         fields = ("slug", "label")
 
 
-class QuestionFilterSet(FilterSet):
+class QuestionFilterSet(MetaFilterSet):
     exclude_forms = GlobalIDMultipleChoiceFilter(field_name="forms", exclude=True)
     search = SearchFilter(fields=("slug", "label"))
     order_by = OrderingFilter(label="QuestionOrdering", fields=("label",))
@@ -36,7 +36,7 @@ class QuestionFilterSet(FilterSet):
         fields = ("slug", "label", "is_required", "is_hidden", "is_archived")
 
 
-class DocumentFilterSet(FilterSet):
+class DocumentFilterSet(MetaFilterSet):
     id = GlobalIDFilter()
     search = SearchFilter(
         fields=("form__slug", "form__name", "form__description", "answers__value")
@@ -48,7 +48,7 @@ class DocumentFilterSet(FilterSet):
         fields = ("form", "search", "id")
 
 
-class AnswerFilterSet(FilterSet):
+class AnswerFilterSet(MetaFilterSet):
     search = SearchFilter(fields=("value",))
     order_by = OrderingFilter(label="AnswerOrdering")
 

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene import relay
+from graphene.types import generic
 from graphene_django.rest_framework import serializer_converter
 
 from . import filters, models, serializers
@@ -43,7 +44,7 @@ class Question(Node, graphene.Interface):
     is_required = QuestionJexl(required=True)
     is_hidden = QuestionJexl(required=True)
     is_archived = graphene.Boolean(required=True)
-    meta = graphene.JSONString(required=True)
+    meta = generic.GenericScalar(required=True)
     forms = DjangoFilterConnectionField(
         "caluma.form.schema.Form", filterset_class=filters.FormFilterSet
     )
@@ -172,6 +173,7 @@ class Form(DjangoObjectType):
     questions = DjangoFilterSetConnectionField(
         QuestionConnection, filterset_class=filters.QuestionFilterSet
     )
+    meta = generic.GenericScalar()
 
     class Meta:
         model = models.Form
@@ -299,7 +301,7 @@ class Answer(Node, graphene.Interface):
     created_by_group = graphene.String()
     modified_at = graphene.DateTime(required=True)
     question = graphene.Field(Question, required=True)
-    meta = graphene.JSONString(required=True)
+    meta = generic.GenericScalar(required=True)
 
     @classmethod
     def resolve_type(cls, instance, info):

--- a/caluma/form/tests/snapshots/snap_test_form.py
+++ b/caluma/form/tests/snapshots/snap_test_form.py
@@ -19,7 +19,7 @@ snapshots["test_save_form[some description text-en] 1"] = {
         "clientMutationId": "testid",
         "form": {
             "id": "Rm9ybTplZmZvcnQtbWVldA==",
-            "meta": "{}",
+            "meta": {},
             "name": "Brian Williams",
             "slug": "effort-meet",
         },
@@ -31,7 +31,7 @@ snapshots["test_save_form[some description text-de] 1"] = {
         "clientMutationId": "testid",
         "form": {
             "id": "Rm9ybTplZmZvcnQtbWVldA==",
-            "meta": "{}",
+            "meta": {},
             "name": "Brian Williams",
             "slug": "effort-meet",
         },
@@ -43,7 +43,7 @@ snapshots["test_save_form[en] 1"] = {
         "clientMutationId": "testid",
         "form": {
             "id": "Rm9ybTplZmZvcnQtbWVldA==",
-            "meta": "{}",
+            "meta": {},
             "name": "Brian Williams",
             "slug": "effort-meet",
         },
@@ -55,7 +55,7 @@ snapshots["test_save_form[de] 1"] = {
         "clientMutationId": "testid",
         "form": {
             "id": "Rm9ybTplZmZvcnQtbWVldA==",
-            "meta": "{}",
+            "meta": {},
             "name": "Brian Williams",
             "slug": "effort-meet",
         },
@@ -69,7 +69,7 @@ snapshots["test_query_all_forms[First result-1st-float] 1"] = {
                 "node": {
                     "description": "First result",
                     "id": "Rm9ybTplZmZvcnQtbWVldA==",
-                    "meta": "{}",
+                    "meta": {},
                     "name": "1st",
                     "questions": {
                         "edges": [
@@ -89,7 +89,7 @@ snapshots["test_query_all_forms[First result-1st-float] 1"] = {
                 "node": {
                     "description": "Second result",
                     "id": "Rm9ybTpraXRjaGVuLWRldmVsb3A=",
-                    "meta": "{}",
+                    "meta": {},
                     "name": "2nd",
                     "questions": {"edges": []},
                     "slug": "kitchen-develop",
@@ -99,7 +99,7 @@ snapshots["test_query_all_forms[First result-1st-float] 1"] = {
                 "node": {
                     "description": "Second result",
                     "id": "Rm9ybTpzZXJ2aWNlLWJhbmstYXJt",
-                    "meta": "{}",
+                    "meta": {},
                     "name": "3rd",
                     "questions": {"edges": []},
                     "slug": "service-bank-arm",

--- a/caluma/form/tests/snapshots/snap_test_question.py
+++ b/caluma/form/tests/snapshots/snap_test_question.py
@@ -14,7 +14,7 @@ snapshots["test_save_table_question[table] 1"] = {
             "__typename": "TableQuestion",
             "id": "VGFibGVRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
             "label": "Thomas Johnson",
-            "meta": "{}",
+            "meta": {},
             "rowForm": {"slug": "effort-meet"},
             "slug": "sound-air-mission",
         },
@@ -31,7 +31,7 @@ snapshots["test_query_all_questions[integer-question__configuration0] 1"] = {
                     "integerMaxValue": 10,
                     "integerMinValue": 0,
                     "label": "Thomas Johnson",
-                    "meta": "{}",
+                    "meta": {},
                     "slug": "sound-air-mission",
                 }
             }
@@ -49,7 +49,7 @@ snapshots["test_query_all_questions[float-question__configuration1] 1"] = {
                     "floatMinValue": 0.0,
                     "id": "RmxvYXRRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
                     "label": "Thomas Johnson",
-                    "meta": "{}",
+                    "meta": {},
                     "slug": "sound-air-mission",
                 }
             }
@@ -67,7 +67,7 @@ snapshots["test_query_all_questions[float-question__configuration2] 1"] = {
                     "floatMinValue": None,
                     "id": "RmxvYXRRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
                     "label": "Thomas Johnson",
-                    "meta": "{}",
+                    "meta": {},
                     "slug": "sound-air-mission",
                 }
             }
@@ -84,7 +84,7 @@ snapshots["test_query_all_questions[text-question__configuration3] 1"] = {
                     "id": "VGV4dFF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
                     "label": "Thomas Johnson",
                     "maxLength": 10,
-                    "meta": "{}",
+                    "meta": {},
                     "slug": "sound-air-mission",
                 }
             }
@@ -101,7 +101,7 @@ snapshots["test_query_all_questions[textarea-question__configuration4] 1"] = {
                     "id": "VGV4dGFyZWFRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
                     "label": "Thomas Johnson",
                     "maxLength": 10,
-                    "meta": "{}",
+                    "meta": {},
                     "slug": "sound-air-mission",
                 }
             }
@@ -117,7 +117,7 @@ snapshots["test_query_all_questions[choice-question__configuration5] 1"] = {
                     "__typename": "ChoiceQuestion",
                     "id": "Q2hvaWNlUXVlc3Rpb246c291bmQtYWlyLW1pc3Npb24=",
                     "label": "Thomas Johnson",
-                    "meta": "{}",
+                    "meta": {},
                     "options": {"edges": [{"node": {"slug": "example-indicate"}}]},
                     "slug": "sound-air-mission",
                 }
@@ -134,7 +134,7 @@ snapshots["test_query_all_questions[multiple_choice-question__configuration6] 1"
                     "__typename": "MultipleChoiceQuestion",
                     "id": "TXVsdGlwbGVDaG9pY2VRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
                     "label": "Thomas Johnson",
-                    "meta": "{}",
+                    "meta": {},
                     "options": {"edges": [{"node": {"slug": "example-indicate"}}]},
                     "slug": "sound-air-mission",
                 }
@@ -150,7 +150,7 @@ snapshots["test_save_question[true-True-SaveTextQuestion] 1"] = {
             "__typename": "TextQuestion",
             "id": "VGV4dFF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
             "label": "Thomas Johnson",
-            "meta": "{}",
+            "meta": {},
             "slug": "sound-air-mission",
         },
     }
@@ -163,7 +163,7 @@ snapshots["test_save_question[true-True-SaveTextareaQuestion] 1"] = {
             "__typename": "TextareaQuestion",
             "id": "VGV4dGFyZWFRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
             "label": "Thomas Johnson",
-            "meta": "{}",
+            "meta": {},
             "slug": "sound-air-mission",
         },
     }
@@ -176,7 +176,7 @@ snapshots["test_save_question[true-True-SaveIntegerQuestion] 1"] = {
             "__typename": "IntegerQuestion",
             "id": "SW50ZWdlclF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
             "label": "Thomas Johnson",
-            "meta": "{}",
+            "meta": {},
             "slug": "sound-air-mission",
         },
     }
@@ -189,7 +189,7 @@ snapshots["test_save_question[true-True-SaveFloatQuestion] 1"] = {
             "__typename": "FloatQuestion",
             "id": "RmxvYXRRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
             "label": "Thomas Johnson",
-            "meta": "{}",
+            "meta": {},
             "slug": "sound-air-mission",
         },
     }
@@ -203,7 +203,7 @@ snapshots["test_save_float_question[float-question__configuration0-True] 1"] = {
             "id": "RmxvYXRRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
             "label": "Thomas Johnson",
             "maxValue": 10.0,
-            "meta": "{}",
+            "meta": {},
             "minValue": 0.0,
             "slug": "sound-air-mission",
         },
@@ -217,7 +217,7 @@ snapshots["test_save_integer_question[integer-question__configuration0-True] 1"]
             "__typename": "IntegerQuestion",
             "id": "SW50ZWdlclF1ZXN0aW9uOnNvdW5kLWFpci1taXNzaW9u",
             "label": "Thomas Johnson",
-            "meta": "{}",
+            "meta": {},
             "slug": "sound-air-mission",
         },
     }
@@ -230,7 +230,7 @@ snapshots["test_save_multiple_choice_question[multiple_choice] 1"] = {
             "__typename": "MultipleChoiceQuestion",
             "id": "TXVsdGlwbGVDaG9pY2VRdWVzdGlvbjpzb3VuZC1haXItbWlzc2lvbg==",
             "label": "Thomas Johnson",
-            "meta": "{}",
+            "meta": {},
             "options": {
                 "edges": [
                     {
@@ -254,7 +254,7 @@ snapshots["test_save_choice_question[choice] 1"] = {
             "__typename": "ChoiceQuestion",
             "id": "Q2hvaWNlUXVlc3Rpb246c291bmQtYWlyLW1pc3Npb24=",
             "label": "Thomas Johnson",
-            "meta": "{}",
+            "meta": {},
             "options": {
                 "edges": [
                     {"node": {"label": "Kelly Brock", "slug": "example-indicate"}}

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -44,7 +44,7 @@ interface Answer {
   createdByGroup: String
   modifiedAt: DateTime!
   question: Question!
-  meta: JSONString!
+  meta: GenericScalar!
 }
 
 type AnswerConnection {
@@ -91,7 +91,7 @@ type Case implements Node {
   status: CaseStatus!
   meta: JSONString!
   document: Document
-  workItems(before: String, after: String, first: Int, last: Int, status: WorkItemStatusArgument, task: ID, case: ID, createdByUser: String, createdByGroup: String, orderBy: [WorkItemOrdering], addressedGroups: [String]): WorkItemConnection
+  workItems(before: String, after: String, first: Int, last: Int, status: WorkItemStatusArgument, task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [WorkItemOrdering], addressedGroups: [String]): WorkItemConnection
   parentWorkItem: WorkItem
 }
 
@@ -140,10 +140,10 @@ type ChoiceQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString!
+  meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String): FormConnection
-  options(before: String, after: String, first: Int, last: Int, slug: String, label: String, createdByUser: String, createdByGroup: String, search: String, orderBy: [OptionOrdering]): OptionConnection
+  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): FormConnection
+  options(before: String, after: String, first: Int, last: Int, slug: String, label: String, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [OptionOrdering]): OptionConnection
   id: ID!
 }
 
@@ -156,7 +156,7 @@ type CompleteTaskFormTask implements Task, Node {
   name: String!
   description: String
   type: TaskType!
-  meta: JSONString!
+  meta: GenericScalar!
   addressGroups: GroupJexl
   isArchived: Boolean!
   leadTime: Int
@@ -184,7 +184,7 @@ type CompleteWorkflowFormTask implements Task, Node {
   name: String!
   description: String
   type: TaskType!
-  meta: JSONString!
+  meta: GenericScalar!
   addressGroups: GroupJexl
   isArchived: Boolean!
   leadTime: Int
@@ -254,7 +254,7 @@ type Document implements Node {
   id: ID!
   form: Form!
   meta: JSONString!
-  answers(before: String, after: String, first: Int, last: Int, question: ID, search: String, createdByUser: String, createdByGroup: String, orderBy: [AnswerOrdering]): AnswerConnection
+  answers(before: String, after: String, first: Int, last: Int, question: ID, search: String, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [AnswerOrdering]): AnswerConnection
   case: Case
   workItem: WorkItem
 }
@@ -288,7 +288,7 @@ type FloatAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: Float!
-  meta: JSONString!
+  meta: GenericScalar!
 }
 
 type FloatQuestion implements Question, Node {
@@ -301,9 +301,9 @@ type FloatQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString!
+  meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): FormConnection
   id: ID!
   minValue: Float
   maxValue: Float
@@ -339,10 +339,10 @@ type Form implements Node {
   slug: String!
   name: String!
   description: String
-  meta: JSONString!
+  meta: GenericScalar
   isPublished: Boolean!
   isArchived: Boolean!
-  questions(before: String, after: String, first: Int, last: Int, slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, excludeForms: [ID], search: String, orderBy: [QuestionOrdering]): QuestionConnection
+  questions(before: String, after: String, first: Int, last: Int, slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, excludeForms: [ID], search: String, orderBy: [QuestionOrdering]): QuestionConnection
   source: Form
   id: ID!
 }
@@ -370,6 +370,8 @@ enum FormOrdering {
   CREATED_BY_GROUP_DESC
 }
 
+scalar GenericScalar
+
 scalar GroupJexl
 
 type IntegerAnswer implements Answer, Node {
@@ -380,7 +382,7 @@ type IntegerAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: Int!
-  meta: JSONString!
+  meta: GenericScalar!
 }
 
 type IntegerQuestion implements Question, Node {
@@ -393,9 +395,9 @@ type IntegerQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString!
+  meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): FormConnection
   id: ID!
   maxValue: Int
   minValue: Int
@@ -411,7 +413,7 @@ type ListAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: [String]!
-  meta: JSONString!
+  meta: GenericScalar!
 }
 
 type MultipleChoiceQuestion implements Question, Node {
@@ -424,10 +426,10 @@ type MultipleChoiceQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString!
+  meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String): FormConnection
-  options(before: String, after: String, first: Int, last: Int, orderBy: [OptionOrdering], slug: String, label: String, createdByUser: String, createdByGroup: String, search: String): OptionConnection
+  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): FormConnection
+  options(before: String, after: String, first: Int, last: Int, orderBy: [OptionOrdering], slug: String, label: String, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): OptionConnection
   id: ID!
 }
 
@@ -514,13 +516,13 @@ type PageInfo {
 }
 
 type Query {
-  allWorkflows(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String, orderBy: [WorkflowOrdering]): WorkflowConnection
-  allTasks(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String, orderBy: [TaskOrdering]): TaskConnection
-  allCases(before: String, after: String, first: Int, last: Int, workflow: ID, status: CaseStatusArgument, createdByUser: String, createdByGroup: String, orderBy: [CaseOrdering]): CaseConnection
-  allWorkItems(before: String, after: String, first: Int, last: Int, status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], task: ID, case: ID, createdByUser: String, createdByGroup: String, addressedGroups: [String]): WorkItemConnection
-  allForms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String): FormConnection
-  allQuestions(before: String, after: String, first: Int, last: Int, orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, excludeForms: [ID], search: String): QuestionConnection
-  allDocuments(before: String, after: String, first: Int, last: Int, form: ID, search: String, id: ID, createdByUser: String, createdByGroup: String, orderBy: [DocumentOrdering]): DocumentConnection
+  allWorkflows(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [WorkflowOrdering]): WorkflowConnection
+  allTasks(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [TaskOrdering]): TaskConnection
+  allCases(before: String, after: String, first: Int, last: Int, workflow: ID, status: CaseStatusArgument, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [CaseOrdering]): CaseConnection
+  allWorkItems(before: String, after: String, first: Int, last: Int, status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
+  allForms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): FormConnection
+  allQuestions(before: String, after: String, first: Int, last: Int, orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, excludeForms: [ID], search: String): QuestionConnection
+  allDocuments(before: String, after: String, first: Int, last: Int, form: ID, search: String, id: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [DocumentOrdering]): DocumentConnection
   node(id: ID!): Node
 }
 
@@ -535,8 +537,8 @@ interface Question {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString!
-  forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String, orderBy: [FormOrdering]): FormConnection
+  meta: GenericScalar!
+  forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [FormOrdering]): FormConnection
   source: Question
 }
 
@@ -915,7 +917,7 @@ type SimpleTask implements Task, Node {
   name: String!
   description: String
   type: TaskType!
-  meta: JSONString!
+  meta: GenericScalar!
   addressGroups: GroupJexl
   isArchived: Boolean!
   leadTime: Int
@@ -944,7 +946,7 @@ type StringAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: String!
-  meta: JSONString!
+  meta: GenericScalar!
 }
 
 type TableAnswer implements Answer, Node {
@@ -955,7 +957,7 @@ type TableAnswer implements Answer, Node {
   id: ID!
   question: Question!
   value: [Document]!
-  meta: JSONString!
+  meta: GenericScalar!
   document: Document!
 }
 
@@ -969,9 +971,9 @@ type TableQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString!
+  meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): FormConnection
   rowForm: Form
   id: ID!
 }
@@ -987,7 +989,7 @@ interface Task {
   description: String
   isArchived: Boolean!
   addressGroups: GroupJexl
-  meta: JSONString!
+  meta: GenericScalar!
   isMultipleInstance: Boolean!
 }
 
@@ -1040,9 +1042,9 @@ type TextQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString!
+  meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): FormConnection
   id: ID!
   maxLength: Int
 }
@@ -1057,9 +1059,9 @@ type TextareaQuestion implements Question, Node {
   isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
-  meta: JSONString!
+  meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): FormConnection
   id: ID!
   maxLength: Int
 }
@@ -1127,7 +1129,7 @@ type Workflow implements Node {
   slug: String!
   name: String!
   description: String
-  meta: JSONString!
+  meta: GenericScalar
   isPublished: Boolean!
   isArchived: Boolean!
   startTasks: [Task]!

--- a/caluma/workflow/filters.py
+++ b/caluma/workflow/filters.py
@@ -2,13 +2,14 @@ from . import models
 from ..core.filters import (
     FilterSet,
     GlobalIDFilter,
+    MetaFilterSet,
     OrderingFilter,
     SearchFilter,
     StringListFilter,
 )
 
 
-class WorkflowFilterSet(FilterSet):
+class WorkflowFilterSet(MetaFilterSet):
     search = SearchFilter(fields=("slug", "name", "description"))
     order_by = OrderingFilter(label="WorkflowOrdering", fields=("name", "description"))
 
@@ -25,7 +26,7 @@ class FlowFilterSet(FilterSet):
         fields = ("task",)
 
 
-class CaseFilterSet(FilterSet):
+class CaseFilterSet(MetaFilterSet):
     order_by = OrderingFilter(label="CaseOrdering", fields=("status",))
 
     class Meta:
@@ -33,7 +34,7 @@ class CaseFilterSet(FilterSet):
         fields = ("workflow", "status")
 
 
-class TaskFilterSet(FilterSet):
+class TaskFilterSet(MetaFilterSet):
     search = SearchFilter(fields=("slug", "name", "description"))
     order_by = OrderingFilter(
         label="TaskOrdering", fields=("name", "description", "type")
@@ -44,7 +45,7 @@ class TaskFilterSet(FilterSet):
         fields = ("slug", "name", "description", "type", "is_archived")
 
 
-class WorkItemFilterSet(FilterSet):
+class WorkItemFilterSet(MetaFilterSet):
     order_by = OrderingFilter(label="WorkItemOrdering", fields=("status",))
     addressed_groups = StringListFilter(lookup_expr="overlap")
 

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -3,6 +3,7 @@ import itertools
 import graphene
 from django.db.models import Q
 from graphene import relay
+from graphene.types import generic
 from graphene_django.rest_framework import serializer_converter
 
 from . import filters, jexl, models, serializers
@@ -60,7 +61,7 @@ class Task(Node, graphene.Interface):
     description = graphene.String()
     is_archived = graphene.Boolean(required=True)
     address_groups = GroupJexl()
-    meta = graphene.JSONString(required=True)
+    meta = generic.GenericScalar(required=True)
     is_multiple_instance = graphene.Boolean(required=True)
 
     @classmethod
@@ -130,6 +131,7 @@ class Workflow(DjangoObjectType):
     tasks = graphene.List(
         Task, required=True, description="List of tasks referenced in workflow"
     )
+    meta = generic.GenericScalar()
 
     def resolve_tasks(self, info, **args):
         flow_jexl = jexl.FlowJexl()

--- a/caluma/workflow/tests/snapshots/snap_test_task.py
+++ b/caluma/workflow/tests/snapshots/snap_test_task.py
@@ -12,7 +12,7 @@ snapshots["test_save_task[SaveSimpleTask] 1"] = {
         "clientMutationId": "testid",
         "task": {
             "__typename": "SimpleTask",
-            "meta": "{}",
+            "meta": {},
             "name": "Thomas Johnson",
             "slug": "sound-air-mission",
         },
@@ -24,7 +24,7 @@ snapshots["test_save_task[SaveCompleteWorkflowFormTask] 1"] = {
         "clientMutationId": "testid",
         "task": {
             "__typename": "CompleteWorkflowFormTask",
-            "meta": "{}",
+            "meta": {},
             "name": "Thomas Johnson",
             "slug": "sound-air-mission",
         },
@@ -36,7 +36,7 @@ snapshots["test_save_comlete_task_form_task 1"] = {
         "clientMutationId": "testid",
         "task": {
             "__typename": "CompleteTaskFormTask",
-            "meta": "{}",
+            "meta": {},
             "name": "Thomas Johnson",
             "slug": "sound-air-mission",
         },
@@ -50,7 +50,7 @@ snapshots["test_query_all_tasks[simple] 1"] = {
                 "node": {
                     "__typename": "SimpleTask",
                     "description": "State section rock event recent. Final activity hope star check record well. Radio with Mr letter eye.",
-                    "meta": "{}",
+                    "meta": {},
                     "name": "Thomas Johnson",
                     "slug": "sound-air-mission",
                 }

--- a/caluma/workflow/tests/snapshots/snap_test_workflow.py
+++ b/caluma/workflow/tests/snapshots/snap_test_workflow.py
@@ -13,7 +13,7 @@ snapshots["test_save_workflow 1"] = {
         "workflow": {
             "allowAllForms": False,
             "allowForms": {"edges": [{"node": {"slug": "sound-air-mission"}}]},
-            "meta": "{}",
+            "meta": {},
             "name": "Brian Williams",
             "slug": "effort-meet",
         },
@@ -39,7 +39,7 @@ Kid avoid player relationship to range whose. Draw free property consider.""",
                             }
                         ]
                     },
-                    "meta": "{}",
+                    "meta": {},
                     "name": "Brian Williams",
                     "slug": "effort-meet",
                     "startTasks": [{"slug": "few-list-tax"}],


### PR DESCRIPTION
This commit implements a "meta_HasKey"-filter.

For this to work, the meta-field is now a "generic.GenericScalar()".

This implementation is up for discussion and only implemented for Form.meta atm. If we decide that this is the way to go, we can implement it for the other models as well.