### PR TITLE
fix(API): use GenericScalar for meta fields

### DIFF
--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -80,6 +80,8 @@ class Question(Node, graphene.Interface):
 
 
 class Option(DjangoObjectType):
+    meta = generic.GenericScalar()
+
     class Meta:
         model = models.Option
         interfaces = (relay.Node,)
@@ -619,6 +621,7 @@ class Document(DjangoObjectType):
     answers = DjangoFilterSetConnectionField(
         AnswerConnection, filterset_class=filters.AnswerFilterSet
     )
+    meta = generic.GenericScalar()
 
     class Meta:
         model = models.Document

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -89,7 +89,7 @@ type Case implements Node {
   closedByGroup: String
   workflow: Workflow!
   status: CaseStatus!
-  meta: JSONString!
+  meta: GenericScalar
   document: Document
   workItems(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, status: WorkItemStatusArgument, task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [WorkItemOrdering], addressedGroups: [String]): WorkItemConnection
   parentWorkItem: WorkItem
@@ -316,7 +316,7 @@ type Document implements Node {
   createdByGroup: String
   id: ID!
   form: Form!
-  meta: JSONString!
+  meta: GenericScalar
   answers(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, question: ID, search: String, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [AnswerOrdering]): AnswerConnection
   parentAnswers: [FileAnswer]
   case: Case
@@ -683,7 +683,7 @@ type Option implements Node {
   createdByGroup: String
   slug: String!
   label: String!
-  meta: JSONString!
+  meta: GenericScalar
   source: Option
   id: ID!
 }
@@ -1482,7 +1482,7 @@ type WorkItem implements Node {
   deadline: DateTime
   task: Task!
   status: WorkItemStatus!
-  meta: JSONString!
+  meta: GenericScalar
   addressedGroups: [String]!
   assignedUsers: [String]!
   case: Case!

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -158,6 +158,7 @@ class Workflow(DjangoObjectType):
 
 class WorkItem(DjangoObjectType):
     task = graphene.Field(Task, required=True)
+    meta = generic.GenericScalar()
 
     class Meta:
         model = models.WorkItem
@@ -168,6 +169,7 @@ class Case(DjangoObjectType):
     work_items = DjangoFilterConnectionField(
         WorkItem, filterset_class=filters.WorkItemFilterSet
     )
+    meta = generic.GenericScalar()
 
     class Meta:
         model = models.Case


### PR DESCRIPTION
BREAKING CHANGE: If you've been manually parsing the JSONString of a
meta field, you can remove that code - meta is automatically expanded now.