### PR TITLE
Performance improvements

### DIFF
--- a/caluma/core/jexl.py
+++ b/caluma/core/jexl.py
@@ -1,7 +1,49 @@
+from itertools import count
+
 import pyjexl
 from pyjexl.analysis import ValidatingAnalyzer
 from pyjexl.exceptions import ParseError
 from rest_framework import exceptions
+
+
+class Cache:
+    """Custom cache.
+
+    For JEXL expressions, we cannot use django's cache infrastructure, as the
+    cached objects are pickled. This won't work for parsed JEXL expressions, as
+    they contain lambdas etc.
+    """
+
+    def __init__(self, max_size=2000, evict_to=1500):
+        self.max_size = max_size
+        self.evict_to = evict_to
+
+        self._cache = {}
+        self._mru = {}
+        self._mru_count = count()
+
+    def get_or_set(self, key, default):
+        if key in self._cache:
+            self._mru[key] = next(self._mru_count)
+            return self._cache[key]
+
+        ret = self._cache[key] = default()
+        self._mru[key] = next(self._mru_count)
+
+        if len(self._mru) > self.max_size:
+            self._evict()
+
+        return ret
+
+    def _evict(self):
+        to_purge = list(sorted(self._cache.keys(), key=lambda key: self._mru[key]))
+        # to_purge contains all keys, but we only want to evict the oldest
+        # ones
+        num_to_evict = len(to_purge) - self.evict_to
+
+        for key in to_purge[:num_to_evict]:
+            del self._cache[key]
+            del self._mru[key]
 
 
 class JexlValidator(object):
@@ -15,6 +57,18 @@ class JexlValidator(object):
 
 
 class JEXL(pyjexl.JEXL):
+    expr_cache = Cache()
+
+    def parse(self, expression):
+        parsed_expression = self.expr_cache.get_or_set(
+            expression, lambda: super(JEXL, self).parse(expression)
+        )
+        return parsed_expression
+
+    def analyze(self, expression, analyzer_class):
+        # some common shortcuts, no need to invoke JEXL engine for real
+        return super().analyze(expression, analyzer_class)
+
     def validate(self, expression, ValidatingAnalyzerClass=ValidatingAnalyzer):
         try:
             for res in self.analyze(expression, ValidatingAnalyzerClass):


### PR DESCRIPTION
Profiling the validation process showed that a lot of time is spent in
parsing (not even executing!) the JEXL expressions.

Caching the parsed expressions (and shortcutting simple "true" / "false"
expressions) improved the validation time for a large-ish document
structure from roughly 46s on my machine down to 23s.

Of the remaining 23s, 17s are spent fetching data from the DB, which
will be sped up when the "flattening" of the document structure is
merged