### PR TITLE
Use different tag for caluma development

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - "${DATABASE_PORT:-5432}:${DATABASE_PORT:-5432}"
   caluma:
+    image: projectcaluma/caluma:dev
     build:
       context: .
       args:


### PR DESCRIPTION
If the user already downloaded the release image and then decides to start
development, docker will use the already cached image, no rebuild is triggered.
By using the tag latest-dev instead of latest, docker can't use the cached
image.


**Update**: Changing Title and Description because the root-cause is different, the old Issue was:

Title: Add a way to install dev_requirements to testing-how-to

Maybe I missed something, but I had to do this to run the testing-commands.