### PR TITLE
Add validators for dynamic choice options questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ This class needs also to be added to the `DATA_SOURCE_CLASSES` environment varia
 * `info`: Descriptive text for the data source (can also be a multilingual dict)
 * `default`: The default value to be returned if execution of `get_data()` fails. If
              this is `None`, the Exception won't be handled. Defaults to None.
+* `validate`: boolean that indicates if answers should be validated against the
+              current response from `get_data()`. Defaults to `True`.
 
 ### `get_data`-method
 Must return an iterable. This iterable can contain strings, ints, floats

--- a/caluma/data_source/data_sources.py
+++ b/caluma/data_source/data_sources.py
@@ -21,6 +21,8 @@ class BaseDataSource:
         info: Informational string about this data source
         default: default value to return if execution of `get_data()` fails.
                  If this is `None`, the Exception won't be handled. Defaults to None.
+        validate: boolean that indicates if answers should be validated against the
+                  current response from `get_data()`. Defaults to `True`.
 
     A custom data source class could look like this:
     ```
@@ -44,6 +46,7 @@ class BaseDataSource:
 
     info = None
     default = None
+    validate = True
 
     def __init__(self):
         pass

--- a/caluma/data_source/tests/data_sources.py
+++ b/caluma/data_source/tests/data_sources.py
@@ -7,6 +7,7 @@ from caluma.data_source.utils import data_source_cache
 class MyDataSource(BaseDataSource):
     info = {"en": "Nice test data source", "de": "Schöne Datenquelle"}
     default = [1, 2, 3]
+    validate = True
 
     @data_source_cache(timeout=3600)
     def get_data(self, info):
@@ -33,6 +34,10 @@ class MyDataSource(BaseDataSource):
     @data_source_cache(timeout=1)
     def get_data_expire(self, info):
         return str(uuid4())
+
+
+class MyOtherDataSource(MyDataSource):
+    validate = False
 
 
 class MyFaultyDataSource(BaseDataSource):

--- a/caluma/form/factories.py
+++ b/caluma/form/factories.py
@@ -109,7 +109,10 @@ class AnswerFactory(DjangoModelFactory):
 
     @lazy_attribute
     def value(self):
-        if self.question.type == models.Question.TYPE_MULTIPLE_CHOICE:
+        if (
+            self.question.type == models.Question.TYPE_MULTIPLE_CHOICE
+            or self.question.type == models.Question.TYPE_DYNAMIC_MULTIPLE_CHOICE
+        ):
             return [Faker("name").generate({}), Faker("name").generate({})]
         elif self.question.type not in [
             models.Question.TYPE_FORM,

--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -481,7 +481,7 @@ class DocumentSerializer(serializers.ModelSerializer):
 
 class SaveAnswerSerializer(serializers.ModelSerializer):
     def validate(self, data):
-        validators.AnswerValidator().validate(**data)
+        validators.AnswerValidator().validate(**data, info=self.context["info"])
         return super().validate(data)
 
     class Meta:

--- a/caluma/form/tests/snapshots/snap_test_document.py
+++ b/caluma/form/tests/snapshots/snap_test_document.py
@@ -4,266 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
-
-snapshots["test_query_all_documents[integer-1-None] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "IntegerAnswer",
-                                    "integer_value": 1,
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
-                }
-            }
-        ]
-    }
-}
-
-snapshots["test_query_all_documents[float-2.1-None] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "FloatAnswer",
-                                    "float_value": 2.1,
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
-                }
-            }
-        ]
-    }
-}
-
-snapshots["test_query_all_documents[text-somevalue-None] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "StringAnswer",
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                    "string_value": "somevalue",
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
-                }
-            }
-        ]
-    }
-}
-
-snapshots["test_query_all_documents[multiple_choice-answer__value3-None] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "ListAnswer",
-                                    "list_value": ["somevalue", "anothervalue"],
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
-                }
-            }
-        ]
-    }
-}
-
-snapshots["test_query_all_documents[table-None-None] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "TableAnswer",
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                    "table_value": [{"form": {"slug": "effort-meet"}}],
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "872d1b6f-790c-473c-b5e9-2e714d607695",
-                }
-            }
-        ]
-    }
-}
-
-snapshots["test_query_all_documents[date-None-2019-02-22] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "DateAnswer",
-                                    "date_value": "2019-02-22",
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
-                }
-            }
-        ]
-    }
-}
-
-snapshots["test_query_all_documents[file-some-file.pdf-None] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "FileAnswer",
-                                    "fileValue": {
-                                        "downloadUrl": "http://minio/download-url",
-                                        "metadata": {
-                                            "bucket_name": "caluma-media",
-                                            "content_type": "application/pdf",
-                                            "etag": "0c81da684e6aaef48e8f3113e5b8769b",
-                                            "is_dir": False,
-                                            "last_modified": (
-                                                2019,
-                                                4,
-                                                5,
-                                                7,
-                                                0,
-                                                49,
-                                                4,
-                                                95,
-                                                0,
-                                            ),
-                                            "metadata": {
-                                                "X-Amz-Meta-Testtag": "super_file"
-                                            },
-                                            "object_name": "some-file.pdf",
-                                            "size": 8200,
-                                        },
-                                        "name": "some-file.pdf",
-                                    },
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
-                }
-            }
-        ]
-    }
-}
-
-snapshots["test_query_all_documents[file-some-other-file.pdf-None] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "FileAnswer",
-                                    "fileValue": {
-                                        "downloadUrl": "http://minio/download-url",
-                                        "metadata": {
-                                            "bucket_name": "caluma-media",
-                                            "content_type": "application/pdf",
-                                            "etag": "0c81da684e6aaef48e8f3113e5b8769b",
-                                            "is_dir": False,
-                                            "last_modified": (
-                                                2019,
-                                                4,
-                                                5,
-                                                7,
-                                                0,
-                                                49,
-                                                4,
-                                                95,
-                                                0,
-                                            ),
-                                            "metadata": {
-                                                "X-Amz-Meta-Testtag": "super_file"
-                                            },
-                                            "object_name": "some-file.pdf",
-                                            "size": 8200,
-                                        },
-                                        "name": "some-other-file.pdf",
-                                    },
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                }
-                            }
-                        ]
-                    },
-                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
-                }
-            }
-        ]
-    }
-}
 
 snapshots[
     "test_save_document_answer[integer-question__configuration0-1-None-SaveDocumentIntegerAnswer-True-option-slug-True] 1"
@@ -480,5 +221,353 @@ snapshots[
     "saveDocumentStringAnswer": {
         "answer": {"stringValue": "option-slug"},
         "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[dynamic_multiple_choice-question__configuration20-answer__value20-None-SaveDocumentListAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentListAnswer": {
+        "answer": {"listValue": ["5.5", "1"]},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[dynamic_multiple_choice-question__configuration20-answer__value20-None-SaveDocumentListAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentListAnswer": {
+        "answer": {"listValue": ["5.5", "1"]},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[dynamic_choice-question__configuration22-5.5-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"stringValue": "5.5"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[dynamic_choice-question__configuration22-5.5-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"stringValue": "5.5"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots["test_query_all_documents[integer-None-1-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "IntegerAnswer",
+                                    "integer_value": 1,
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
+    }
+}
+
+snapshots["test_query_all_documents[float-None-2.1-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "FloatAnswer",
+                                    "float_value": 2.1,
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
+    }
+}
+
+snapshots["test_query_all_documents[text-None-somevalue-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "StringAnswer",
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                    "string_value": "somevalue",
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
+    }
+}
+
+snapshots["test_query_all_documents[multiple_choice-None-answer__value3-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "ListAnswer",
+                                    "list_value": ["somevalue", "anothervalue"],
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
+    }
+}
+
+snapshots["test_query_all_documents[table-None-None-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "TableAnswer",
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                    "table_value": [{"form": {"slug": "effort-meet"}}],
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "872d1b6f-790c-473c-b5e9-2e714d607695",
+                }
+            }
+        ]
+    }
+}
+
+snapshots["test_query_all_documents[date-None-None-2019-02-22] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "DateAnswer",
+                                    "date_value": "2019-02-22",
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
+    }
+}
+
+snapshots["test_query_all_documents[file-None-some-file.pdf-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "FileAnswer",
+                                    "fileValue": {
+                                        "downloadUrl": "http://minio/download-url",
+                                        "metadata": {
+                                            "bucket_name": "caluma-media",
+                                            "content_type": "application/pdf",
+                                            "etag": "0c81da684e6aaef48e8f3113e5b8769b",
+                                            "is_dir": False,
+                                            "last_modified": (
+                                                2019,
+                                                4,
+                                                5,
+                                                7,
+                                                0,
+                                                49,
+                                                4,
+                                                95,
+                                                0,
+                                            ),
+                                            "metadata": {
+                                                "X-Amz-Meta-Testtag": "super_file"
+                                            },
+                                            "object_name": "some-file.pdf",
+                                            "size": 8200,
+                                        },
+                                        "name": "some-file.pdf",
+                                    },
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
+    }
+}
+
+snapshots["test_query_all_documents[file-None-some-other-file.pdf-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "FileAnswer",
+                                    "fileValue": {
+                                        "downloadUrl": "http://minio/download-url",
+                                        "metadata": {
+                                            "bucket_name": "caluma-media",
+                                            "content_type": "application/pdf",
+                                            "etag": "0c81da684e6aaef48e8f3113e5b8769b",
+                                            "is_dir": False,
+                                            "last_modified": (
+                                                2019,
+                                                4,
+                                                5,
+                                                7,
+                                                0,
+                                                49,
+                                                4,
+                                                95,
+                                                0,
+                                            ),
+                                            "metadata": {
+                                                "X-Amz-Meta-Testtag": "super_file"
+                                            },
+                                            "object_name": "some-file.pdf",
+                                            "size": 8200,
+                                        },
+                                        "name": "some-other-file.pdf",
+                                    },
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
+    }
+}
+
+snapshots["test_query_all_documents[dynamic_choice-MyDataSource-5.5-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "StringAnswer",
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                    "string_value": "5.5",
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
+    }
+}
+
+snapshots[
+    "test_query_all_documents[dynamic_multiple_choice-MyDataSource-5.5-None] 1"
+] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "StringAnswer",
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                    "string_value": "5.5",
+                                }
+                            }
+                        ]
+                    },
+                    "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
+                }
+            }
+        ]
     }
 }

--- a/caluma/form/tests/test_document.py
+++ b/caluma/form/tests/test_document.py
@@ -8,16 +8,18 @@ from .. import serializers
 
 
 @pytest.mark.parametrize(
-    "question__type,answer__value,answer__date",
+    "question__type,question__data_source,answer__value,answer__date",
     [
-        (Question.TYPE_INTEGER, 1, None),
-        (Question.TYPE_FLOAT, 2.1, None),
-        (Question.TYPE_TEXT, "somevalue", None),
-        (Question.TYPE_MULTIPLE_CHOICE, ["somevalue", "anothervalue"], None),
-        (Question.TYPE_TABLE, None, None),
-        (Question.TYPE_DATE, None, "2019-02-22"),
-        (Question.TYPE_FILE, "some-file.pdf", None),
-        (Question.TYPE_FILE, "some-other-file.pdf", None),
+        (Question.TYPE_INTEGER, None, 1, None),
+        (Question.TYPE_FLOAT, None, 2.1, None),
+        (Question.TYPE_TEXT, None, "somevalue", None),
+        (Question.TYPE_MULTIPLE_CHOICE, None, ["somevalue", "anothervalue"], None),
+        (Question.TYPE_TABLE, None, None, None),
+        (Question.TYPE_DATE, None, None, "2019-02-22"),
+        (Question.TYPE_FILE, None, "some-file.pdf", None),
+        (Question.TYPE_FILE, None, "some-other-file.pdf", None),
+        (Question.TYPE_DYNAMIC_CHOICE, "MyDataSource", "5.5", None),
+        (Question.TYPE_DYNAMIC_MULTIPLE_CHOICE, "MyDataSource", "5.5", None),
     ],
 )
 def test_query_all_documents(
@@ -36,6 +38,7 @@ def test_query_all_documents(
     schema_executor,
     question,
     minio_mock,
+    data_source_settings,
     settings,
 ):
     query = """
@@ -407,6 +410,38 @@ def test_save_document(db, document, schema_executor, update):
             "SaveDocumentStringAnswer",
             False,
         ),
+        (
+            Question.TYPE_DYNAMIC_MULTIPLE_CHOICE,
+            {"data_source": "MyDataSource"},
+            ["5.5", "1"],
+            None,
+            "SaveDocumentListAnswer",
+            True,
+        ),
+        (
+            Question.TYPE_DYNAMIC_MULTIPLE_CHOICE,
+            {"data_source": "MyDataSource"},
+            ["not in data"],
+            None,
+            "SaveDocumentStringAnswer",
+            False,
+        ),
+        (
+            Question.TYPE_DYNAMIC_CHOICE,
+            {"data_source": "MyDataSource"},
+            "5.5",
+            None,
+            "SaveDocumentStringAnswer",
+            True,
+        ),
+        (
+            Question.TYPE_DYNAMIC_CHOICE,
+            {"data_source": "MyDataSource"},
+            "not in data",
+            None,
+            "SaveDocumentStringAnswer",
+            False,
+        ),
     ],
 )
 def test_save_document_answer(
@@ -424,6 +459,7 @@ def test_save_document_answer(
     schema_executor,
     delete_answer,
     minio_mock,
+    data_source_settings,
 ):
     mutation_func = mutation[0].lower() + mutation[1:]
     query = f"""

--- a/caluma/form/tests/test_validators.py
+++ b/caluma/form/tests/test_validators.py
@@ -15,7 +15,7 @@ from ..validators import DocumentValidator
     ],
 )
 def test_validate_hidden_required_field(
-    db, required_jexl, hidden_jexl, should_throw, form_question, document_factory
+    db, required_jexl, hidden_jexl, should_throw, form_question, document_factory, info
 ):
     form_question.question.is_required = required_jexl
     form_question.question.is_hidden = hidden_jexl
@@ -25,21 +25,21 @@ def test_validate_hidden_required_field(
     error_msg = f"Questions {form_question.question.slug} are required but not provided"
     if should_throw:
         with pytest.raises(ValidationError, match=error_msg):
-            DocumentValidator().validate(document)
+            DocumentValidator().validate(document, info)
     else:
-        DocumentValidator().validate(document)
+        DocumentValidator().validate(document, info)
 
 
 @pytest.mark.parametrize(
     "question__type,question__is_required",
     [(Question.TYPE_FILE, "false"), (Question.TYPE_DATE, "false")],
 )
-def test_validate_special_fields(
-    db, form_question, question, document_factory, answer_factory
+def test_validate_file_field(
+    db, form_question, question, document_factory, answer_factory, info
 ):
     document = document_factory(form=form_question.form)
     answer_factory(document=document, question=question)
-    DocumentValidator().validate(document)
+    DocumentValidator().validate(document, info)
 
 
 @pytest.mark.parametrize(
@@ -61,6 +61,7 @@ def test_validate_nested_form(
     question_factory,
     answer_factory,
     answer_document_factory,
+    info,
 ):
     sub_form_question_1 = form_question_factory(
         form__slug="sub_1",
@@ -102,6 +103,6 @@ def test_validate_nested_form(
     if should_throw:
         error_msg = f"Questions {sub_form_question_1.question.slug} are required but not provided"
         with pytest.raises(ValidationError, match=error_msg):
-            DocumentValidator().validate(main_document)
+            DocumentValidator().validate(main_document, info)
     else:
-        DocumentValidator().validate(main_document)
+        DocumentValidator().validate(main_document, info)

--- a/caluma/workflow/serializers.py
+++ b/caluma/workflow/serializers.py
@@ -293,6 +293,7 @@ class CompleteWorkItemSerializer(serializers.ModelSerializer):
             task=self.instance.task,
             case=self.instance.case,
             document=self.instance.document,
+            info=self.context["info"],
         )
         data["status"] = models.WorkItem.STATUS_COMPLETED
         data["closed_at"] = timezone.now()

--- a/caluma/workflow/validators.py
+++ b/caluma/workflow/validators.py
@@ -5,16 +5,16 @@ from . import models
 
 
 class WorkItemValidator:
-    def _validate_task_simple(self, task, case, document):
+    def _validate_task_simple(self, task, case, document, info):
         pass
 
-    def _validate_task_complete_workflow_form(self, task, case, document):
-        self._validate_task_complete_task_form(task, case, case.document)
+    def _validate_task_complete_workflow_form(self, task, case, document, info):
+        self._validate_task_complete_task_form(task, case, case.document, info)
 
-    def _validate_task_complete_task_form(self, task, case, document):
-        DocumentValidator().validate(document)
+    def _validate_task_complete_task_form(self, task, case, document, info):
+        DocumentValidator().validate(document, info)
 
-    def validate(self, *, status, child_case, case, task, document, **kwargs):
+    def validate(self, *, status, child_case, case, task, document, info, **kwargs):
         if status != models.WorkItem.STATUS_READY:
             raise exceptions.ValidationError("Only ready work items can be completed.")
 
@@ -24,4 +24,4 @@ class WorkItemValidator:
                     "Work item can only be completed when child case is in a finish state."
                 )
 
-        getattr(self, f"_validate_task_{task.type}")(task, case, document)
+        getattr(self, f"_validate_task_{task.type}")(task, case, document, info)


### PR DESCRIPTION
This PR adds validators for answers to DynamicChoiceQuestion and
DynamicMultipleChoiceQuestion.

For this to work, all validators need access to the `info`-object.

Closes #412