### PR TITLE
Bugfix: When creating a document tree, set the family

### DIFF
--- a/caluma/form/models.py
+++ b/caluma/form/models.py
@@ -164,7 +164,9 @@ class DocumentManager(models.Manager):
         form_questions = form.questions.filter(type=Question.TYPE_FORM)
 
         for form_question in form_questions:
-            child_document = self.create(form=form_question.sub_form)
+            child_document = self.create(
+                form=form_question.sub_form, family=document.family
+            )
             Answer.objects.create(
                 question=form_question, document=document, value_document=child_document
             )

--- a/caluma/form/tests/test_document.py
+++ b/caluma/form/tests/test_document.py
@@ -3,7 +3,7 @@ from graphql_relay import to_global_id
 
 from ...core.relay import extract_global_id
 from ...core.tests import extract_serializer_input_fields
-from ...form.models import Answer, Question
+from ...form.models import Answer, Document, Question
 from .. import serializers
 
 
@@ -620,5 +620,19 @@ def test_create_document_with_children(
     sub_document = result.data["saveDocument"]["document"]["answers"]["edges"][0][
         "node"
     ]
+
+    doc_id = extract_global_id(result.data["saveDocument"]["document"]["id"])
+    doc = Document.objects.get(pk=doc_id)
+
+    # top-level document should be "head of family"
+    assert doc.pk == doc.family
+
+    subdoc_id = extract_global_id(
+        sub_document["value"]["answers"]["edges"][0]["node"]["value"]["id"]
+    )
+    sub_doc = Document.objects.get(pk=subdoc_id)
+
+    assert sub_doc.family == doc.family
+
     assert sub_document["id"]
     assert sub_document["value"]["answers"]["edges"][0]["node"]["id"]


### PR DESCRIPTION
The family field represents the identifier of the topmost document of
the structure. When recursively creating a document structure, we need
to pass down the family, otherwise it will be set anew for each sub
document, defeating the purpose.