### PR TITLE
fix(meta filter): use GenericScalar for meta filter value

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -22,6 +22,7 @@ from django_filters.rest_framework import (
 )
 from graphene import Enum, InputObjectType, List
 from graphene.types.utils import get_type
+from graphene.types import generic
 from graphene.utils.str_converters import to_camel_case
 from graphene_django import filter
 from graphene_django.converter import convert_choice_name
@@ -191,7 +192,7 @@ class MetaLookupMode(Enum):
 
 class MetaValueFilterType(InputObjectType):
     key = graphene.String(required=True)
-    value = graphene.String(required=True)
+    value = generic.GenericScalar(required=True)
     lookup = MetaLookupMode()
 
 


### PR DESCRIPTION
This is required if we want to filter by e.g. numbers instead of
strings.