### PR TITLE
Add removeAnswer mutation

### DIFF
--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -747,6 +747,12 @@ class SaveDocumentFileAnswer(SaveDocumentAnswer):
         return_field_type = Answer
 
 
+class RemoveAnswer(Mutation):
+    class Meta:
+        lookup_input_kwarg = "answer"
+        serializer_class = serializers.RemoveAnswerSerializer
+
+
 class Mutation(object):
     save_form = SaveForm().Field()
     copy_form = CopyForm().Field()
@@ -782,6 +788,7 @@ class Mutation(object):
     save_document_table_answer = SaveDocumentTableAnswer().Field()
     save_document_form_answer = SaveDocumentFormAnswer().Field()
     save_document_file_answer = SaveDocumentFileAnswer().Field()
+    remove_answer = RemoveAnswer().Field()
 
 
 class Query(object):

--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -691,3 +691,15 @@ class SaveDocumentFileAnswerSerializer(SaveAnswerSerializer):
 
     class Meta(SaveAnswerSerializer.Meta):
         fields = "__all__"
+
+
+class RemoveAnswerSerializer(serializers.ModelSerializer):
+    answer = PrimaryKeyRelatedField(queryset=models.Answer.objects.all())
+
+    def update(self, instance, validated_data):
+        instance.delete()
+        return instance
+
+    class Meta:
+        fields = ("answer",)
+        model = models.Answer

--- a/caluma/form/tests/snapshots/snap_test_answer.py
+++ b/caluma/form/tests/snapshots/snap_test_answer.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+
+snapshots["test_remove_answer[integer-23] 1"] = {
+    "removeAnswer": {
+        "answer": {"id": "RmlsZUFuc3dlcjpOb25l", "meta": {}},
+        "clientMutationId": None,
+    }
+}

--- a/caluma/form/tests/test_answer.py
+++ b/caluma/form/tests/test_answer.py
@@ -1,0 +1,28 @@
+import pytest
+
+from .. import models
+
+
+@pytest.mark.parametrize(
+    "question__type,answer__value", [(models.Question.TYPE_INTEGER, 23)]
+)
+def test_remove_answer(db, snapshot, question, answer, schema_executor):
+    query = """
+        mutation RemoveAnswer($input: RemoveAnswerInput!) {
+          removeAnswer(input: $input) {
+            answer {
+              id
+              meta
+            }
+            clientMutationId
+          }
+        }
+    """
+
+    result = schema_executor(query, variables={"input": {"answer": str(answer.pk)}})
+
+    assert not result.errors
+    with pytest.raises(models.Answer.DoesNotExist):
+        answer.refresh_from_db()
+
+    snapshot.assert_match(result.data)

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots[
@@ -670,6 +669,7 @@ type Mutation {
   saveDocumentTableAnswer(input: SaveDocumentTableAnswerInput!): SaveDocumentTableAnswerPayload
   saveDocumentFormAnswer(input: SaveDocumentFormAnswerInput!): SaveDocumentFormAnswerPayload
   saveDocumentFileAnswer(input: SaveDocumentFileAnswerInput!): SaveDocumentFileAnswerPayload
+  removeAnswer(input: RemoveAnswerInput!): RemoveAnswerPayload
 }
 
 interface Node {
@@ -771,6 +771,16 @@ enum QuestionOrdering {
   CREATED_BY_USER_DESC
   CREATED_BY_GROUP_ASC
   CREATED_BY_GROUP_DESC
+}
+
+input RemoveAnswerInput {
+  answer: ID!
+  clientMutationId: String
+}
+
+type RemoveAnswerPayload {
+  answer: FileAnswer
+  clientMutationId: String
 }
 
 input RemoveFlowInput {


### PR DESCRIPTION
This commit adds a removeAnswer mutation.

So if a user answered an optional question, there is now a way to completely
remove it's answer.

Closes #392