### PR TITLE
String Answer: Allow blank values on serializer

### DIFF
--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -407,7 +407,7 @@ class SaveAnswerSerializer(serializers.ModelSerializer):
 
 
 class SaveDocumentStringAnswerSerializer(SaveAnswerSerializer):
-    value = CharField()
+    value = CharField(allow_blank=True)
 
     class Meta(SaveAnswerSerializer.Meta):
         pass


### PR DESCRIPTION
The actual required check comes later in the validator.