### PR TITLE
Make form accessible in JEXL

### DIFF
--- a/caluma/form/jexl.py
+++ b/caluma/form/jexl.py
@@ -1,4 +1,5 @@
 from pyjexl.analysis import ValidatingAnalyzer
+from pyjexl.evaluator import Context
 
 from ..core.jexl import JEXL
 
@@ -12,10 +13,12 @@ class QuestionValidatingAnalyzer(ValidatingAnalyzer):
 
 
 class QuestionJexl(JEXL):
-    def __init__(self, answer_by_question={}, **kwargs):
+    def __init__(self, answer_by_question={}, root_form=None, **kwargs):
         super().__init__(**kwargs)
 
-        self.context = answer_by_question
+        self.context = Context({"rootForm": root_form})
+        self.answer_by_question = answer_by_question
+
         self.add_transform("answer", self.answer_transform)
         self.add_transform("mapby", lambda arr, key: [obj[key] for obj in arr])
         self.add_binary_operator(
@@ -23,7 +26,7 @@ class QuestionJexl(JEXL):
         )
 
     def answer_transform(self, question_with_path):
-        current_context = self.context
+        current_context = self.answer_by_question
         segments = question_with_path.split(".")
 
         # Allow question paths to originate from the toplevel (root) document

--- a/caluma/form/models.py
+++ b/caluma/form/models.py
@@ -199,6 +199,13 @@ class Document(UUIDModel):
     )
     meta = JSONField(default=dict)
 
+    @property
+    def root_form(self):
+        d = self
+        while d.parent_answers.count():
+            d = d.parent_answers.first().document
+        return d.form
+
 
 class Answer(UUIDModel):
     question = models.ForeignKey(

--- a/caluma/form/tests/test_jexl.py
+++ b/caluma/form/tests/test_jexl.py
@@ -62,3 +62,15 @@ def test_jexl_traversal(expression, result, should_raise):
 )
 def test_intersects_operator(expression, result):
     assert QuestionJexl().evaluate(expression) == result
+
+
+def test_jexl_form():
+    answer_by_question = {
+        "a1": {"value": "A1", "root_form": "f-main-slug"},
+        "b1": {"value": "B1", "root_form": "f-main-slug"},
+    }
+
+    assert (
+        QuestionJexl(answer_by_question, "f-main-slug").evaluate("rootForm")
+        == "f-main-slug"
+    )

--- a/caluma/form/validators.py
+++ b/caluma/form/validators.py
@@ -291,12 +291,16 @@ class DocumentValidator:
             try:
                 expr = "is_required"
                 is_required = (
-                    jexl.QuestionJexl(answer_tree).evaluate(question.is_required)
+                    jexl.QuestionJexl(answer_tree, document.root_form.slug).evaluate(
+                        question.is_required
+                    )
                     and self.do_check_required
                 )
 
                 expr = "is_hidden"
-                is_hidden = jexl.QuestionJexl(answer_tree).evaluate(question.is_hidden)
+                is_hidden = jexl.QuestionJexl(
+                    answer_tree, document.root_form.slug
+                ).evaluate(question.is_hidden)
                 if is_required and not is_hidden:
                     if answer_tree.get(question.slug, None) in EMPTY_VALUES:
                         required_but_empty.append(question.slug)


### PR DESCRIPTION
This commit makes `form` and `rootForm` accessible
in JEXL expressions.

Closes #503