### PR TITLE
Avoid count queries when possible

### DIFF
--- a/caluma/form/tests/test_document.py
+++ b/caluma/form/tests/test_document.py
@@ -244,7 +244,7 @@ def test_complex_document_query_performance(
         }
     """
 
-    with django_assert_num_queries(12):
+    with django_assert_num_queries(8):
         result = schema_executor(query, variables={"id": str(document.pk)})
     assert not result.errors
 


### PR DESCRIPTION
* if totalCount is requested only run count query once
* avoid count query when no pagination arguments are set

For large forms this is a approximate improvement of 15%