### PR TITLE
Set max-line-length = 88 instead of ignore E266

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,8 +3,6 @@ ignore =
     # whitespace before ':'
     E203,
     # too many leading ### in a block comment
-    E266,
-    # line too long (managed by black)
     E501,
     # Line break occurred before a binary operator (this is not PEP8 compatible)
     W503,
@@ -21,7 +19,7 @@ ignore =
     D202,
     # other string does contain unindexed parameters
     P103
-max-line-length = 80
+max-line-length = 88
 exclude = migrations snapshots
 max-complexity = 10
 doctests = True


### PR DESCRIPTION
This is the cannonical way to deal with black.