### PR TITLE
Fix SaveDocumentFileAnswerSerializer fields

### DIFF
--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -687,7 +687,7 @@ class SaveDocumentFileAnswerSerializer(SaveAnswerSerializer):
         return super().update(instance, validated_data)
 
     class Meta(SaveAnswerSerializer.Meta):
-        fields = "__all__"
+        fields = SaveAnswerSerializer.Meta.fields + ("value_id",)
 
 
 class RemoveAnswerSerializer(serializers.ModelSerializer):

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -920,20 +920,11 @@ type SaveDocumentDateAnswerPayload {
 }
 
 input SaveDocumentFileAnswerInput {
-  id: String
-  value: String!
-  valueId: ID
-  createdAt: DateTime
-  modifiedAt: DateTime
-  createdByUser: String
-  createdByGroup: String
-  meta: JSONString
-  date: Date
   question: ID!
   document: ID!
-  valueDocument: ID
-  file: ID
-  documents: [ID]
+  meta: JSONString
+  value: String!
+  valueId: ID
   clientMutationId: String
 }
 


### PR DESCRIPTION
This was set to `__all__` which is obviously too much.

This commit adds the right fields.

Closes #411