### PR TITLE
Revert "Fix type of Document.parentAnswers"

### DIFF
--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -622,7 +622,6 @@ class Document(DjangoObjectType):
         AnswerConnection, filterset_class=filters.AnswerFilterSet
     )
     meta = generic.GenericScalar()
-    parent_answers = graphene.List("caluma.form.schema.FormAnswer")
 
     class Meta:
         model = models.Document
@@ -661,7 +660,6 @@ class File(DjangoObjectType):
     upload_url = graphene.String()
     download_url = graphene.String()
     metadata = generic.GenericScalar()
-    answer = graphene.Field("caluma.form.schema.FileAnswer")
 
     class Meta:
         model = models.File

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -317,7 +317,7 @@ type Document implements Node {
   form: Form!
   meta: GenericScalar
   answers(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, question: ID, search: String, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [AnswerOrdering], questions: [ID]): AnswerConnection
-  parentAnswers: [FormAnswer]
+  parentAnswers: [FileAnswer]
   case: Case
   workItem: WorkItem
 }


### PR DESCRIPTION
This fix caused issues in "getFileAnswerInfo": "FormAnswer" is returned.
This reverts commit 7920a276a74d5f7e5beb0b92e845640d4850fcfb.