### PR TITLE
feat: enforce conventional commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,10 @@ target/
 # Editor swap files
 *.swp
 
+# npm (used for commit linting)
+node_modules/
+package-lock.json
+
 # IDE specific configurations
 .idea/
 .vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,11 @@ before_install:
 
 install:
   - docker-compose up -d --build
+  - npm install @commitlint/{config-conventional,travis-cli}
 
 script:
   - docker-compose exec caluma black --check .
   - docker-compose exec caluma flake8
+  - ./node_modules/.bin/commitlint-travis
   - docker-compose exec caluma ./manage.py makemigrations --check --dry-run --no-input
   - docker-compose exec caluma pytest --no-cov-on-fail --cov --create-db -vv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,11 @@ pip install pre-commit
 pip install -r requirements-dev.txt -U
 pre-commit install
 ```
+
+### Setup commit-msg hook
+If you want to have your commit message automatically linted, execute below commands:
+
+```bash
+npm install @commitlint/{config-conventional,cli}
+ln -s "$(pwd)/commit-msg" .git/hooks/commit-msg
+```

--- a/commit-msg
+++ b/commit-msg
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Called by "git commit" with one argument, the name of the file
+# that has the commit message.  The hook should exit with non-zero
+# status after issuing an appropriate message if it wants to stop the
+# commit.  The hook is allowed to edit the commit message file.
+
+./node_modules/.bin/commitlint --edit "$1"
+lint_exit="$?"
+
+if [[ "$lint_exit" -ne 0 ]]; then
+    echo -e "Failing commit msg:\n"
+    cat "$1"
+    exit "$lint_exit"
+ fi

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};


### PR DESCRIPTION
This commit adds enforcement of [conventional
commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) to the
pipeline.

Additionally it adds a `commit-msg` hook for git.

Closes #532