### PR TITLE
feat(history): support asOf per type

### DIFF
--- a/caluma/form/historical_schema.py
+++ b/caluma/form/historical_schema.py
@@ -9,9 +9,9 @@ from . import models
 from .schema import (
     Answer,
     DateAnswer,
-    Document,
     FileAnswer,
     FloatAnswer,
+    FormDjangoObjectType,
     IntegerAnswer,
     ListAnswer,
     StringAnswer,
@@ -106,7 +106,9 @@ class HistoricalFile(ObjectType):
     name = graphene.String(required=True)
     download_url = graphene.String()
     metadata = generic.GenericScalar()
-    answer = graphene.Field("caluma.form.historical_schema.HistoricalFileAnswer")
+    historical_answer = graphene.Field(
+        "caluma.form.historical_schema.HistoricalFileAnswer"
+    )
     history_date = graphene.types.datetime.DateTime(required=True)
     history_user_id = graphene.String()
     history_type = graphene.String()
@@ -144,16 +146,17 @@ class HistoricalFileAnswer(FileAnswer):
         interfaces = (HistoricalAnswer, graphene.Node)
 
 
-class HistoricalDocument(Document):
-    answers = ConnectionField(
+class HistoricalDocument(FormDjangoObjectType):
+    historical_answers = ConnectionField(
         HistoricalAnswerConnection,
         as_of=graphene.types.datetime.DateTime(required=True),
     )
     history_date = graphene.types.datetime.DateTime(required=True)
     history_user_id = graphene.String()
     history_type = graphene.String()
+    meta = generic.GenericScalar()
 
-    def resolve_answers(self, info, as_of, *args):
+    def resolve_historical_answers(self, info, as_of, *args):
         answers = [
             a
             for a in historical_qs_as_of(

--- a/caluma/form/historical_schema.py
+++ b/caluma/form/historical_schema.py
@@ -125,12 +125,16 @@ class HistoricalFile(ObjectType):
 
 
 class HistoricalFileAnswer(FileAnswer):
-    value = graphene.Field(HistoricalFile, required=True)
+    value = graphene.Field(
+        HistoricalFile,
+        required=True,
+        as_of=graphene.types.datetime.DateTime(required=True),
+    )
 
-    def resolve_value(self, info, **args):
+    def resolve_value(self, info, as_of, **args):
         # we need to use the HistoricalFile of the correct revision
         return models.File.history.filter(
-            id=self.file_id, history_date__lte=self.history_date
+            id=self.file_id, history_date__lte=as_of
         ).first()
 
     class Meta:
@@ -141,18 +145,19 @@ class HistoricalFileAnswer(FileAnswer):
 
 
 class HistoricalDocument(Document):
-    answers = ConnectionField(HistoricalAnswerConnection)
+    answers = ConnectionField(
+        HistoricalAnswerConnection,
+        as_of=graphene.types.datetime.DateTime(required=True),
+    )
     history_date = graphene.types.datetime.DateTime(required=True)
     history_user_id = graphene.String()
     history_type = graphene.String()
 
-    def resolve_answers(self, info, *args):
+    def resolve_answers(self, info, as_of, *args):
         answers = [
             a
             for a in historical_qs_as_of(
-                models.Answer.history.filter(document_id=self.id),
-                info.variable_values["asOf"],
-                "id",
+                models.Answer.history.filter(document_id=self.id), as_of, "id"
             )
         ]
         return answers
@@ -165,15 +170,17 @@ class HistoricalDocument(Document):
 
 
 class HistoricalTableAnswer(TableAnswer):
-    value = graphene.List(HistoricalDocument, required=True)
+    value = graphene.List(
+        HistoricalDocument,
+        required=True,
+        as_of=graphene.types.datetime.DateTime(required=True),
+    )
 
-    def resolve_value(self, info, **args):
+    def resolve_value(self, info, as_of, *args):
         answerdocuments = [
             ad
             for ad in historical_qs_as_of(
-                models.AnswerDocument.history.filter(answer_id=self.id),
-                info.variable_values["asOf"],
-                "id",
+                models.AnswerDocument.history.filter(answer_id=self.id), as_of, "id"
             )
         ]
 
@@ -181,7 +188,7 @@ class HistoricalTableAnswer(TableAnswer):
 
         documents = [
             models.Document.history.filter(id=ad.document_id).filter(
-                history_date__lte=info.variable_values["asOf"]
+                history_date__lte=as_of
             )[0]
             for ad in answerdocuments
         ]

--- a/caluma/form/tests/snapshots/snap_test_history.py
+++ b/caluma/form/tests/snapshots/snap_test_history.py
@@ -58,7 +58,7 @@ snapshots["test_document_as_of 3"] = {
 }
 
 snapshots["test_historical_table_answer 1"] = {
-    "documentAsOf": {
+    "d1": {
         "answers": {
             "edges": [
                 {
@@ -80,11 +80,8 @@ snapshots["test_historical_table_answer 1"] = {
                 }
             ]
         }
-    }
-}
-
-snapshots["test_historical_table_answer 2"] = {
-    "documentAsOf": {
+    },
+    "d2": {
         "answers": {
             "edges": [
                 {
@@ -101,5 +98,5 @@ snapshots["test_historical_table_answer 2"] = {
                 }
             ]
         }
-    }
+    },
 }

--- a/caluma/form/tests/snapshots/snap_test_history.py
+++ b/caluma/form/tests/snapshots/snap_test_history.py
@@ -8,7 +8,7 @@ snapshots = Snapshot()
 
 snapshots["test_document_as_of 1"] = {
     "documentAsOf": {
-        "answers": {
+        "historicalAnswers": {
             "edges": [
                 {
                     "node": {
@@ -25,7 +25,7 @@ snapshots["test_document_as_of 1"] = {
 
 snapshots["test_document_as_of 2"] = {
     "documentAsOf": {
-        "answers": {
+        "historicalAnswers": {
             "edges": [
                 {
                     "node": {
@@ -42,7 +42,7 @@ snapshots["test_document_as_of 2"] = {
 
 snapshots["test_document_as_of 3"] = {
     "documentAsOf": {
-        "answers": {
+        "historicalAnswers": {
             "edges": [
                 {
                     "node": {
@@ -59,19 +59,19 @@ snapshots["test_document_as_of 3"] = {
 
 snapshots["test_historical_table_answer 1"] = {
     "d1": {
-        "answers": {
+        "historicalAnswers": {
             "edges": [
                 {
                     "node": {
                         "__typename": "HistoricalTableAnswer",
                         "value": [
                             {
-                                "answers": {
+                                "historicalAnswers": {
                                     "edges": [{"node": {"value": "first row value"}}]
                                 }
                             },
                             {
-                                "answers": {
+                                "historicalAnswers": {
                                     "edges": [{"node": {"value": "second row value"}}]
                                 }
                             },
@@ -82,14 +82,14 @@ snapshots["test_historical_table_answer 1"] = {
         }
     },
     "d2": {
-        "answers": {
+        "historicalAnswers": {
             "edges": [
                 {
                     "node": {
                         "__typename": "HistoricalTableAnswer",
                         "value": [
                             {
-                                "answers": {
+                                "historicalAnswers": {
                                     "edges": [{"node": {"value": "first row value"}}]
                                 }
                             }

--- a/caluma/form/tests/test_history.py
+++ b/caluma/form/tests/test_history.py
@@ -121,7 +121,7 @@ def test_document_as_of(
         query documentAsOf($id: ID!, $asOf: DateTime!) {
           documentAsOf (id: $id, asOf: $asOf) {
             meta
-            answers (asOf: $asOf) {
+            historicalAnswers (asOf: $asOf) {
               edges {
                 node {
                   ...on HistoricalStringAnswer {
@@ -209,7 +209,7 @@ def test_historical_file_answer(
     historical_query = """
             query documentAsOf($id: ID!, $asOf: DateTime!) {
               documentAsOf (id: $id, asOf: $asOf) {
-                answers (asOf: $asOf) {
+                historicalAnswers (asOf: $asOf) {
                   edges {
                     node {
                       ...on HistoricalFileAnswer {
@@ -220,6 +220,9 @@ def test_historical_file_answer(
                           downloadUrl
                           historyUserId
                           historyType
+                          historicalAnswer {
+                            id
+                          }
                         }
                       }
                     }
@@ -233,7 +236,7 @@ def test_historical_file_answer(
     result = schema_executor(historical_query, variables=variables)
     assert not result.errors
     assert (
-        result.data["documentAsOf"]["answers"]["edges"][0]["node"]["value"][
+        result.data["documentAsOf"]["historicalAnswers"]["edges"][0]["node"]["value"][
             "downloadUrl"
         ]
         == f"http://minio/download-url/{hist_file_1.pk}_{hist_file_1.name}"
@@ -243,7 +246,7 @@ def test_historical_file_answer(
     result = schema_executor(historical_query, variables=variables)
     assert not result.errors
     assert (
-        result.data["documentAsOf"]["answers"]["edges"][0]["node"]["value"][
+        result.data["documentAsOf"]["historicalAnswers"]["edges"][0]["node"]["value"][
             "downloadUrl"
         ]
         == f"http://minio/download-url/{hist_file_2.pk}_{hist_file_2.name}"
@@ -255,7 +258,7 @@ def test_historical_file_answer(
     result = schema_executor(historical_query, variables=variables)
     assert not result.errors
     assert (
-        result.data["documentAsOf"]["answers"]["edges"][0]["node"]["value"][
+        result.data["documentAsOf"]["historicalAnswers"]["edges"][0]["node"]["value"][
             "downloadUrl"
         ]
         == f"http://minio/download-url/{file3.pk}_{file3.name}"
@@ -314,13 +317,13 @@ def test_historical_table_answer(
     historical_query = """
         query documentAsOf($id: ID!, $asOf1: DateTime!, $asOf2: DateTime!) {
           d1: documentAsOf (id: $id, asOf: $asOf1) {
-            answers (asOf: $asOf1) {
+            historicalAnswers (asOf: $asOf1) {
               edges {
                 node {
                   ...on HistoricalTableAnswer {
                     __typename
                     value (asOf: $asOf1) {
-                      answers (asOf: $asOf1) {
+                      historicalAnswers (asOf: $asOf1) {
                         edges {
                           node {
                             ...on HistoricalStringAnswer {
@@ -336,13 +339,13 @@ def test_historical_table_answer(
             }
           }
           d2: documentAsOf (id: $id, asOf: $asOf2) {
-            answers (asOf: $asOf2) {
+            historicalAnswers (asOf: $asOf2) {
               edges {
                 node {
                   ...on HistoricalTableAnswer {
                     __typename
                     value (asOf: $asOf2) {
-                      answers (asOf: $asOf2) {
+                      historicalAnswers (asOf: $asOf2) {
                         edges {
                           node {
                             ...on HistoricalStringAnswer {

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots[
@@ -687,7 +686,7 @@ type HistoricalDocument implements Node {
   form: Form
   historyDate: DateTime!
   historyType: String
-  answers(before: String, after: String, first: Int, last: Int): HistoricalAnswerConnection
+  answers(asOf: DateTime!, before: String, after: String, first: Int, last: Int): HistoricalAnswerConnection
 }
 
 type HistoricalFile implements Node {
@@ -707,7 +706,7 @@ type HistoricalFileAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value: HistoricalFile!
+  value(asOf: DateTime!): HistoricalFile!
   meta: GenericScalar!
   historyUserId: String
   question: Question!
@@ -788,7 +787,7 @@ type HistoricalTableAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value: [HistoricalDocument]!
+  value(asOf: DateTime!): [HistoricalDocument]!
   meta: GenericScalar!
   historyUserId: String
   question: Question!

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -686,7 +686,7 @@ type HistoricalDocument implements Node {
   form: Form
   historyDate: DateTime!
   historyType: String
-  answers(asOf: DateTime!, before: String, after: String, first: Int, last: Int): HistoricalAnswerConnection
+  historicalAnswers(asOf: DateTime!, before: String, after: String, first: Int, last: Int): HistoricalAnswerConnection
 }
 
 type HistoricalFile implements Node {
@@ -694,7 +694,7 @@ type HistoricalFile implements Node {
   name: String!
   downloadUrl: String
   metadata: GenericScalar
-  answer: HistoricalFileAnswer
+  historicalAnswer: HistoricalFileAnswer
   historyDate: DateTime!
   historyUserId: String
   historyType: String


### PR DESCRIPTION
This commit implements the argument `asOf` for all related types in the
historical schema.

This removes the need for accessing variables from other types (i.e. the
top level `documentAsOf`). But also it gives us much more flexibilty
when constructing queries.

Closes #683