### PR TITLE
New: query for validating documents

### DIFF
--- a/caluma/form/tests/snapshots/snap_test_document.py
+++ b/caluma/form/tests/snapshots/snap_test_document.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots["test_query_all_documents[integer-None-1-None] 1"] = {
@@ -111,34 +112,6 @@ snapshots["test_query_all_documents[multiple_choice-None-answer__value3-None] 1"
                         "totalCount": 1,
                     },
                     "createdByUser": "b24d3781-2f59-44c4-8602-cffe6aa89ae7",
-                }
-            }
-        ],
-        "totalCount": 1,
-    }
-}
-
-snapshots["test_query_all_documents[table-None-None-None] 1"] = {
-    "allDocuments": {
-        "edges": [
-            {
-                "node": {
-                    "answers": {
-                        "edges": [
-                            {
-                                "node": {
-                                    "__typename": "TableAnswer",
-                                    "question": {
-                                        "label": "Thomas Johnson",
-                                        "slug": "sound-air-mission",
-                                    },
-                                    "table_value": [{"form": {"slug": "effort-meet"}}],
-                                }
-                            }
-                        ],
-                        "totalCount": 1,
-                    },
-                    "createdByUser": "872d1b6f-790c-473c-b5e9-2e714d607695",
                 }
             }
         ],
@@ -331,6 +304,34 @@ snapshots[
                         "totalCount": 1,
                     },
                     "createdByUser": "b24d3781-2f59-44c4-8602-cffe6aa89ae7",
+                }
+            }
+        ],
+        "totalCount": 1,
+    }
+}
+
+snapshots["test_query_all_documents[table-None-None-None] 1"] = {
+    "allDocuments": {
+        "edges": [
+            {
+                "node": {
+                    "answers": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "__typename": "TableAnswer",
+                                    "question": {
+                                        "label": "Thomas Johnson",
+                                        "slug": "sound-air-mission",
+                                    },
+                                    "table_value": [{"form": {"slug": "effort-meet"}}],
+                                }
+                            }
+                        ],
+                        "totalCount": 1,
+                    },
+                    "createdByUser": "872d1b6f-790c-473c-b5e9-2e714d607695",
                 }
             }
         ],

--- a/caluma/form/tests/snapshots/snap_test_filter_by_answer.py
+++ b/caluma/form/tests/snapshots/snap_test_filter_by_answer.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots["test_query_all_questions[multiple_choice-search_value0-matching-None] 1"] = {

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -363,6 +363,17 @@ enum DocumentOrdering {
   CREATED_BY_GROUP_DESC
 }
 
+type DocumentValidityConnection {
+  pageInfo: PageInfo!
+  edges: [DocumentValidityEdge]!
+  totalCount: Int
+}
+
+type DocumentValidityEdge {
+  node: ValidationResult
+  cursor: String!
+}
+
 type DynamicChoiceQuestion implements Question, Node {
   createdAt: DateTime!
   modifiedAt: DateTime!
@@ -764,6 +775,7 @@ type Query {
   allQuestions(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, excludeForms: [ID], search: String): QuestionConnection
   allDocuments(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, form: ID, search: String, id: ID, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, orderBy: [DocumentOrdering], rootDocument: ID, hasAnswer: [HasAnswerFilterType]): DocumentConnection
   allFormatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
+  documentValidity(id: ID!, before: String, after: String, first: Int, last: Int): DocumentValidityConnection
   node(id: ID!): Node
 }
 
@@ -1498,6 +1510,17 @@ type TextareaQuestion implements Question, Node {
   forms(before: String, after: String, first: Int, last: Int, metaValue: MetaValueFilterType, orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, offset: Int, limit: Int, metaHasKey: String, search: String, slugs: [String]): FormConnection
   id: ID!
   maxLength: Int
+}
+
+type ValidationEntry {
+  slug: String!
+  errorMsg: String!
+}
+
+type ValidationResult {
+  id: ID
+  isValid: Boolean
+  errors: [ValidationEntry]
 }
 
 type WorkItem implements Node {

--- a/caluma/workflow/tests/snapshots/snap_test_workflow.py
+++ b/caluma/workflow/tests/snapshots/snap_test_workflow.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots["test_query_all_workflows 1"] = {


### PR DESCRIPTION
This allows validating documents without trying to complete a work item.

The query will return a list of errors from the validator (as far as
possible, as it currently works with exceptions when something happens)

Implements #509 via this query:

```graphql

query ValidateFoo {
  documentValidity(
    id: "RG9jdW1lbnQ6MDFjNTgwYmItZmU1Zi00ZmY2LTlmMDctMWVlNDJlNjVhNmNl"
  ) {
    edges {
      node {
        id
        isValid
        errors {
          slug
          errorMsg
        }
      }
    }
  }
}
```

resultin in a response like this
```json
{
  "data": {
    "documentValidity": {
      "edges": [
        {
          "node": {
            "id": "01c580bb-fe5f-4ff6-9f07-1ee42e65a6ce",
            "isValid": true,
            "errors": []
          }
        }
      ]
    }
  }
}
```