### PR TITLE
Adjust obsolete type comments

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -469,13 +469,6 @@ class MetaFilterSet(FilterSet):
 class DjangoFilterConnectionField(
     filter.DjangoFilterConnectionField, DjangoConnectionField
 ):
-    """
-    Django connection filter field with object type get_queryset support.
-
-    Inspired by https://github.com/graphql-python/graphene-django/pull/528/files
-    and might be removed once merged.
-    """
-
     @property
     def filterset_class(self):
         return self._provided_filterset_class

--- a/caluma/core/types.py
+++ b/caluma/core/types.py
@@ -34,12 +34,7 @@ class Node(object):
 
 
 class DjangoObjectType(Node, types.DjangoObjectType):
-    """
-    Django object type with overwriting get_queryset support.
-
-    Inspired by https://github.com/graphql-python/graphene-django/pull/528/files
-    and might be removed once merged.
-    """
+    """Django object type implementing default get_queryset with visibility layer."""
 
     class Meta:
         abstract = True


### PR DESCRIPTION
Those comments got actually resolved with graphene-django 2.3.2 see #493