### PR TITLE
Do not slugify the object name of files

### DIFF
--- a/caluma/form/models.py
+++ b/caluma/form/models.py
@@ -2,7 +2,6 @@ from django.contrib.postgres.fields import JSONField
 from django.db import models, transaction
 from django.db.models.signals import post_init
 from django.dispatch import receiver
-from django.template.defaultfilters import slugify
 from localized_fields.fields import LocalizedField
 
 from ..core.models import SlugModel, UUIDModel
@@ -236,7 +235,7 @@ class File(UUIDModel):
 
     @property
     def object_name(self):
-        return f"{self.pk}_{slugify(self.name)}"
+        return f"{self.pk}_{self.name}"
 
     @property
     def upload_url(self):


### PR DESCRIPTION
This commit removes the slugification of object names for file in minIO.

Caluma and minIO can handle special characters, so there is no need for
this.

closes #387