### PR TITLE
Fix returning __typename for removeAnswer mutation

### DIFF
--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -751,6 +751,7 @@ class RemoveAnswer(Mutation):
     class Meta:
         lookup_input_kwarg = "answer"
         serializer_class = serializers.RemoveAnswerSerializer
+        return_field_type = Answer
 
 
 class Mutation(object):

--- a/caluma/form/tests/snapshots/snap_test_answer.py
+++ b/caluma/form/tests/snapshots/snap_test_answer.py
@@ -8,7 +8,11 @@ snapshots = Snapshot()
 
 snapshots["test_remove_answer[integer-23] 1"] = {
     "removeAnswer": {
-        "answer": {"id": "RmlsZUFuc3dlcjpOb25l", "meta": {}},
+        "answer": {
+            "__typename": "IntegerAnswer",
+            "id": "SW50ZWdlckFuc3dlcjpOb25l",
+            "meta": {},
+        },
         "clientMutationId": None,
     }
 }

--- a/caluma/form/tests/test_answer.py
+++ b/caluma/form/tests/test_answer.py
@@ -13,6 +13,7 @@ def test_remove_answer(db, snapshot, question, answer, schema_executor):
             answer {
               id
               meta
+              __typename
             }
             clientMutationId
           }

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -779,7 +779,7 @@ input RemoveAnswerInput {
 }
 
 type RemoveAnswerPayload {
-  answer: FileAnswer
+  answer: Answer
   clientMutationId: String
 }
 


### PR DESCRIPTION
The removeAnswer mutation always returned `FileAnswer` as __typename.

This commit fixes that, so that the returned `__typename` always matches
the answer that was removed.