### PR TITLE
Feature: Allow updating documents and cases

### DIFF
--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -576,6 +576,7 @@ class FileAnswer(AnswerQuerysetMixin, DjangoObjectType):
 class SaveDocument(Mutation):
     class Meta:
         serializer_class = serializers.DocumentSerializer
+        model_operations = ["create", "update"]
 
 
 class SaveDocumentAnswer(Mutation):

--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -435,7 +435,7 @@ class DocumentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Document
-        fields = ("form", "meta")
+        fields = ("id", "form", "meta")
 
 
 class SaveAnswerSerializer(serializers.ModelSerializer):

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -552,7 +552,8 @@ type Mutation {
   saveSimpleTask(input: SaveSimpleTaskInput!): SaveSimpleTaskPayload
   saveCompleteWorkflowFormTask(input: SaveCompleteWorkflowFormTaskInput!): SaveCompleteWorkflowFormTaskPayload
   saveCompleteTaskFormTask(input: SaveCompleteTaskFormTaskInput!): SaveCompleteTaskFormTaskPayload
-  startCase(input: StartCaseInput!): StartCasePayload
+  startCase(input: StartCaseInput!): StartCasePayload @deprecated(reason: "Use SaveCase mutation instead")
+  saveCase(input: SaveCaseInput!): SaveCasePayload
   cancelCase(input: CancelCaseInput!): CancelCasePayload
   completeWorkItem(input: CompleteWorkItemInput!): CompleteWorkItemPayload
   saveWorkItem(input: SaveWorkItemInput!): SaveWorkItemPayload
@@ -727,6 +728,20 @@ type ReorderFormQuestionsPayload {
   clientMutationId: String
 }
 
+input SaveCaseInput {
+  id: String
+  workflow: ID!
+  meta: JSONString
+  parentWorkItem: ID
+  form: ID
+  clientMutationId: String
+}
+
+type SaveCasePayload {
+  case: Case
+  clientMutationId: String
+}
+
 input SaveChoiceQuestionInput {
   slug: String!
   label: String!
@@ -858,6 +873,7 @@ type SaveDocumentFormAnswerPayload {
 }
 
 input SaveDocumentInput {
+  id: String
   form: ID!
   meta: JSONString
   clientMutationId: String

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -226,8 +226,14 @@ class SaveCompleteTaskFormTask(SaveTask):
 
 class StartCase(Mutation):
     class Meta:
-        serializer_class = serializers.StartCaseSerializer
+        serializer_class = serializers.CaseSerializer
         model_operations = ["create"]
+
+
+class SaveCase(Mutation):
+    class Meta:
+        serializer_class = serializers.SaveCaseSerializer
+        model_operations = ["create", "update"]
 
 
 class CancelCase(Mutation):
@@ -265,6 +271,10 @@ class Mutation(object):
     save_complete_task_form_task = SaveCompleteTaskFormTask().Field()
 
     start_case = StartCase().Field()
+
+    start_case.deprecation_reason = "Use SaveCase mutation instead"
+
+    save_case = SaveCase().Field()
     cancel_case = CancelCase().Field()
     complete_work_item = CompleteWorkItem().Field()
     save_work_item = SaveWorkItem().Field()

--- a/caluma/workflow/serializers.py
+++ b/caluma/workflow/serializers.py
@@ -164,7 +164,7 @@ class SaveCompleteTaskFormTaskSerializer(SaveTaskSerializer):
         fields = SaveTaskSerializer.Meta.fields + ("form",)
 
 
-class StartCaseSerializer(serializers.ModelSerializer):
+class CaseSerializer(serializers.ModelSerializer):
     workflow = serializers.GlobalIDPrimaryKeyRelatedField(
         queryset=models.Workflow.objects.prefetch_related("start_tasks")
     )
@@ -239,6 +239,11 @@ class StartCaseSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Case
         fields = ("workflow", "meta", "parent_work_item", "form")
+
+
+class SaveCaseSerializer(CaseSerializer):
+    class Meta(CaseSerializer.Meta):
+        fields = ("id", "workflow", "meta", "parent_work_item", "form")
 
 
 class CancelCaseSerializer(serializers.ModelSerializer):

--- a/caluma/workflow/tests/snapshots/snap_test_case.py
+++ b/caluma/workflow/tests/snapshots/snap_test_case.py
@@ -7,99 +7,187 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['test_start_case[startCase-["group-name"]|groups-100] 1'] = {
+    "startCase": {
+        "case": {
+            "document": {"form": {"slug": "sound-air-mission"}},
+            "parentWorkItem": None,
+            "status": "RUNNING",
+            "workItems": {
+                "edges": [
+                    {
+                        "node": {
+                            "addressedGroups": ["group-name"],
+                            "document": {"form": {"slug": "sound-air-mission"}},
+                            "status": "READY",
+                        }
+                    }
+                ]
+            },
+        },
+        "clientMutationId": None,
+    }
+}
+
+snapshots['test_start_case[startCase-["group-name"]|groups-None] 1'] = {
+    "startCase": {
+        "case": {
+            "document": {"form": {"slug": "sound-air-mission"}},
+            "parentWorkItem": None,
+            "status": "RUNNING",
+            "workItems": {
+                "edges": [
+                    {
+                        "node": {
+                            "addressedGroups": ["group-name"],
+                            "document": {"form": {"slug": "sound-air-mission"}},
+                            "status": "READY",
+                        }
+                    }
+                ]
+            },
+        },
+        "clientMutationId": None,
+    }
+}
+
+snapshots["test_start_case[startCase-None-100] 1"] = {
+    "startCase": {
+        "case": {
+            "document": {"form": {"slug": "sound-air-mission"}},
+            "parentWorkItem": None,
+            "status": "RUNNING",
+            "workItems": {
+                "edges": [
+                    {
+                        "node": {
+                            "addressedGroups": [],
+                            "document": {"form": {"slug": "sound-air-mission"}},
+                            "status": "READY",
+                        }
+                    }
+                ]
+            },
+        },
+        "clientMutationId": None,
+    }
+}
+
+snapshots["test_start_case[startCase-None-None] 1"] = {
+    "startCase": {
+        "case": {
+            "document": {"form": {"slug": "sound-air-mission"}},
+            "parentWorkItem": None,
+            "status": "RUNNING",
+            "workItems": {
+                "edges": [
+                    {
+                        "node": {
+                            "addressedGroups": [],
+                            "document": {"form": {"slug": "sound-air-mission"}},
+                            "status": "READY",
+                        }
+                    }
+                ]
+            },
+        },
+        "clientMutationId": None,
+    }
+}
+
+snapshots['test_start_case[saveCase-["group-name"]|groups-100] 1'] = {
+    "saveCase": {
+        "case": {
+            "document": {"form": {"slug": "sound-air-mission"}},
+            "parentWorkItem": {"status": "READY"},
+            "status": "RUNNING",
+            "workItems": {
+                "edges": [
+                    {
+                        "node": {
+                            "addressedGroups": [],
+                            "document": {"form": {"slug": "sound-air-mission"}},
+                            "status": "READY",
+                        }
+                    }
+                ]
+            },
+        },
+        "clientMutationId": None,
+    }
+}
+
+snapshots['test_start_case[saveCase-["group-name"]|groups-None] 1'] = {
+    "saveCase": {
+        "case": {
+            "document": {"form": {"slug": "sound-air-mission"}},
+            "parentWorkItem": {"status": "READY"},
+            "status": "RUNNING",
+            "workItems": {
+                "edges": [
+                    {
+                        "node": {
+                            "addressedGroups": [],
+                            "document": {"form": {"slug": "sound-air-mission"}},
+                            "status": "READY",
+                        }
+                    }
+                ]
+            },
+        },
+        "clientMutationId": None,
+    }
+}
+
+snapshots["test_start_case[saveCase-None-100] 1"] = {
+    "saveCase": {
+        "case": {
+            "document": {"form": {"slug": "sound-air-mission"}},
+            "parentWorkItem": {"status": "READY"},
+            "status": "RUNNING",
+            "workItems": {
+                "edges": [
+                    {
+                        "node": {
+                            "addressedGroups": [],
+                            "document": {"form": {"slug": "sound-air-mission"}},
+                            "status": "READY",
+                        }
+                    }
+                ]
+            },
+        },
+        "clientMutationId": None,
+    }
+}
+
+snapshots["test_start_case[saveCase-None-None] 1"] = {
+    "saveCase": {
+        "case": {
+            "document": {"form": {"slug": "sound-air-mission"}},
+            "parentWorkItem": {"status": "READY"},
+            "status": "RUNNING",
+            "workItems": {
+                "edges": [
+                    {
+                        "node": {
+                            "addressedGroups": [],
+                            "document": {"form": {"slug": "sound-air-mission"}},
+                            "status": "READY",
+                        }
+                    }
+                ]
+            },
+        },
+        "clientMutationId": None,
+    }
+}
+
 snapshots["test_query_all_cases[running-1] 1"] = {
     "allCases": {"edges": [{"node": {"status": "RUNNING"}}]}
 }
 
 snapshots["test_query_all_cases[completed-0] 1"] = {"allCases": {"edges": []}}
-
-snapshots['test_start_case[["group-name"]|groups-100] 1'] = {
-    "startCase": {
-        "case": {
-            "document": {"form": {"slug": "sound-air-mission"}},
-            "parentWorkItem": None,
-            "status": "RUNNING",
-            "workItems": {
-                "edges": [
-                    {
-                        "node": {
-                            "addressedGroups": ["group-name"],
-                            "document": {"form": {"slug": "sound-air-mission"}},
-                            "status": "READY",
-                        }
-                    }
-                ]
-            },
-        },
-        "clientMutationId": None,
-    }
-}
-
-snapshots['test_start_case[["group-name"]|groups-None] 1'] = {
-    "startCase": {
-        "case": {
-            "document": {"form": {"slug": "sound-air-mission"}},
-            "parentWorkItem": None,
-            "status": "RUNNING",
-            "workItems": {
-                "edges": [
-                    {
-                        "node": {
-                            "addressedGroups": ["group-name"],
-                            "document": {"form": {"slug": "sound-air-mission"}},
-                            "status": "READY",
-                        }
-                    }
-                ]
-            },
-        },
-        "clientMutationId": None,
-    }
-}
-
-snapshots["test_start_case[None-100] 1"] = {
-    "startCase": {
-        "case": {
-            "document": {"form": {"slug": "sound-air-mission"}},
-            "parentWorkItem": None,
-            "status": "RUNNING",
-            "workItems": {
-                "edges": [
-                    {
-                        "node": {
-                            "addressedGroups": [],
-                            "document": {"form": {"slug": "sound-air-mission"}},
-                            "status": "READY",
-                        }
-                    }
-                ]
-            },
-        },
-        "clientMutationId": None,
-    }
-}
-
-snapshots["test_start_case[None-None] 1"] = {
-    "startCase": {
-        "case": {
-            "document": {"form": {"slug": "sound-air-mission"}},
-            "parentWorkItem": None,
-            "status": "RUNNING",
-            "workItems": {
-                "edges": [
-                    {
-                        "node": {
-                            "addressedGroups": [],
-                            "document": {"form": {"slug": "sound-air-mission"}},
-                            "status": "READY",
-                        }
-                    }
-                ]
-            },
-        },
-        "clientMutationId": None,
-    }
-}
 
 snapshots["test_cancel_case[running-True-completed] 1"] = {
     "cancelCase": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,10 @@ psycopg2-binary==2.8.2
 pyjexl==0.2.3
 python-memcached==1.59
 requests==2.21.0
+# urllib3 explicit version requirement. Pin it to below 1.25, as
+# requests doesn't work above that version (and minio would pull
+# in the newest version) Can be removed once the following issue
+# is resolved:
+# https://github.com/kennethreitz/requests/issues/5067
+urllib3>=1.21.1,<1.25
 uwsgi==2.0.18


### PR DESCRIPTION
We need to be able to update the `meta` field of cases and documents.
The current implementations only allowed creation.

While we're at it, rename the `startCase` mutation to `saveCase` via
proper deprecation (yay GraphQL!).

The `startCase` mutation is not modified in any way, but the `saveCase` has an optional ID parameter to allow updating cases.