### PR TITLE
Introduce family filter for documents

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -34,7 +34,11 @@ from localized_fields.fields import LocalizedField
 
 from caluma.form.models import Answer, Question
 
-from .forms import GlobalIDFormField, GlobalIDMultipleChoiceField
+from .forms import (
+    GlobalIDFormField,
+    GlobalIDMultipleChoiceField,
+    SlugMultipleChoiceField,
+)
 from .relay import extract_global_id
 from .types import DjangoConnectionField
 
@@ -55,6 +59,13 @@ class GlobalIDMultipleChoiceFilter(MultipleChoiceFilter):
     def filter(self, qs, value):
         gids = [extract_global_id(v) for v in value]
         return super(GlobalIDMultipleChoiceFilter, self).filter(qs, gids)
+
+
+class SlugMultipleChoiceFilter(MultipleChoiceFilter):
+    field_class = SlugMultipleChoiceField
+
+    def filter(self, qs, value):
+        return super().filter(qs, value)
 
 
 class LocalizedFilter(Filter):

--- a/caluma/core/forms.py
+++ b/caluma/core/forms.py
@@ -1,4 +1,6 @@
+from graphene import List, String
 from graphene_django import forms
+from graphene_django.forms.converter import convert_form_field
 
 
 class GlobalIDFormField(forms.GlobalIDFormField):
@@ -23,3 +25,20 @@ class GlobalIDMultipleChoiceField(forms.GlobalIDMultipleChoiceField):
 
     def valid_value(self, value):
         return True
+
+
+class SlugMultipleChoiceField(GlobalIDMultipleChoiceField):
+    """
+    Slug multiple choice field which allows listing multiple slugs.
+
+    Disable cleaning as we don't know which slugs may be valid down
+    the line
+    """
+
+    def valid_value(self, value):  # pragma: no cover
+        return True
+
+
+@convert_form_field.register(SlugMultipleChoiceField)
+def slug_to_list(field):
+    return List(String, required=field.required)

--- a/caluma/form/filters.py
+++ b/caluma/form/filters.py
@@ -49,6 +49,7 @@ class DocumentFilterSet(MetaFilterSet):
         )
     )
     order_by = OrderingFilter(label="DocumentOrdering")
+    root_document = GlobalIDFilter(field_name="family")
 
     has_answer = HasAnswerFilter(document_id="pk")
 

--- a/caluma/form/filters.py
+++ b/caluma/form/filters.py
@@ -1,3 +1,5 @@
+from django_filters.rest_framework import CharFilter
+
 from ..core.filters import (
     GlobalIDFilter,
     GlobalIDMultipleChoiceFilter,
@@ -5,6 +7,7 @@ from ..core.filters import (
     MetaFilterSet,
     OrderingFilter,
     SearchFilter,
+    SlugMultipleChoiceFilter,
 )
 from . import models
 
@@ -12,6 +15,9 @@ from . import models
 class FormFilterSet(MetaFilterSet):
     search = SearchFilter(fields=("slug", "name", "description"))
     order_by = OrderingFilter(label="FormOrdering", fields=("name",))
+    slugs = SlugMultipleChoiceFilter(field_name="slug")
+    slug = CharFilter()
+    slug.deprecation_reason = "Use the `slugs` (plural) filter instead, which allows filtering for multiple slugs"
 
     class Meta:
         model = models.Form

--- a/caluma/form/tests/test_root_document_filter.py
+++ b/caluma/form/tests/test_root_document_filter.py
@@ -1,6 +1,3 @@
-import pytest
-
-from ...core.filters import AnswerHierarchyMode, AnswerLookupMode
 from ...core.relay import extract_global_id
 from .. import models
 

--- a/caluma/form/tests/test_root_document_filter.py
+++ b/caluma/form/tests/test_root_document_filter.py
@@ -1,0 +1,93 @@
+import pytest
+
+from ...core.filters import AnswerHierarchyMode, AnswerLookupMode
+from ...core.relay import extract_global_id
+from .. import models
+
+
+def test_root_document_filter(
+    schema_executor,
+    db,
+    question,
+    form_factory,
+    form_question_factory,
+    question_factory,
+    document_factory,
+    answer_factory,
+):
+    # build up our form first
+    top_form = form_factory()
+    top_question = form_question_factory.create(
+        form=top_form,
+        question__slug="top_question",
+        question__type=models.Question.TYPE_TEXT,
+    ).question
+    subform_question = form_question_factory.create(
+        form=top_form,
+        question__slug="subform",
+        question__type=models.Question.TYPE_FORM,
+        question__sub_form__slug="subform",
+    ).question
+
+    sub_questions = [
+        form_question_factory(
+            question__slug="foo",
+            question__type=models.Question.TYPE_TEXT,
+            form=subform_question.sub_form,
+        ).question,
+        form_question_factory(
+            question__slug="bar",
+            question__type=models.Question.TYPE_TEXT,
+            form=subform_question.sub_form,
+        ).question,
+    ]
+
+    # Now, make a document for it
+    result = schema_executor(
+        """
+            mutation foo ($form_id: ID!){
+                saveDocument(input: {form: $form_id}) {
+                    document {
+                      id
+                    }
+                }
+            }
+        """,
+        variables={"form_id": top_form.pk},
+    )
+
+    document_id = extract_global_id(result.data["saveDocument"]["document"]["id"])
+    document = models.Document.objects.get(pk=document_id)
+    # just some other question in the tree
+    answer_factory(question=top_question, document=document, value="foo")
+    ans_subform = document.answers.get(question__slug="subform")
+
+    for question in sub_questions:
+        answer_factory(
+            question=question, document=ans_subform.value_document, value="hello"
+        )
+
+    # fetch documents, see if subdocuments are included
+    query = """
+        query asdf ($root: ID!) {
+          allDocuments(rootDocument: $root) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+    """
+    variables = {"root": str(document.id)}
+
+    result = schema_executor(query, variables=variables)
+    assert not result.errors
+    result_ids = set(
+        extract_global_id(doc["node"]["id"])
+        for doc in result.data["allDocuments"]["edges"]
+    )
+
+    db_doc_ids = set(str(doc.id) for doc in models.Document.objects.all())
+
+    assert db_doc_ids == result_ids

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -161,7 +161,7 @@ type ChoiceQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   options(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, slug: String, label: String, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, orderBy: [OptionOrdering]): OptionConnection
   id: ID!
 }
@@ -323,7 +323,7 @@ type DateQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   id: ID!
 }
 
@@ -378,7 +378,7 @@ type DynamicChoiceQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   options(before: String, after: String, first: Int, last: Int): DataSourceDataConnection
   dataSource: String!
   id: ID!
@@ -397,7 +397,7 @@ type DynamicMultipleChoiceQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   options(before: String, after: String, first: Int, last: Int): DataSourceDataConnection
   dataSource: String!
   id: ID!
@@ -441,7 +441,7 @@ type FileQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   id: ID!
 }
 
@@ -470,7 +470,7 @@ type FloatQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   id: ID!
   minValue: Float
   maxValue: Float
@@ -565,7 +565,7 @@ type FormQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   subForm: Form
   id: ID!
 }
@@ -624,7 +624,7 @@ type IntegerQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   id: ID!
   maxValue: Int
   minValue: Int
@@ -668,7 +668,7 @@ type MultipleChoiceQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   options(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [OptionOrdering], slug: String, label: String, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): OptionConnection
   staticContent: String
   id: ID!
@@ -775,7 +775,7 @@ type Query {
   allTasks(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, orderBy: [TaskOrdering]): TaskConnection
   allCases(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, workflow: ID, status: CaseStatusArgument, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, orderBy: [CaseOrdering], hasAnswer: [HasAnswerFilterType]): CaseConnection
   allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], task: ID, case: ID, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
-  allForms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  allForms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   allQuestions(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, excludeForms: [ID], search: String): QuestionConnection
   allDocuments(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, form: ID, search: String, id: ID, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, orderBy: [DocumentOrdering], rootDocument: ID, hasAnswer: [HasAnswerFilterType]): DocumentConnection
   allFormatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
@@ -795,7 +795,7 @@ interface Question {
   isHidden: QuestionJexl!
   isArchived: Boolean!
   meta: GenericScalar!
-  forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, metaValue: MetaValueFilterType, search: String, orderBy: [FormOrdering]): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, metaValue: MetaValueFilterType, search: String, orderBy: [FormOrdering], slugs: [String]): FormConnection
   source: Question
 }
 
@@ -1385,7 +1385,7 @@ type StaticQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   staticContent: String
   dataSource: String
   id: ID!
@@ -1428,7 +1428,7 @@ type TableQuestion implements Question, Node {
   infoText: String
   meta: GenericScalar!
   source: Question
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   rowForm: Form
   id: ID!
 }
@@ -1503,7 +1503,7 @@ type TextQuestion implements Question, Node {
   meta: GenericScalar!
   source: Question
   formatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   id: ID!
   maxLength: Int
 }
@@ -1523,7 +1523,7 @@ type TextareaQuestion implements Question, Node {
   meta: GenericScalar!
   source: Question
   formatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
-  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
+  forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   id: ID!
   maxLength: Int
 }

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots[
@@ -776,7 +777,7 @@ type Query {
   allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], task: ID, case: ID, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
   allForms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String): FormConnection
   allQuestions(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, excludeForms: [ID], search: String): QuestionConnection
-  allDocuments(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, form: ID, search: String, id: ID, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, orderBy: [DocumentOrdering], hasAnswer: [HasAnswerFilterType]): DocumentConnection
+  allDocuments(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, form: ID, search: String, id: ID, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, orderBy: [DocumentOrdering], rootDocument: ID, hasAnswer: [HasAnswerFilterType]): DocumentConnection
   allFormatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
   node(id: ID!): Node
 }


### PR DESCRIPTION
This is intended to improve loading speed so you don't need to build a
large nested query anymore, which should speed up data retreival:
```graphql
        query foo ($root: ID!) {
          allDocuments(rootDocument: $root) {
            edges {
              node {
                id
              }
            }
          }
        }
```
This should get you all documents regardless of nesting level. Fetching the corresponding answers for them should then allow you to get the whole structure in a flat result