### PR TITLE
Fix unlinking last document in table answer

### DIFF
--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -416,7 +416,10 @@ class SaveDocumentTableAnswerSerializer(SaveAnswerSerializer):
 
     def validate(self, data):
         documents = (
-            data.get("documents") or self.instance and self.instance.documents or []
+            data.get("documents")
+            or self.instance
+            and self.instance.documents.all()
+            or []
         )
         question = data.get("question") or self.instance and self.instance.question
 


### PR DESCRIPTION
When an empty document list is passed to the validate function, a
ManyRelatedManager object was used as fallback for validation instead of the actual
documents queryset.

Fixes #313 