### PR TITLE
docs(history): document cleanup commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ If you wish to expose an API for querying previous revisions of documents, you n
 
 If you enable this, make sure to also configure [visibilities](#visibility-classes) and [permissions](#permission-classes) for historical types.
 
+##### Cleanup
+You may want to periodically cleanup the historical records. There are two commands available for this:
+
+ - `clean_duplicate_history`: Historical records are always created when `save()` has been called on a model. This command removes all duplicates.
+ - `cleanup_history`: Remove all historical records, or the ones that are older than specified.
+
 #### FormatValidators
 FormatValidator classes can validate input data for answers, based on rules set on the question.
 

--- a/caluma/form/tests/test_command.py
+++ b/caluma/form/tests/test_command.py
@@ -21,7 +21,7 @@ def test_create_bucket_command(mocker):
 @pytest.mark.parametrize("dry", [True, False])
 @pytest.mark.parametrize("keep,kept", [("1 year", 2), ("1 day", 1), (None, 0)])
 def test_cleanup_history_command(db, dry, keep, kept):
-    # we need to override the rehistered models dict in order to get rid of the
+    # we need to override the registered models dict in order to get rid of the
     # fake models created in core tests
     cleanup_history.registered_models = {
         k: v for k, v in registered_models.items() if not k.startswith("core_")


### PR DESCRIPTION
This commit adds a section about cleanup commands for historical records
to the README.md.

Drive-by typo fix in command test.