### PR TITLE
Enable auto-merge for renovate for certain dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,34 @@
         "pinDigests": false
       }
     ]
-  }
+  },
+  "digest": {
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "packageNames": [
+        "black",
+        "factory",
+        "faker",
+        "flake8",
+        "flake8-debugger",
+        "flake8-docstrings",
+        "flake8-isort",
+        "flake8-string-format",
+        "flake8-tuple",
+        "isort",
+        "pytest",
+        "pytest-cov",
+        "pytest-django",
+        "pytest-env",
+        "pytest-factoryboy",
+        "pytest-mock",
+        "pytest-randomly",
+        "requests-mock",
+        "snapshottest"
+      ],
+      "automerge": true
+    }
+  ]
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
+# When adding new dependencies here, also add them to the renovate.json to
+# enable auto-merge
+
 -r requirements.txt
 black==18.9b0
 factory-boy==2.11.1


### PR DESCRIPTION
This commit enables auto-merge for Docker digests and dev dependencies.

Unfortunately renovate does not support `devDependencies` for pip, so
all those have to be explicitly listed in the renovate config.

Closes #442