### PR TITLE
Remove left overs of validation answer tree

### DIFF
--- a/caluma/form/jexl.py
+++ b/caluma/form/jexl.py
@@ -27,10 +27,7 @@ class QuestionJexl(JEXL):
 
     def answer_transform(self, question):
         try:
-            return (
-                self.answer_by_question.get(question)
-                or self.answer_by_question.get("parent", {})[question]
-            )
+            return self.answer_by_question[question]
         except KeyError:
             raise RuntimeError(f"Question could not be found: {question}")
 

--- a/caluma/form/tests/test_validators.py
+++ b/caluma/form/tests/test_validators.py
@@ -144,7 +144,7 @@ def test_validate_nested_form(
     "required_jexl_main,required_jexl_sub,should_throw",
     [
         ("true", "false", True),
-        ("'other_q_1'|answer == 'something'", "false", True),
+        ("'other_q_1'|answer == 'something'", "false", False),
         ("false", "false", False),
         ("'foo' in 'main_table_1'|answer|mapby('sub_1_question_a')", "false", True),
         (
@@ -216,7 +216,7 @@ def test_validate_table(
     )
 
     answer_factory(
-        question=other_q_1.question, document=main_document, value="something"
+        question=other_q_1.question, document=row_document_1, value="something"
     )
 
     if should_throw and required_jexl_sub.startswith("'fail'"):
@@ -280,7 +280,7 @@ def test_validate_empty_answers(
     expected_value,
 ):
 
-    answer_value = DocumentValidator()._get_answer_value(answer, document, None)
+    answer_value = DocumentValidator()._get_answer_value(answer, document)
     assert answer_value == expected_value
 
 


### PR DESCRIPTION
* There is no need for answer_tree anymore as of #505
* parent doesn't exist and can be removed
* requiredness does not to be inherited as a form question does actually
  have answers.