### PR TITLE
chore(uwsgi): Sane defaults for uWSGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,42 @@ Following environment variables need to be set for caluma:
 * `OIDC_INTROSPECT_CLIENT_ID`: ID of the OIDC-client
 * `OIDC_INTROSPECT_CLIENT_SECRET`: Secret of the OIDC-client
 
+## uWSGI defaults
+
+We are using the sane uWSGI-defaults researched by [bloomberg](https://www.techatbloomberg.com/blog/configuring-uwsgi-production-deployment/?sf104898833=1). You can override the defaults using environment-variables.
+
+- UWSGI_STRICT=true
+- UWSGI_WSGI_FILE=/app/caluma/wsgi.py
+- UWSGI_MASTER=true
+- UWSGI_ENABLE_THREADS=true
+- UWSGI_VACUUM=true
+- UWSGI_SINGLE_INTERPRETER=true
+- UWSGI_DIE_ON_TERM=true
+- UWSGI_NEED_APP=true
+- UWSGI_DISABLE_LOGGING=true
+- UWSGI_LOG_4XX=true
+- UWSGI_LOG_5XX=true
+- UWSGI_MAX_REQUESTS=1000
+- UWSGI_MAX_WORKER_LIFETIME=3600
+- UWSGI_RELOAD_ON_RSS=2048
+- UWSGI_WORKER_RELOAD_MERCY=60
+- UWSGI_CHEAPER_ALGO=busyness
+- UWSGI_PROCESSES=500
+- UWSGI_CHEAPER=8
+- UWSGI_CHEAPER_INITIAL=16
+- UWSGI_CHEAPER_OVERLOAD=1
+- UWSGI_CHEAPER_STEP=16
+- UWSGI_CHEAPER_BUSYNESS_MULTIPLIER=30
+- UWSGI_CHEAPER_BUSYNESS_MIN=20
+- UWSGI_CHEAPER_BUSYNESS_MAX=70
+- UWSGI_CHEAPER_BUSYNESS_BACKLOG_ALERT=16
+- UWSGI_CHEAPER_BUSYNESS_BACKLOG_STEP=2
+- UWSGI_HARAKIRI=60
+- UWSGI_AUTO_PROCNAME=true
+- UWSGI_PROCNAME_PREFIX="caluma "
+
+See https://git.io/JemA2 for more information.
+
 ## Auditing
 
 Caluma uses [django-simple-history](https://github.com/treyhunner/django-simple-history)

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,7 +1,69 @@
+# These settings can be overridden by environment-variables: https://git.io/JemA2
 [uwsgi]
 http = 0.0.0.0:8000
+
+# Crash if there are any unknown configuration parameters in the ini file.
+strict = true
+
+# Path to wsgi.py
 wsgi-file = /app/caluma/wsgi.py
-max-requests = 2000
-harakiri = 5
-processes = 4
-master = True
+
+# Enable graceful shutdown of workers (built-in prefork+threading multi-worker
+# management mode)
+master = true
+
+# By default threads are disabled. This can cause issues if your application
+# uses background threads. Without setting this parameter to true, your
+# threads will not run.
+enable-threads = true
+
+# Delete temporary file (sockets, pidfiles, ...) during shutdown
+vacuum = true
+
+# Disable single interpreter since certain C extenions can not cope with it.
+# Since we don't run multiple applications on the same workers we can safely
+# disable this.
+single-interpreter = true
+
+# By default SIGTERM will brutally reload uWSGI instead of shuting it down. With
+# this option enabled SIGTERM shuts down uWSGI as everybody would expect.
+die-on-term = true
+
+# Let uWSGI crash if it is not able to load the application module.
+need-app = true
+
+# uWSGI's logging is rather verbose. Instead of logging every request (which
+# already happens on the reverse proxy level), logging all 4xx and 5xx errors
+# should suffice.
+disable-logging = true
+log-4xx = true
+log-5xx = true
+
+# It is a good idea to recycle workers every now and then to prevent memory
+# leaks or unintentional states.
+max-requests = 1000                ; Restart workers after this many requests
+max-worker-lifetime = 3600         ; Restart workers after this many seconds
+reload-on-rss = 2048               ; Restart workers after this much resident memory
+worker-reload-mercy = 60           ; How long to wait before forcefully killing workers
+
+# The busyness algorithm attempts to always have spare workers available,
+# which is useful when anticipating unexpected traffic surges.
+cheaper-algo = busyness
+processes = 500                      ; Maximum number of workers allowed
+cheaper = 8                          ; Minimum number of workers allowed
+cheaper-initial = 16                 ; Workers created at startup
+cheaper-overload = 1                 ; Length of a cycle in seconds
+cheaper-step = 16                    ; How many workers to spawn at a time
+
+cheaper-busyness-multiplier = 30     ; How many cycles to wait before killing workers
+cheaper-busyness-min = 20            ; Below this threshold, kill workers (if stable for multiplier cycles)
+cheaper-busyness-max = 70            ; Above this threshold, spawn new workers
+cheaper-busyness-backlog-alert = 16  ; Spawn emergency workers if more than this many requests are waiting in the queue
+cheaper-busyness-backlog-step = 2    ; How many emergency workers to create if there are too many requests in the queue
+
+# SIGKILL workers after certain timeout if they get stuck.
+harakiri = 60
+
+# Auto rename worker processes
+auto-procname = true
+procname-prefix = "caluma "  ; note the space


### PR DESCRIPTION
The defaults of uWSGI are not good. These are the settings researched by
Peter Sperl at [bloomberg](https://www.techatbloomberg.com/blog/configuring-uwsgi-production-deployment/?sf104898833=1) and @winpat.

I checked that uWSGI accepts overriding these settings by
environment-variables and composed gist for the admins wanting to change
our defaults. https://git.io/JemA2

It is gist because it is interesting for other projects and caluma doesn't
have a place for this kind of documentation, yet. It would have been out of
place in the README which is about caluma not uWSGI.