### PR TITLE
feat(filters): Text search across multiple answers

### DIFF
--- a/caluma/form/tests/test_search_answers.py
+++ b/caluma/form/tests/test_search_answers.py
@@ -1,0 +1,83 @@
+from ...core.relay import extract_global_id
+from .. import models
+
+
+def test_search(
+    schema_executor,
+    db,
+    question,
+    form_factory,
+    form_question_factory,
+    question_factory,
+    document_factory,
+    answer_factory,
+    case_factory,
+    form,
+):
+
+    doc_a, doc_b = document_factory.create_batch(2, form=form)
+    case_a, case_b = [case_factory(document=doc) for doc in [doc_a, doc_b]]
+
+    question_a = question_factory(type=models.Question.TYPE_TEXT)
+    question_b = question_factory(type=models.Question.TYPE_TEXT)
+
+    doc_a.answers.create(question=question_a, value="hello world")
+    doc_a.answers.create(question=question_b, value="whatsup planet")
+
+    doc_b.answers.create(question=question_a, value="goodbye planet")
+    doc_b.answers.create(question=question_b, value="seeya world")
+
+    def _search(slugs, word, expect_count):
+        result = schema_executor(
+            """
+                query ($search: SearchAnswerFilterType!) {
+                  allDocuments (searchAnswers: $search) {
+                    edges {
+                      node {
+                        id
+                      }
+                    }
+                  }
+                }
+            """,
+            variables={"search": {"slugs": slugs, "value": word}},
+        )
+        assert not result.errors
+        edges = result.data["allDocuments"]["edges"]
+        assert len(edges) == expect_count
+        return edges
+
+    # search for "hello world". this should return doc a
+    edges = _search([question_a.slug], "hello world", 1)
+    assert extract_global_id(edges[0]["node"]["id"]) == str(doc_a.id)
+
+    # search for "planet" across both questions. this should return both doc a
+    # and b
+    edges = _search([question_b.slug, question_a.slug], "planet", 2)
+    assert set([str(doc_a.id), str(doc_b.id)]) == set(
+        extract_global_id(e["node"]["id"]) for e in edges
+    )
+
+
+def test_search_invalid_question_type(schema_executor, db, question_factory):
+
+    question = question_factory(type=models.Question.TYPE_FORM)
+
+    result = schema_executor(
+        """
+            query ($search: SearchAnswerFilterType!) {
+              allDocuments (searchAnswers: $search) {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+        """,
+        variables={"search": {"slugs": [question.slug], "value": "blah"}},
+    )
+
+    assert [str(err) for err in result.errors] == [
+        ("['Questions of type form cannot be used in searchAnswers']")
+    ]

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots[
@@ -817,11 +818,11 @@ type Query {
   dataSource(name: String, before: String, after: String, first: Int, last: Int): DataSourceDataConnection
   allWorkflows(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [WorkflowOrdering]): WorkflowConnection
   allTasks(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [TaskOrdering]): TaskConnection
-  allCases(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], workflow: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [CaseOrdering], documentForm: String, hasAnswer: [HasAnswerFilterType], status: [CaseStatusArgument], orderByQuestionAnswerValue: String): CaseConnection
+  allCases(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], workflow: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [CaseOrdering], documentForm: String, hasAnswer: [HasAnswerFilterType], searchAnswers: SearchAnswerFilterType, status: [CaseStatusArgument], orderByQuestionAnswerValue: String): CaseConnection
   allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType], task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
   allForms(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, slugs: [String]): FormConnection
   allQuestions(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, createdByUser: String, createdByGroup: String, metaHasKey: String, excludeForms: [ID], search: String): QuestionConnection
-  allDocuments(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], form: ID, forms: [ID], search: String, id: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [DocumentOrdering], rootDocument: ID, hasAnswer: [HasAnswerFilterType]): DocumentConnection
+  allDocuments(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], form: ID, forms: [ID], search: String, id: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [DocumentOrdering], rootDocument: ID, hasAnswer: [HasAnswerFilterType], searchAnswers: SearchAnswerFilterType): DocumentConnection
   allFormatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
   documentValidity(id: ID!, before: String, after: String, first: Int, last: Int): DocumentValidityConnection
   node(id: ID!): Node
@@ -1380,6 +1381,18 @@ input SaveWorkflowInput {
 type SaveWorkflowPayload {
   workflow: Workflow
   clientMutationId: String
+}
+
+input SearchAnswerFilterType {
+  slugs: [String]
+  value: GenericScalar!
+  lookup: SearchLookupMode
+}
+
+enum SearchLookupMode {
+  STARTSWITH
+  CONTAINS
+  TEXT
 }
 
 type SimpleTask implements Task, Node {

--- a/caluma/workflow/filters.py
+++ b/caluma/workflow/filters.py
@@ -12,7 +12,7 @@ from ..core.filters import (
     StringListFilter,
     generate_list_filter_class,
 )
-from ..form.filters import HasAnswerFilter
+from ..form.filters import HasAnswerFilter, SearchAnswerFilter
 from ..form.models import Answer, Question
 from . import models
 
@@ -57,6 +57,7 @@ class CaseFilterSet(MetaFilterSet):
 
     document_form = CharFilter(field_name="document__form_id")
     has_answer = HasAnswerFilter(document_id="document__pk")
+    search_answers = SearchAnswerFilter(document_id="document__pk")
     status = case_status_filter(lookup_expr="in")
     order_by_question_answer_value = CharFilter(
         method="filter_order_by_question_answer_value",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # enable auto-merge
 
 -r requirements.txt
-black==18.9b0
+black==19.3b0
 factory-boy==2.12.0
 faker==2.0.0
 flake8==3.7.8


### PR DESCRIPTION
This introduces a filter named `searchAnswers` that allows you to search
text within documents/cases across multiple answers.

The way it works is you pass a list of questions to search, and a search
string. The search string is split by words. Each word must then be
found in at least one answer for a document/case to show up.

You may optionally provide a lookup type: `STARTSWITH`, `TEXT`,
`CONTAINS`.

Note that depending on the database, those may or may not perform well,
as we do not at this point in time preemptively optimize by creating
indexes etc.

/cc @fkm 