### PR TITLE
Fix OIDC-middleware error handling

### DIFF
--- a/caluma/user/middleware.py
+++ b/caluma/user/middleware.py
@@ -112,5 +112,7 @@ class OIDCAuthenticationMiddleware(object):
                     timeout=settings.OIDC_BEARER_TOKEN_REVALIDATION_TIME,
                 )
                 request.user = models.OIDCClient(token, introspection)
+            else:
+                raise e
 
         return next(root, info, **args)


### PR DESCRIPTION
This commit fixes the error handling of `user.middleware`.

Before, if the unserinfo endpoint returned 401 or 403 and NO
introspection endpoint was configured, the user was left unset.

Now we raise the proper exception.

Closes #422