### PR TITLE
Implement totalCount for connections

### DIFF
--- a/caluma/core/types.py
+++ b/caluma/core/types.py
@@ -1,4 +1,6 @@
+import graphene
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models.query import QuerySet
 from graphene_django import types
 
 
@@ -38,3 +40,17 @@ class DjangoObjectType(Node, types.DjangoObjectType):
 
     class Meta:
         abstract = True
+
+
+class CountableConnectionBase(graphene.Connection):
+    """Connection subclass that supports totalCount."""
+
+    class Meta:
+        abstract = True
+
+    total_count = graphene.Int()
+
+    def resolve_total_count(self, info, **kwargs):
+        if isinstance(self.iterable, QuerySet):
+            return self.iterable.count()
+        return len(self.iterable)

--- a/caluma/data_source/schema.py
+++ b/caluma/data_source/schema.py
@@ -1,6 +1,7 @@
-from graphene import Connection, ConnectionField, String
+from graphene import ConnectionField, String
 from graphene.types import ObjectType
 
+from ..core.types import CountableConnectionBase
 from .data_source_handlers import get_data_source_data, get_data_sources
 
 
@@ -9,7 +10,7 @@ class DataSource(ObjectType):
     name = String(required=True)
 
 
-class DataSourceConnection(Connection):
+class DataSourceConnection(CountableConnectionBase):
     class Meta:
         node = DataSource
 
@@ -19,7 +20,7 @@ class DataSourceData(ObjectType):
     slug = String(required=True)
 
 
-class DataSourceDataConnection(Connection):
+class DataSourceDataConnection(CountableConnectionBase):
     class Meta:
         node = DataSourceData
 

--- a/caluma/data_source/tests/snapshots/snap_test_data_source.py
+++ b/caluma/data_source/tests/snapshots/snap_test_data_source.py
@@ -22,23 +22,7 @@ snapshots["test_fetch_data_sources 1"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
-    }
-}
-
-snapshots["test_fetch_data_from_data_source 1"] = {
-    "dataSource": {
-        "edges": [
-            {"node": {"label": "1", "slug": "1"}},
-            {"node": {"label": "5.5", "slug": "5.5"}},
-            {"node": {"label": "sdkj", "slug": "sdkj"}},
-            {"node": {"label": "info", "slug": "value"}},
-            {"node": {"label": "something", "slug": "something"}},
-            {"node": {"label": "english description", "slug": "translated_value"}},
-        ],
-        "pageInfo": {
-            "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
-            "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
-        },
+        "totalCount": 3,
     }
 }
 
@@ -58,6 +42,7 @@ snapshots["test_fetch_data_sources 2"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
+        "totalCount": 3,
     }
 }
 
@@ -77,6 +62,25 @@ snapshots["test_fetch_data_sources 3"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
+        "totalCount": 3,
+    }
+}
+
+snapshots["test_fetch_data_from_data_source 1"] = {
+    "dataSource": {
+        "edges": [
+            {"node": {"label": "1", "slug": "1"}},
+            {"node": {"label": "5.5", "slug": "5.5"}},
+            {"node": {"label": "sdkj", "slug": "sdkj"}},
+            {"node": {"label": "info", "slug": "value"}},
+            {"node": {"label": "something", "slug": "something"}},
+            {"node": {"label": "english description", "slug": "translated_value"}},
+        ],
+        "pageInfo": {
+            "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
+            "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+        },
+        "totalCount": 6,
     }
 }
 
@@ -94,6 +98,7 @@ snapshots["test_fetch_data_from_data_source 2"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
+        "totalCount": 6,
     }
 }
 
@@ -111,6 +116,7 @@ snapshots["test_fetch_data_from_data_source 3"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjU=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
+        "totalCount": 6,
     }
 }
 
@@ -125,5 +131,6 @@ snapshots["test_data_source_defaults 1"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
+        "totalCount": 3,
     }
 }

--- a/caluma/data_source/tests/test_data_source.py
+++ b/caluma/data_source/tests/test_data_source.py
@@ -12,6 +12,7 @@ def test_fetch_data_sources(snapshot, schema_executor, settings):
     query = """
         query dataSources {
           allDataSources {
+            totalCount
             pageInfo {
               startCursor
               endCursor
@@ -45,6 +46,7 @@ def test_fetch_data_from_data_source(snapshot, schema_executor, data_source_sett
     query = """
         query dataSource {
           dataSource (name: "MyDataSource") {
+            totalCount
             pageInfo {
               startCursor
               endCursor
@@ -124,6 +126,7 @@ def test_data_source_defaults(snapshot, schema_executor, settings):
     query = """
             query dataSource {
               dataSource (name: "MyBrokenDataSource") {
+                totalCount
                 pageInfo {
                   startCursor
                   endCursor

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -1,12 +1,12 @@
 import graphene
-from graphene import Connection, ConnectionField, relay
+from graphene import ConnectionField, relay
 from graphene.types import ObjectType, generic
 from graphene_django.rest_framework import serializer_converter
 
 from ..core.filters import DjangoFilterConnectionField, DjangoFilterSetConnectionField
 from ..core.mutation import Mutation, UserDefinedPrimaryKeyMixin
 from ..core.relay import extract_global_id
-from ..core.types import DjangoObjectType, Node
+from ..core.types import CountableConnectionBase, DjangoObjectType, Node
 from ..data_source.data_source_handlers import get_data_source_data
 from ..data_source.schema import DataSourceDataConnection
 from . import filters, models, serializers
@@ -132,6 +132,7 @@ class Option(FormDjangoObjectType):
         model = models.Option
         interfaces = (relay.Node,)
         exclude_fields = ("questions",)
+        connection_class = CountableConnectionBase
 
     @classmethod
     def get_queryset(cls, queryset, info):
@@ -139,7 +140,7 @@ class Option(FormDjangoObjectType):
         return queryset.order_by("-questionoption__sort")
 
 
-class QuestionConnection(graphene.Connection):
+class QuestionConnection(CountableConnectionBase):
     class Meta:
         node = Question
 
@@ -159,7 +160,7 @@ class FormatValidator(ObjectType):
     error_msg = graphene.String(required=True)
 
 
-class FormatValidatorConnection(Connection):
+class FormatValidatorConnection(CountableConnectionBase):
     class Meta:
         node = FormatValidator
 
@@ -447,6 +448,7 @@ class Form(FormDjangoObjectType):
         model = models.Form
         interfaces = (relay.Node,)
         exclude_fields = ("workflows", "tasks")
+        connection_class = CountableConnectionBase
 
 
 class SaveForm(UserDefinedPrimaryKeyMixin, Mutation):
@@ -673,7 +675,7 @@ class ListAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
         interfaces = (Answer, graphene.Node)
 
 
-class AnswerConnection(graphene.Connection):
+class AnswerConnection(CountableConnectionBase):
     class Meta:
         node = Answer
 
@@ -689,6 +691,7 @@ class Document(FormDjangoObjectType):
         model = models.Document
         exclude_fields = ("family",)
         interfaces = (graphene.Node,)
+        connection_class = CountableConnectionBase
 
 
 class TableAnswer(AnswerQuerysetMixin, FormDjangoObjectType):

--- a/caluma/form/tests/snapshots/snap_test_document.py
+++ b/caluma/form/tests/snapshots/snap_test_document.py
@@ -23,12 +23,14 @@ snapshots["test_query_all_documents[integer-None-1-None] 1"] = {
                                     },
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -49,12 +51,14 @@ snapshots["test_query_all_documents[float-None-2.1-None] 1"] = {
                                     },
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -75,12 +79,14 @@ snapshots["test_query_all_documents[text-None-somevalue-None] 1"] = {
                                     "string_value": "somevalue",
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -101,12 +107,14 @@ snapshots["test_query_all_documents[multiple_choice-None-answer__value3-None] 1"
                                     },
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -127,12 +135,14 @@ snapshots["test_query_all_documents[table-None-None-None] 1"] = {
                                     "table_value": [{"form": {"slug": "effort-meet"}}],
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "872d1b6f-790c-473c-b5e9-2e714d607695",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -153,12 +163,14 @@ snapshots["test_query_all_documents[date-None-None-2019-02-22] 1"] = {
                                     },
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -204,12 +216,14 @@ snapshots["test_query_all_documents[file-None-some-file.pdf-None] 1"] = {
                                     },
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -255,12 +269,14 @@ snapshots["test_query_all_documents[file-None-some-other-file.pdf-None] 1"] = {
                                     },
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -281,12 +297,14 @@ snapshots["test_query_all_documents[dynamic_choice-MyDataSource-5.5-None] 1"] = 
                                     "string_value": "5.5",
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -309,12 +327,14 @@ snapshots[
                                     "string_value": "5.5",
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "createdByUser": "4602cffe-6aa8-4ae7-ba6b-2cf34839ef47",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 

--- a/caluma/form/tests/snapshots/snap_test_format_validators.py
+++ b/caluma/form/tests/snapshots/snap_test_format_validators.py
@@ -38,6 +38,7 @@ snapshots["test_fetch_format_validators 1"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
+        "totalCount": 3,
     }
 }
 
@@ -73,6 +74,7 @@ snapshots["test_fetch_format_validators 2"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
+        "totalCount": 3,
     }
 }
 
@@ -108,6 +110,7 @@ snapshots["test_fetch_format_validators 3"] = {
             "endCursor": "YXJyYXljb25uZWN0aW9uOjI=",
             "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
         },
+        "totalCount": 3,
     }
 }
 

--- a/caluma/form/tests/snapshots/snap_test_question.py
+++ b/caluma/form/tests/snapshots/snap_test_question.py
@@ -24,7 +24,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -46,7 +47,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -68,7 +70,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -87,7 +90,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -120,7 +124,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -142,7 +147,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -158,11 +164,15 @@ snapshots[
                     "infoText": "",
                     "label": "Brian Williams",
                     "meta": {},
-                    "options": {"edges": [{"node": {"slug": "treatment-radio"}}]},
+                    "options": {
+                        "edges": [{"node": {"slug": "treatment-radio"}}],
+                        "totalCount": 1,
+                    },
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -178,11 +188,15 @@ snapshots[
                     "infoText": "",
                     "label": "Brian Williams",
                     "meta": {},
-                    "options": {"edges": [{"node": {"slug": "treatment-radio"}}]},
+                    "options": {
+                        "edges": [{"node": {"slug": "treatment-radio"}}],
+                        "totalCount": 1,
+                    },
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -202,7 +216,8 @@ snapshots[
                     "subForm": {"slug": "suggest-traditional"},
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -221,7 +236,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -255,7 +271,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -289,7 +306,8 @@ snapshots[
                     "slug": "effort-meet",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 
@@ -310,7 +328,8 @@ snapshots[
 Kid avoid player relationship to range whose. Draw free property consider.""",
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
     }
 }
 

--- a/caluma/form/tests/test_document.py
+++ b/caluma/form/tests/test_document.py
@@ -44,10 +44,12 @@ def test_query_all_documents(
     query = """
         query AllDocumentsQuery($search: String) {
           allDocuments(search: $search) {
+            totalCount
             edges {
               node {
                 createdByUser
                 answers {
+                  totalCount
                   edges {
                     node {
                       __typename

--- a/caluma/form/tests/test_format_validators.py
+++ b/caluma/form/tests/test_format_validators.py
@@ -25,6 +25,7 @@ def test_fetch_format_validators(snapshot, schema_executor, settings):
               startCursor
               endCursor
             }
+            totalCount
             edges {
               node {
                 slug

--- a/caluma/form/tests/test_question.py
+++ b/caluma/form/tests/test_question.py
@@ -40,6 +40,7 @@ def test_query_all_questions(
     query = """
         query AllQuestionsQuery($search: String, $forms: [ID]) {
           allQuestions(isArchived: false, search: $search, excludeForms: $forms) {
+            totalCount
             edges {
               node {
                 id
@@ -88,6 +89,7 @@ def test_query_all_questions(
                 }
                 ... on MultipleChoiceQuestion {
                   options {
+                    totalCount
                     edges {
                       node {
                         slug
@@ -97,6 +99,7 @@ def test_query_all_questions(
                 }
                 ... on ChoiceQuestion {
                   options {
+                    totalCount
                     edges {
                       node {
                         slug

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -49,6 +49,7 @@ interface Answer {
 type AnswerConnection {
   pageInfo: PageInfo!
   edges: [AnswerEdge]!
+  totalCount: Int
 }
 
 type AnswerEdge {
@@ -97,6 +98,7 @@ type Case implements Node {
 type CaseConnection {
   pageInfo: PageInfo!
   edges: [CaseEdge]!
+  totalCount: Int
 }
 
 type CaseEdge {
@@ -253,6 +255,7 @@ type DataSource {
 type DataSourceConnection {
   pageInfo: PageInfo!
   edges: [DataSourceEdge]!
+  totalCount: Int
 }
 
 type DataSourceData {
@@ -263,6 +266,7 @@ type DataSourceData {
 type DataSourceDataConnection {
   pageInfo: PageInfo!
   edges: [DataSourceDataEdge]!
+  totalCount: Int
 }
 
 type DataSourceDataEdge {
@@ -325,6 +329,7 @@ type Document implements Node {
 type DocumentConnection {
   pageInfo: PageInfo!
   edges: [DocumentEdge]!
+  totalCount: Int
 }
 
 type DocumentEdge {
@@ -467,6 +472,7 @@ type Flow implements Node {
 type FlowConnection {
   pageInfo: PageInfo!
   edges: [FlowEdge]!
+  totalCount: Int
 }
 
 type FlowEdge {
@@ -508,6 +514,7 @@ type FormAnswer implements Answer, Node {
 type FormConnection {
   pageInfo: PageInfo!
   edges: [FormEdge]!
+  totalCount: Int
 }
 
 type FormEdge {
@@ -556,6 +563,7 @@ type FormatValidator {
 type FormatValidatorConnection {
   pageInfo: PageInfo!
   edges: [FormatValidatorEdge]!
+  totalCount: Int
 }
 
 type FormatValidatorEdge {
@@ -708,6 +716,7 @@ type Option implements Node {
 type OptionConnection {
   pageInfo: PageInfo!
   edges: [OptionEdge]!
+  totalCount: Int
 }
 
 type OptionEdge {
@@ -769,6 +778,7 @@ interface Question {
 type QuestionConnection {
   pageInfo: PageInfo!
   edges: [QuestionEdge]!
+  totalCount: Int
 }
 
 type QuestionEdge {
@@ -1417,6 +1427,7 @@ interface Task {
 type TaskConnection {
   pageInfo: PageInfo!
   edges: [TaskEdge]!
+  totalCount: Int
 }
 
 type TaskEdge {
@@ -1516,6 +1527,7 @@ type WorkItem implements Node {
 type WorkItemConnection {
   pageInfo: PageInfo!
   edges: [WorkItemEdge]!
+  totalCount: Int
 }
 
 type WorkItemEdge {
@@ -1572,6 +1584,7 @@ type Workflow implements Node {
 type WorkflowConnection {
   pageInfo: PageInfo!
   edges: [WorkflowEdge]!
+  totalCount: Int
 }
 
 type WorkflowEdge {

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -8,7 +8,7 @@ from graphene_django.rest_framework import serializer_converter
 
 from ..core.filters import DjangoFilterConnectionField, DjangoFilterSetConnectionField
 from ..core.mutation import Mutation, UserDefinedPrimaryKeyMixin
-from ..core.types import DjangoObjectType, Node
+from ..core.types import CountableConnectionBase, DjangoObjectType, Node
 from . import filters, jexl, models, serializers
 
 
@@ -75,7 +75,7 @@ class Task(Node, graphene.Interface):
         return TASK_TYPE[instance.type]
 
 
-class TaskConnection(graphene.Connection):
+class TaskConnection(CountableConnectionBase):
     class Meta:
         node = Task
 
@@ -124,6 +124,7 @@ class Flow(DjangoObjectType):
     class Meta:
         model = models.Flow
         interfaces = (relay.Node,)
+        connection_class = CountableConnectionBase
 
 
 class Workflow(DjangoObjectType):
@@ -154,6 +155,7 @@ class Workflow(DjangoObjectType):
         model = models.Workflow
         exclude_fields = ("cases", "task_flows")
         interfaces = (relay.Node,)
+        connection_class = CountableConnectionBase
 
 
 class WorkItem(DjangoObjectType):
@@ -163,6 +165,7 @@ class WorkItem(DjangoObjectType):
     class Meta:
         model = models.WorkItem
         interfaces = (relay.Node,)
+        connection_class = CountableConnectionBase
 
 
 class Case(DjangoObjectType):
@@ -174,6 +177,7 @@ class Case(DjangoObjectType):
     class Meta:
         model = models.Case
         interfaces = (relay.Node,)
+        connection_class = CountableConnectionBase
 
 
 class SaveWorkflow(UserDefinedPrimaryKeyMixin, Mutation):

--- a/caluma/workflow/tests/snapshots/snap_test_case.py
+++ b/caluma/workflow/tests/snapshots/snap_test_case.py
@@ -4,8 +4,15 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
+
+snapshots["test_query_all_cases[running-1] 1"] = {
+    "allCases": {"edges": [{"node": {"status": "RUNNING"}}], "totalCount": 1}
+}
+
+snapshots["test_query_all_cases[completed-0] 1"] = {
+    "allCases": {"edges": [], "totalCount": 0}
+}
 
 snapshots['test_start_case[startCase-["group-name"]|groups-100] 1'] = {
     "startCase": {
@@ -182,12 +189,6 @@ snapshots["test_start_case[saveCase-None-None] 1"] = {
         "clientMutationId": None,
     }
 }
-
-snapshots["test_query_all_cases[running-1] 1"] = {
-    "allCases": {"edges": [{"node": {"status": "RUNNING"}}]}
-}
-
-snapshots["test_query_all_cases[completed-0] 1"] = {"allCases": {"edges": []}}
 
 snapshots["test_cancel_case[running-True-completed] 1"] = {
     "cancelCase": {

--- a/caluma/workflow/tests/snapshots/snap_test_task.py
+++ b/caluma/workflow/tests/snapshots/snap_test_task.py
@@ -4,8 +4,24 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
+
+snapshots["test_query_all_tasks[simple] 1"] = {
+    "allTasks": {
+        "edges": [
+            {
+                "node": {
+                    "__typename": "SimpleTask",
+                    "description": "State section rock event recent. Final activity hope star check record well. Radio with Mr letter eye.",
+                    "meta": {},
+                    "name": "Thomas Johnson",
+                    "slug": "sound-air-mission",
+                }
+            }
+        ],
+        "totalCount": 1,
+    }
+}
 
 snapshots["test_save_task[SaveSimpleTask] 1"] = {
     "saveSimpleTask": {
@@ -40,21 +56,5 @@ snapshots["test_save_comlete_task_form_task 1"] = {
             "name": "Thomas Johnson",
             "slug": "sound-air-mission",
         },
-    }
-}
-
-snapshots["test_query_all_tasks[simple] 1"] = {
-    "allTasks": {
-        "edges": [
-            {
-                "node": {
-                    "__typename": "SimpleTask",
-                    "description": "State section rock event recent. Final activity hope star check record well. Radio with Mr letter eye.",
-                    "meta": {},
-                    "name": "Thomas Johnson",
-                    "slug": "sound-air-mission",
-                }
-            }
-        ]
     }
 }

--- a/caluma/workflow/tests/snapshots/snap_test_work_item.py
+++ b/caluma/workflow/tests/snapshots/snap_test_work_item.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots["test_complete_work_item_last[ready-completed-True-simple-None] 1"] = {
@@ -13,29 +12,6 @@ snapshots["test_complete_work_item_last[ready-completed-True-simple-None] 1"] = 
         "workItem": {
             "case": {"closedByUser": "admin", "status": "COMPLETED"},
             "closedByUser": "admin",
-            "status": "COMPLETED",
-        },
-    }
-}
-
-snapshots["test_complete_work_item_with_next[ready-None-simple] 1"] = {
-    "completeWorkItem": {
-        "clientMutationId": None,
-        "workItem": {
-            "case": {
-                "status": "RUNNING",
-                "workItems": {
-                    "edges": [
-                        {
-                            "node": {
-                                "addressedGroups": ["group-name"],
-                                "status": "READY",
-                            }
-                        },
-                        {"node": {"addressedGroups": [], "status": "COMPLETED"}},
-                    ]
-                },
-            },
             "status": "COMPLETED",
         },
     }
@@ -57,7 +33,32 @@ snapshots["test_complete_multiple_instance_task_form_work_item_next[integer-1] 1
                         },
                         {"node": {"addressedGroups": [], "status": "COMPLETED"}},
                         {"node": {"addressedGroups": [], "status": "COMPLETED"}},
-                    ]
+                    ],
+                    "totalCount": 3,
+                },
+            },
+            "status": "COMPLETED",
+        },
+    }
+}
+
+snapshots["test_complete_work_item_with_next[ready-None-simple] 1"] = {
+    "completeWorkItem": {
+        "clientMutationId": None,
+        "workItem": {
+            "case": {
+                "status": "RUNNING",
+                "workItems": {
+                    "edges": [
+                        {
+                            "node": {
+                                "addressedGroups": ["group-name"],
+                                "status": "READY",
+                            }
+                        },
+                        {"node": {"addressedGroups": [], "status": "COMPLETED"}},
+                    ],
+                    "totalCount": 2,
                 },
             },
             "status": "COMPLETED",

--- a/caluma/workflow/tests/snapshots/snap_test_workflow.py
+++ b/caluma/workflow/tests/snapshots/snap_test_workflow.py
@@ -4,21 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
-
-snapshots["test_save_workflow 1"] = {
-    "saveWorkflow": {
-        "clientMutationId": "testid",
-        "workflow": {
-            "allowAllForms": False,
-            "allowForms": {"edges": [{"node": {"slug": "sound-air-mission"}}]},
-            "meta": {},
-            "name": "Brian Williams",
-            "slug": "effort-meet",
-        },
-    }
-}
 
 snapshots["test_query_all_workflows 1"] = {
     "allWorkflows": {
@@ -37,7 +23,8 @@ Kid avoid player relationship to range whose. Draw free property consider.""",
                                     "tasks": [{"slug": "few-list-tax"}],
                                 }
                             }
-                        ]
+                        ],
+                        "totalCount": 1,
                     },
                     "meta": {},
                     "name": "Brian Williams",
@@ -46,7 +33,24 @@ Kid avoid player relationship to range whose. Draw free property consider.""",
                     "tasks": [{"slug": "few-list-tax"}],
                 }
             }
-        ]
+        ],
+        "totalCount": 1,
+    }
+}
+
+snapshots["test_save_workflow 1"] = {
+    "saveWorkflow": {
+        "clientMutationId": "testid",
+        "workflow": {
+            "allowAllForms": False,
+            "allowForms": {
+                "edges": [{"node": {"slug": "sound-air-mission"}}],
+                "totalCount": 1,
+            },
+            "meta": {},
+            "name": "Brian Williams",
+            "slug": "effort-meet",
+        },
     }
 }
 
@@ -64,7 +68,8 @@ snapshots['test_add_workflow_flow[task-slug-"task-slug"|task-True] 1'] = {
                             "tasks": [{"slug": "task-slug"}],
                         }
                     }
-                ]
+                ],
+                "totalCount": 1,
             },
             "tasks": [
                 {"slug": "task-slug"},

--- a/caluma/workflow/tests/test_case.py
+++ b/caluma/workflow/tests/test_case.py
@@ -13,6 +13,7 @@ def test_query_all_cases(db, snapshot, case, result_count, flow, schema_executor
     query = """
         query AllCases {
           allCases (status: RUNNING){
+            totalCount
             edges {
               node {
                 status
@@ -229,6 +230,7 @@ def test_start_case_with_child_documents(
                     document {
                         id
                         answers {
+                            totalCount
                             edges {
                                 node {
                                     id
@@ -236,6 +238,7 @@ def test_start_case_with_child_documents(
                                         value {
                                             id
                                             answers {
+                                                totalCount
                                                 edges {
                                                     node {
                                                         id

--- a/caluma/workflow/tests/test_task.py
+++ b/caluma/workflow/tests/test_task.py
@@ -9,6 +9,7 @@ def test_query_all_tasks(db, snapshot, task, schema_executor):
     query = """
         query AllTasks($name: String!) {
           allTasks(name: $name) {
+            totalCount
             edges {
               node {
                 __typename

--- a/caluma/workflow/tests/test_work_item.py
+++ b/caluma/workflow/tests/test_work_item.py
@@ -15,6 +15,7 @@ def test_query_all_work_items_filter_status(db, work_item_factory, schema_execut
     query = """
         query WorkItems($status: WorkItemStatusArgument!) {
           allWorkItems(status: $status) {
+            totalCount
             edges {
               node {
                 status
@@ -43,6 +44,7 @@ def test_query_all_work_items_filter_addressed_groups(
     query = """
             query WorkItems($addressedGroups: [String]!) {
               allWorkItems(addressedGroups: $addressedGroups) {
+                totalCount
                 edges {
                   node {
                     addressedGroups
@@ -297,6 +299,7 @@ def test_complete_multiple_instance_task_form_work_item_next(
               case {
                 status
                 workItems(orderBy: STATUS_DESC) {
+                  totalCount
                   edges {
                     node {
                       status
@@ -348,6 +351,7 @@ def test_complete_work_item_with_next(
               case {
                 status
                 workItems(orderBy: STATUS_DESC) {
+                  totalCount
                   edges {
                     node {
                       status
@@ -398,6 +402,7 @@ def test_complete_work_item_with_next_multiple_tasks(
               case {
                 status
                 workItems {
+                  totalCount
                   edges {
                     node {
                       status
@@ -452,6 +457,7 @@ def test_complete_work_item_with_next_multiple_instance_task(
               case {
                 status
                 workItems {
+                  totalCount
                   edges {
                     node {
                       status

--- a/caluma/workflow/tests/test_workflow.py
+++ b/caluma/workflow/tests/test_workflow.py
@@ -18,6 +18,7 @@ def test_query_all_workflows(
     query = """
         query AllWorkflows($name: String!) {
           allWorkflows(name: $name) {
+            totalCount
             edges {
               node {
                 slug
@@ -28,6 +29,7 @@ def test_query_all_workflows(
                   slug
                 }
                 flows {
+                  totalCount
                   edges {
                     node {
                       tasks {
@@ -69,6 +71,7 @@ def test_save_workflow(
             workflow {
               allowAllForms
               allowForms {
+                totalCount
                 edges {
                   node {
                     slug
@@ -124,6 +127,7 @@ def test_add_workflow_flow(
                 slug
               }
               flows {
+                totalCount
                 edges {
                   node {
                     createdByUser


### PR DESCRIPTION
This commit implements `totalCount` for connections as per graphQL spec.

Closes #404