### PR TITLE
Add `is_published` to the CopyFormSerializer

### DIFF
--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -49,7 +49,7 @@ class CopyFormSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Form
-        fields = ("slug", "name", "description", "source")
+        fields = ("slug", "name", "description", "source", "is_published")
 
 
 class AddFormQuestionSerializer(serializers.ModelSerializer):

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -197,6 +197,7 @@ input CopyFormInput {
   name: String!
   description: String
   source: ID!
+  isPublished: Boolean
   clientMutationId: String
 }
 


### PR DESCRIPTION
The new field `is_published` on the form model is not accessible in the
CopyForm mutation. Add it to the CopyFormSerializer so it can be
set/changed with the mutation.