### PR TITLE
Fix saving table answers with value 0

### DIFF
--- a/caluma/form/tests/test_validators.py
+++ b/caluma/form/tests/test_validators.py
@@ -213,3 +213,16 @@ def test_validate_invalid_jexl(
         assert exc.value.args[0] == exception_message
     else:
         assert DocumentValidator().validate(document, info) is None
+
+
+def test_validate_required_integer_0(
+    db, form_question, answer_factory, document_factory, info
+):
+    form_question.question.is_required = "true"
+    form_question.question.type = Question.TYPE_INTEGER
+    form_question.question.save()
+
+    document = document_factory(form=form_question.form)
+    answer_factory(document=document, value=0, question=form_question.question)
+
+    DocumentValidator().validate(document, info)

--- a/caluma/form/validators.py
+++ b/caluma/form/validators.py
@@ -235,7 +235,7 @@ class DocumentValidator:
                     question.is_hidden
                 )
                 if is_required and not is_hidden:
-                    if not answer_by_question.get(question.slug, None):
+                    if answer_by_question.get(question.slug, None) in [None, ""]:
                         required_but_empty.append(question.slug)
             except Exception as exc:
                 expr_jexl = getattr(question, expr)


### PR DESCRIPTION
`validate_required()` on `DocumentValidator` used a "if not" condition.

With this commit, it checks explicitly for `None` and `""`.

Closes #435