### PR TITLE
feat(history): expose original document id

### DIFF
--- a/caluma/form/historical_schema.py
+++ b/caluma/form/historical_schema.py
@@ -151,6 +151,10 @@ class HistoricalDocument(FormDjangoObjectType):
     history_user_id = graphene.String()
     history_type = graphene.String()
     meta = generic.GenericScalar()
+    document_id = graphene.UUID()
+
+    def resolve_document_id(self, info, *args):
+        return self.id
 
     def resolve_historical_answers(self, info, as_of, *args):
         answers = [

--- a/caluma/form/tests/snapshots/snap_test_history.py
+++ b/caluma/form/tests/snapshots/snap_test_history.py
@@ -8,6 +8,7 @@ snapshots = Snapshot()
 
 snapshots["test_document_as_of 1"] = {
     "documentAsOf": {
+        "documentId": "890ca108-d93d-4725-9066-7d0bddad8230",
         "historicalAnswers": {
             "edges": [
                 {
@@ -25,6 +26,7 @@ snapshots["test_document_as_of 1"] = {
 
 snapshots["test_document_as_of 2"] = {
     "documentAsOf": {
+        "documentId": "890ca108-d93d-4725-9066-7d0bddad8230",
         "historicalAnswers": {
             "edges": [
                 {
@@ -42,6 +44,7 @@ snapshots["test_document_as_of 2"] = {
 
 snapshots["test_document_as_of 3"] = {
     "documentAsOf": {
+        "documentId": "890ca108-d93d-4725-9066-7d0bddad8230",
         "historicalAnswers": {
             "edges": [
                 {

--- a/caluma/form/tests/test_history.py
+++ b/caluma/form/tests/test_history.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 import pytest
 from django.utils import timezone
 
@@ -76,7 +78,7 @@ def test_document_as_of(
     admin_schema_executor,
 ):
     f = form_factory(slug="root-form")
-    document = document_factory(form=f)
+    document = document_factory(form=f, id=UUID("890ca108-d93d-4725-9066-7d0bddad8230"))
 
     q1 = form_question_factory(
         question__type=models.Question.TYPE_TEXT,
@@ -121,6 +123,7 @@ def test_document_as_of(
         query documentAsOf($id: ID!, $asOf: DateTime!) {
           documentAsOf (id: $id, asOf: $asOf) {
             meta
+            documentId
             historicalAnswers (asOf: $asOf) {
               edges {
                 node {

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -687,6 +687,7 @@ type HistoricalDocument implements Node {
   historyDate: DateTime!
   historyType: String
   historicalAnswers(asOf: DateTime!, before: String, after: String, first: Int, last: Int): HistoricalAnswerConnection
+  documentId: UUID
 }
 
 type HistoricalFile implements Node {


### PR DESCRIPTION
This commit exposes the original document id as `documentId` on a
`HistoricalDocument`.