### PR TITLE
Fix HasAnswerFilter: correct field for date types

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -335,7 +335,10 @@ class HasAnswerFilter(Filter):
         question = Question.objects.get(slug=question_slug)
         self._validate_lookup(question, lookup)
 
-        filters = {f"value__{lookup}": match_value, "question__slug": question_slug}
+        if question.type == Question.TYPE_DATE:
+            filters = {f"date__{lookup}": match_value, "question__slug": question_slug}
+        else:
+            filters = {f"value__{lookup}": match_value, "question__slug": question_slug}
 
         if form_slug:
             filters["document__form_id"] = form_slug

--- a/caluma/form/tests/test_filter_by_answer.py
+++ b/caluma/form/tests/test_filter_by_answer.py
@@ -111,11 +111,18 @@ def test_query_all_questions(
     ans_subform = document.answers.get(question__slug="subform")
 
     for qtype, question in sub_questions.items():
-        answer_factory(
-            question=question,
-            document=ans_subform.value_document,
-            value=TEST_VALUES[qtype][form_value],
-        )
+        if qtype == models.Question.TYPE_DATE:
+            answer_factory(
+                question=question,
+                document=ans_subform.value_document,
+                date=TEST_VALUES[qtype][form_value],
+            )
+        else:
+            answer_factory(
+                question=question,
+                document=ans_subform.value_document,
+                value=TEST_VALUES[qtype][form_value],
+            )
 
     query = """
         query asdf ($hasAnswer: [HasAnswerFilterType]!) {


### PR DESCRIPTION
Date answers use a dedicated field, so we should use it instead of
`value` when searching