### PR TITLE
Braindump: add filters typed

### DIFF
--- a/caluma/conftest.py
+++ b/caluma/conftest.py
@@ -128,3 +128,15 @@ def minio_mock(mocker):
     Minio.stat_object.return_value = stat_response
     Minio.bucket_exists.return_value = True
     return Minio
+def custom_visibility_classes():
+    from caluma.core.types import Node
+
+    old_classes = Node.visibility_classes
+
+    def set_classes(classes):
+        Node.visibility_classes = classes
+
+    yield set_classes
+
+    # restore old (default) visibility classes
+    set_classes(old_classes)

--- a/caluma/form/filters.py
+++ b/caluma/form/filters.py
@@ -43,7 +43,7 @@ class DocumentFilterSet(MetaFilterSet):
         fields=("form__slug", "form__name", "form__description", "answers__value")
     )
     order_by = OrderingFilter(label="DocumentOrdering")
-    has_answer = AnswerValueFilter()
+    has_answer = AnswerValueFilter(label='has_answer')
 
     class Meta:
         model = models.Document

--- a/caluma/form/filters.py
+++ b/caluma/form/filters.py
@@ -1,4 +1,5 @@
 from ..core.filters import (
+    AnswerValueFilter,
     GlobalIDFilter,
     GlobalIDMultipleChoiceFilter,
     MetaFilterSet,
@@ -42,10 +43,11 @@ class DocumentFilterSet(MetaFilterSet):
         fields=("form__slug", "form__name", "form__description", "answers__value")
     )
     order_by = OrderingFilter(label="DocumentOrdering")
+    has_answer = AnswerValueFilter()
 
     class Meta:
         model = models.Document
-        fields = ("form", "search", "id")
+        fields = ("form", "search", "id", "has_answer")
 
 
 class AnswerFilterSet(MetaFilterSet):

--- a/caluma/user/middleware.py
+++ b/caluma/user/middleware.py
@@ -60,6 +60,7 @@ class OIDCAuthenticationMiddleware(object):
         if token is None:
             request.user = models.AnonymousUser()
             return next(root, info, **args)
+        # TODO: don't query userinfo if no OIDC_USERINFO_ENDPOINT is configured
 
         userinfo_method = functools.partial(self.get_userinfo, token=token)
         # token might be too long for key so we use hash sum instead.

--- a/caluma/workflow/filters.py
+++ b/caluma/workflow/filters.py
@@ -1,4 +1,5 @@
 from ..core.filters import (
+    AnswerValueFilter,
     FilterSet,
     GlobalIDFilter,
     MetaFilterSet,
@@ -28,10 +29,11 @@ class FlowFilterSet(FilterSet):
 
 class CaseFilterSet(MetaFilterSet):
     order_by = OrderingFilter(label="CaseOrdering", fields=("status",))
+    has_answer = AnswerValueFilter(answers_via="document__answers")
 
     class Meta:
         model = models.Case
-        fields = ("workflow", "status")
+        fields = ("workflow", "status", "has_answer")
 
 
 class TaskFilterSet(MetaFilterSet):

--- a/caluma/workflow/filters.py
+++ b/caluma/workflow/filters.py
@@ -29,7 +29,7 @@ class FlowFilterSet(FilterSet):
 
 class CaseFilterSet(MetaFilterSet):
     order_by = OrderingFilter(label="CaseOrdering", fields=("status",))
-    has_answer = AnswerValueFilter(answers_via="document__answers")
+    has_answer = AnswerValueFilter(answers_via="document__answers", label="has_answer")
 
     class Meta:
         model = models.Case


### PR DESCRIPTION
This does not work and is NOT intended to be merged, more like a "letter of intent":

The "has_answer" filter from #348 should be typed, so we can match arbitrary question types, in a clean manner.

This PR just contains some code I've been messing with - probably I was on the wrong path all together..