### PR TITLE
Fix type of Document.parentAnswers

### DIFF
--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -622,6 +622,7 @@ class Document(DjangoObjectType):
         AnswerConnection, filterset_class=filters.AnswerFilterSet
     )
     meta = generic.GenericScalar()
+    parent_answers = graphene.List("caluma.form.schema.FormAnswer")
 
     class Meta:
         model = models.Document
@@ -660,6 +661,7 @@ class File(DjangoObjectType):
     upload_url = graphene.String()
     download_url = graphene.String()
     metadata = generic.GenericScalar()
+    answer = graphene.Field("caluma.form.schema.FileAnswer")
 
     class Meta:
         model = models.File

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -317,7 +317,7 @@ type Document implements Node {
   form: Form!
   meta: GenericScalar
   answers(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, question: ID, search: String, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [AnswerOrdering], questions: [ID]): AnswerConnection
-  parentAnswers: [FileAnswer]
+  parentAnswers: [FormAnswer]
   case: Case
   workItem: WorkItem
 }


### PR DESCRIPTION
The type of `parentAnswers` on `Document` and `answer` on `File`
was not explicitly set.

This commit sets the type for them.

Closes #382