### PR TITLE
Fix returned types

### DIFF
--- a/caluma/form/factories.py
+++ b/caluma/form/factories.py
@@ -105,7 +105,6 @@ class FileFactory(DjangoModelFactory):
 class AnswerFactory(DjangoModelFactory):
     question = SubFactory(QuestionFactory)
     document = SubFactory(DocumentFactory)
-    date = None
     meta = {}
 
     @lazy_attribute
@@ -115,6 +114,10 @@ class AnswerFactory(DjangoModelFactory):
             or self.question.type == models.Question.TYPE_DYNAMIC_MULTIPLE_CHOICE
         ):
             return [Faker("name").generate({}), Faker("name").generate({})]
+        elif self.question.type == models.Question.TYPE_FLOAT:
+            return Faker("pyfloat").generate({})
+        elif self.question.type == models.Question.TYPE_INTEGER:
+            return Faker("pyint").generate({})
         elif self.question.type not in [
             models.Question.TYPE_FORM,
             models.Question.TYPE_TABLE,

--- a/caluma/form/tests/snapshots/snap_test_document.py
+++ b/caluma/form/tests/snapshots/snap_test_document.py
@@ -322,7 +322,7 @@ snapshots[
     "test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentIntegerAnswer": {
-        "answer": {"integerValue": 1},
+        "answer": {"__typename": "IntegerAnswer", "integerValue": 1},
         "clientMutationId": "testid",
     }
 }
@@ -331,7 +331,7 @@ snapshots[
     "test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentIntegerAnswer": {
-        "answer": {"integerValue": 1},
+        "answer": {"__typename": "IntegerAnswer", "integerValue": 1},
         "clientMutationId": "testid",
     }
 }
@@ -340,7 +340,7 @@ snapshots[
     "test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentFloatAnswer": {
-        "answer": {"floatValue": 2.1},
+        "answer": {"__typename": "FloatAnswer", "floatValue": 2.1},
         "clientMutationId": "testid",
     }
 }
@@ -349,7 +349,7 @@ snapshots[
     "test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentFloatAnswer": {
-        "answer": {"floatValue": 2.1},
+        "answer": {"__typename": "FloatAnswer", "floatValue": 2.1},
         "clientMutationId": "testid",
     }
 }
@@ -358,7 +358,7 @@ snapshots[
     "test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "Test"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
         "clientMutationId": "testid",
     }
 }
@@ -367,7 +367,7 @@ snapshots[
     "test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "Test"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
         "clientMutationId": "testid",
     }
 }
@@ -376,7 +376,7 @@ snapshots[
     "test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentDateAnswer": {
-        "answer": {"dateValue": "2019-02-22"},
+        "answer": {"__typename": "DateAnswer", "dateValue": "2019-02-22"},
         "clientMutationId": "testid",
     }
 }
@@ -385,7 +385,7 @@ snapshots[
     "test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentDateAnswer": {
-        "answer": {"dateValue": "2019-02-22"},
+        "answer": {"__typename": "DateAnswer", "dateValue": "2019-02-22"},
         "clientMutationId": "testid",
     }
 }
@@ -395,10 +395,11 @@ snapshots[
 ] = {
     "saveDocumentFileAnswer": {
         "answer": {
+            "__typename": "FileAnswer",
             "fileValue": {
                 "name": "some-file.pdf",
                 "uploadUrl": "http://minio/upload-url",
-            }
+            },
         },
         "clientMutationId": "testid",
     }
@@ -408,7 +409,13 @@ snapshots[
     "test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentFileAnswer": {
-        "answer": {"stringValue": "some-file.pdf"},
+        "answer": {
+            "__typename": "FileAnswer",
+            "fileValue": {
+                "name": "some-file.pdf",
+                "uploadUrl": "http://minio/upload-url",
+            },
+        },
         "clientMutationId": "testid",
     }
 }
@@ -418,10 +425,11 @@ snapshots[
 ] = {
     "saveDocumentFileAnswer": {
         "answer": {
+            "__typename": "FileAnswer",
             "fileValue": {
                 "name": "not-exist.pdf",
                 "uploadUrl": "http://minio/upload-url",
-            }
+            },
         },
         "clientMutationId": "testid",
     }
@@ -431,7 +439,13 @@ snapshots[
     "test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentFileAnswer": {
-        "answer": {"stringValue": "not-exist.pdf"},
+        "answer": {
+            "__typename": "FileAnswer",
+            "fileValue": {
+                "name": "not-exist.pdf",
+                "uploadUrl": "http://minio/upload-url",
+            },
+        },
         "clientMutationId": "testid",
     }
 }
@@ -441,10 +455,11 @@ snapshots[
 ] = {
     "saveDocumentTableAnswer": {
         "answer": {
+            "__typename": "TableAnswer",
             "table_value": [
                 {"form": {"slug": "suggest-traditional"}},
                 {"form": {"slug": "suggest-traditional"}},
-            ]
+            ],
         },
         "clientMutationId": "testid",
     }
@@ -455,10 +470,11 @@ snapshots[
 ] = {
     "saveDocumentTableAnswer": {
         "answer": {
+            "__typename": "TableAnswer",
             "table_value": [
                 {"form": {"slug": "suggest-traditional"}},
                 {"form": {"slug": "suggest-traditional"}},
-            ]
+            ],
         },
         "clientMutationId": "testid",
     }
@@ -468,7 +484,10 @@ snapshots[
     "test_save_document_answer[form-question__configuration13-None-question__format_validators13-None-None-SaveDocumentFormAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentFormAnswer": {
-        "answer": {"form_value": {"form": {"slug": "suggest-traditional"}}},
+        "answer": {
+            "__typename": "FormAnswer",
+            "form_value": {"form": {"slug": "suggest-traditional"}},
+        },
         "clientMutationId": "testid",
     }
 }
@@ -477,7 +496,10 @@ snapshots[
     "test_save_document_answer[form-question__configuration13-None-question__format_validators13-None-None-SaveDocumentFormAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentFormAnswer": {
-        "answer": {"form_value": {"form": {"slug": "suggest-traditional"}}},
+        "answer": {
+            "__typename": "FormAnswer",
+            "form_value": {"form": {"slug": "suggest-traditional"}},
+        },
         "clientMutationId": "testid",
     }
 }
@@ -486,7 +508,7 @@ snapshots[
     "test_save_document_answer[textarea-question__configuration14-None-question__format_validators14-Test-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "Test"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
         "clientMutationId": "testid",
     }
 }
@@ -495,7 +517,7 @@ snapshots[
     "test_save_document_answer[textarea-question__configuration14-None-question__format_validators14-Test-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "Test"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
         "clientMutationId": "testid",
     }
 }
@@ -504,7 +526,7 @@ snapshots[
     "test_save_document_answer[multiple_choice-question__configuration16-None-question__format_validators16-answer__value16-None-SaveDocumentListAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentListAnswer": {
-        "answer": {"listValue": ["option-slug"]},
+        "answer": {"__typename": "ListAnswer", "listValue": ["option-slug"]},
         "clientMutationId": "testid",
     }
 }
@@ -513,7 +535,7 @@ snapshots[
     "test_save_document_answer[multiple_choice-question__configuration16-None-question__format_validators16-answer__value16-None-SaveDocumentListAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentListAnswer": {
-        "answer": {"listValue": ["option-slug"]},
+        "answer": {"__typename": "ListAnswer", "listValue": ["option-slug"]},
         "clientMutationId": "testid",
     }
 }
@@ -522,7 +544,7 @@ snapshots[
     "test_save_document_answer[choice-question__configuration18-None-question__format_validators18-option-slug-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "option-slug"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "option-slug"},
         "clientMutationId": "testid",
     }
 }
@@ -531,7 +553,7 @@ snapshots[
     "test_save_document_answer[choice-question__configuration18-None-question__format_validators18-option-slug-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "option-slug"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "option-slug"},
         "clientMutationId": "testid",
     }
 }
@@ -540,7 +562,7 @@ snapshots[
     "test_save_document_answer[dynamic_multiple_choice-question__configuration20-MyDataSource-question__format_validators20-answer__value20-None-SaveDocumentListAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentListAnswer": {
-        "answer": {"listValue": ["5.5", "1"]},
+        "answer": {"__typename": "ListAnswer", "listValue": ["5.5", "1"]},
         "clientMutationId": "testid",
     }
 }
@@ -549,7 +571,7 @@ snapshots[
     "test_save_document_answer[dynamic_multiple_choice-question__configuration20-MyDataSource-question__format_validators20-answer__value20-None-SaveDocumentListAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentListAnswer": {
-        "answer": {"listValue": ["5.5", "1"]},
+        "answer": {"__typename": "ListAnswer", "listValue": ["5.5", "1"]},
         "clientMutationId": "testid",
     }
 }
@@ -558,7 +580,7 @@ snapshots[
     "test_save_document_answer[dynamic_choice-question__configuration22-MyDataSource-question__format_validators22-5.5-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "5.5"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "5.5"},
         "clientMutationId": "testid",
     }
 }
@@ -567,7 +589,7 @@ snapshots[
     "test_save_document_answer[dynamic_choice-question__configuration22-MyDataSource-question__format_validators22-5.5-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "5.5"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "5.5"},
         "clientMutationId": "testid",
     }
 }
@@ -576,7 +598,7 @@ snapshots[
     "test_save_document_answer[text-question__configuration25-None-question__format_validators25-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "test@example.com"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
         "clientMutationId": "testid",
     }
 }
@@ -585,7 +607,7 @@ snapshots[
     "test_save_document_answer[text-question__configuration25-None-question__format_validators25-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "test@example.com"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
         "clientMutationId": "testid",
     }
 }
@@ -594,7 +616,7 @@ snapshots[
     "test_save_document_answer[textarea-question__configuration27-None-question__format_validators27-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "test@example.com"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
         "clientMutationId": "testid",
     }
 }
@@ -603,7 +625,7 @@ snapshots[
     "test_save_document_answer[textarea-question__configuration27-None-question__format_validators27-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
 ] = {
     "saveDocumentStringAnswer": {
-        "answer": {"stringValue": "test@example.com"},
+        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
         "clientMutationId": "testid",
     }
 }

--- a/caluma/form/tests/test_document.py
+++ b/caluma/form/tests/test_document.py
@@ -644,6 +644,7 @@ def test_save_document_answer(
         mutation {mutation}($input: {mutation}Input!) {{
           {mutation_func}(input: $input) {{
             answer {{
+              __typename
               ... on StringAnswer {{
                 stringValue: value
               }}
@@ -707,11 +708,11 @@ def test_save_document_answer(
         document = document_factory.create(form=question.sub_form)
         inp["input"]["value"] = document.pk
 
-    if question.type == Question.TYPE_FILE and answer.value == "some-file.pdf":
-        file = file_factory(name="some-file.pdf")
-        answer.file = file
+    if question.type == Question.TYPE_FILE:
+        if answer.value == "some-file.pdf":
+            minio_mock.bucket_exists.return_value = False
+        answer.value = None
         answer.save()
-        minio_mock.bucket_exists.return_value = False
 
     if question.type == Question.TYPE_DATE:
         inp["input"]["value"] = answer.date

--- a/caluma/form/tests/test_type.py
+++ b/caluma/form/tests/test_type.py
@@ -1,0 +1,77 @@
+import pytest
+from graphql_relay import to_global_id
+
+from .. import models
+
+
+@pytest.mark.parametrize(
+    "question__type,expected_typename",
+    [
+        (models.Question.TYPE_FILE, "FileAnswer"),
+        (models.Question.TYPE_TEXT, "StringAnswer"),
+        (models.Question.TYPE_TEXTAREA, "StringAnswer"),
+        (models.Question.TYPE_FLOAT, "FloatAnswer"),
+        (models.Question.TYPE_CHOICE, "StringAnswer"),
+        (models.Question.TYPE_INTEGER, "IntegerAnswer"),
+        (models.Question.TYPE_MULTIPLE_CHOICE, "ListAnswer"),
+        (models.Question.TYPE_DYNAMIC_CHOICE, "StringAnswer"),
+        (models.Question.TYPE_DYNAMIC_MULTIPLE_CHOICE, "ListAnswer"),
+        (models.Question.TYPE_DATE, "DateAnswer"),
+        (models.Question.TYPE_TABLE, "TableAnswer"),
+        (models.Question.TYPE_STATIC, "StringAnswer"),
+        (models.Question.TYPE_FORM, "FormAnswer"),
+    ],
+)
+def test_answer_types(db, question, expected_typename, answer_factory, schema_executor):
+    answer = answer_factory(question=question)
+    global_id = to_global_id(expected_typename, answer.pk)
+
+    query = """
+        query Answer($id: ID!) {
+            node(id: $id) {
+              id
+              __typename
+            }
+        }
+    """
+
+    result = schema_executor(query, variables={"id": global_id})
+    assert not result.errors
+    assert result.data["node"]["__typename"] == expected_typename
+
+
+@pytest.mark.parametrize(
+    "question__type,expected_typename",
+    [
+        (models.Question.TYPE_TEXT, "TextQuestion"),
+        (models.Question.TYPE_FLOAT, "FloatQuestion"),
+        (models.Question.TYPE_CHOICE, "ChoiceQuestion"),
+        (models.Question.TYPE_INTEGER, "IntegerQuestion"),
+        (models.Question.TYPE_MULTIPLE_CHOICE, "MultipleChoiceQuestion"),
+        (models.Question.TYPE_DYNAMIC_CHOICE, "DynamicChoiceQuestion"),
+        (models.Question.TYPE_DYNAMIC_MULTIPLE_CHOICE, "DynamicMultipleChoiceQuestion"),
+        (models.Question.TYPE_TEXTAREA, "TextareaQuestion"),
+        (models.Question.TYPE_DATE, "DateQuestion"),
+        (models.Question.TYPE_TABLE, "TableQuestion"),
+        (models.Question.TYPE_FORM, "FormQuestion"),
+        (models.Question.TYPE_FILE, "FileQuestion"),
+        (models.Question.TYPE_STATIC, "StaticQuestion"),
+    ],
+)
+def test_question_types(
+    db, question, expected_typename, answer_factory, schema_executor
+):
+    global_id = to_global_id(expected_typename, question.pk)
+
+    query = """
+        query Question($id: ID!) {
+            node(id: $id) {
+              id
+              __typename
+            }
+        }
+    """
+
+    result = schema_executor(query, variables={"id": global_id})
+    assert not result.errors
+    assert result.data["node"]["__typename"] == expected_typename

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots[
@@ -318,7 +317,7 @@ type Document implements Node {
   form: Form!
   meta: GenericScalar
   answers(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, question: ID, search: String, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [AnswerOrdering], questions: [ID]): AnswerConnection
-  parentAnswers: [FileAnswer]
+  parentAnswers: [FormAnswer]
   case: Case
   workItem: WorkItem
 }


### PR DESCRIPTION
Graphenes auto type detection doesn't work reliably with our different
Question and Answer types.

This commit adds a subclass of our subclass of DjangoObjectType with
support for resolving Question and Answer types.

Additionally the type is explicitly set for `parent_answers` of `Document`
and `answer` on `File`.

Also updated the `AnswerFactory` to correctly set float and int values for
their respective Answers.

Closes #432