### PR TITLE
chore(ci): Use pytest-flake8 and pytest-black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,5 @@ install:
   - docker-compose up -d --build
 
 script:
-  - docker-compose exec caluma black --check .
-  - docker-compose exec caluma flake8
   - docker-compose exec caluma ./manage.py makemigrations --check --dry-run --no-input
   - docker-compose exec caluma pytest --no-cov-on-fail --cov --create-db -vv

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --reuse-db --randomly-seed=1521188766 --randomly-dont-reorganize
+addopts = --reuse-db --randomly-seed=1521188766 --randomly-dont-reorganize --flake8 --black
 DJANGO_SETTINGS_MODULE = caluma.settings
 env =
     META_FIELDS=test-key,foobar

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,3 +21,5 @@ pytest-mock==1.10.4
 pytest-randomly==3.0.0
 requests-mock==1.6.0
 snapshottest==0.5.0
+pytest-black==0.3.7
+pytest-flake8==1.0.4


### PR DESCRIPTION
Instead of calling flake8 / black explicitly, add them to pytest.  This
should help with forgetting to call those tools before committing, as
it's only one commandline call now instead of three.