### PR TITLE
 Do not swallow question-is-missing-exception 

### DIFF
--- a/caluma/form/jexl.py
+++ b/caluma/form/jexl.py
@@ -27,10 +27,7 @@ class QuestionJexl(JEXL):
 
     def answer_transform(self, question):
         try:
-            return (
-                self.answer_by_question.get(question)
-                or self.answer_by_question.get("parent", {})[question]
-            )
+            return self.answer_by_question[question]
         except KeyError:
             raise RuntimeError(f"Question could not be found: {question}")
 

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -117,7 +117,11 @@ class Question(Node, graphene.Interface):
     slug = graphene.String(required=True)
     label = graphene.String(required=True)
     info_text = graphene.String()
-    is_required = QuestionJexl(required=True)
+    # TODO: define what is_required means
+    is_required = QuestionJexl(
+        required=True,
+        description="Required expression is only evaluated when question is not hidden.",
+    )
     is_hidden = QuestionJexl(required=True)
     is_archived = graphene.Boolean(required=True)
     meta = generic.GenericScalar(required=True)

--- a/caluma/form/tests/test_validators.py
+++ b/caluma/form/tests/test_validators.py
@@ -216,7 +216,7 @@ def test_validate_table(
     )
 
     answer_factory(
-        question=other_q_1.question, document=main_document, value="something"
+        question=other_q_1.question, document=row_document_1, value="something"
     )
 
     if should_throw and required_jexl_sub.startswith("'fail'"):
@@ -280,7 +280,7 @@ def test_validate_empty_answers(
     expected_value,
 ):
 
-    answer_value = DocumentValidator()._get_answer_value(answer, document, None)
+    answer_value = DocumentValidator()._get_answer_value(answer, document)
     assert answer_value == expected_value
 
 


### PR DESCRIPTION
Fixes #609

As Caluma validates jexl when saving it technically the only exception
which can happen here is that an answer is missing.
Hence removing whole block.

It might make sense to have a possibility to validate all jexl
of a form to avoid Runtime error but this should happen outside
the document validation.