### PR TITLE
feat(static): make static question content optional

### DIFF
--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -420,7 +420,7 @@ class SaveFileQuestionSerializer(SaveQuestionSerializer):
 
 
 class SaveStaticQuestionSerializer(SaveQuestionSerializer):
-    static_content = CharField(required=True)
+    static_content = CharField(required=False)
 
     def validate(self, data):
         data["type"] = models.Question.TYPE_STATIC

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots[
@@ -1214,7 +1215,7 @@ input SaveStaticQuestionInput {
   isHidden: QuestionJexl
   meta: JSONString
   isArchived: Boolean
-  staticContent: String!
+  staticContent: String
   clientMutationId: String
 }
 


### PR DESCRIPTION
Static content is also supposed to be the primary field type for custom
field overrides. For those overrides, no actual static content is
required.