### PR TITLE
Fix: Continue workflow after completing multiple instance task

### DIFF
--- a/caluma/workflow/tests/snapshots/snap_test_work_item.py
+++ b/caluma/workflow/tests/snapshots/snap_test_work_item.py
@@ -40,3 +40,27 @@ snapshots["test_complete_work_item_with_next[ready-None-simple] 1"] = {
         },
     }
 }
+
+snapshots["test_complete_multiple_instance_task_form_work_item_next[integer-1] 1"] = {
+    "completeWorkItem": {
+        "clientMutationId": None,
+        "workItem": {
+            "case": {
+                "status": "RUNNING",
+                "workItems": {
+                    "edges": [
+                        {
+                            "node": {
+                                "addressedGroups": ["group-name"],
+                                "status": "READY",
+                            }
+                        },
+                        {"node": {"addressedGroups": [], "status": "COMPLETED"}},
+                        {"node": {"addressedGroups": [], "status": "COMPLETED"}},
+                    ]
+                },
+            },
+            "status": "COMPLETED",
+        },
+    }
+}


### PR DESCRIPTION
With multiple instance tasks, comparing the amount of tasks referenced
by a flow to the amount of finished related work items doesn't work
anymore. This makes sure that each task is checked for completion
individually.