### PR TITLE
Check authentication only once

### DIFF
--- a/caluma/user/middleware.py
+++ b/caluma/user/middleware.py
@@ -76,6 +76,11 @@ class OIDCAuthenticationMiddleware(object):
 
     def resolve(self, next, root, info, **args):
         request = info.context
+
+        # user already set on request, hence authentication already passed
+        if hasattr(request, "user"):
+            return next(root, info, **args)
+
         token = self.get_bearer_token(request)
 
         if token is None:


### PR DESCRIPTION
Once a user is set on request authentication is already passed and we can exit.