### PR TITLE
Filters: Syntactic separation of ordering and filtering

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -127,6 +127,7 @@ def FilterCollectionFactory(filterset_class):
         filter_fields = {
             name: _get_or_make_field(name, filt)
             for name, filt in _filter_coll.filters.items()
+            if not isinstance(filt, OrderingFilter)
         }
 
         filter_fields["invert"] = graphene.Boolean(required=False, default=False)

--- a/caluma/core/ordering.py
+++ b/caluma/core/ordering.py
@@ -1,0 +1,101 @@
+from typing import Any, Tuple, Union
+
+from django import forms
+from django.db.models.expressions import CombinedExpression, F, Value
+from django.db.models.query import QuerySet
+from django_filters.fields import ChoiceField
+from django_filters.rest_framework import Filter
+from graphene import Enum
+from graphene_django.forms.converter import convert_form_field
+from graphene_django.registry import get_global_registry
+from rest_framework import exceptions
+
+OrderingFieldType = Union[F, str]
+
+
+class CalumaOrdering(Filter):
+    """Base class for new-style ordering filters.
+
+    This is not really a filter in the rest framework sense,
+    but we use it's infrastructure to get conversion to GraphQL
+    types.
+
+    This is an abstract base class. To use it, you need to
+    implement the `get_ordering_value()` method to return a tuple
+    of `(queryset, ordering_field)`. The queryset may be modified,
+    for example if you need to annotate it to get to the desired
+    ordering field.
+    """
+
+    def get_ordering_value(
+        self, qs: QuerySet, value: Any
+    ) -> Tuple[QuerySet, OrderingFieldType]:  # pragma: no cover
+        raise NotImplementedError("get_ordering_value() needs to be implemented")
+
+
+class MetaFieldOrdering(CalumaOrdering):
+    """Ordering filter for ordering by `meta` values."""
+
+    def __init__(self, field_name="meta"):
+        super().__init__()
+        self.field_name = field_name
+
+    field_class = forms.CharField
+
+    def get_ordering_value(
+        self, qs: QuerySet, value: Any
+    ) -> Tuple[QuerySet, OrderingFieldType]:
+
+        return qs, CombinedExpression(F(self.field_name), "->", Value(value))
+
+
+class AttributeOrderingMixin(CalumaOrdering):
+    def get_ordering_value(self, qs, value):
+        if value not in self._fields:  # pragma: no cover
+            # this is normally covered by graphene enforcing its schema,
+            # but we still need to handle it
+            raise exceptions.ValidationError(
+                f"Field '{value}' not available for sorting on {qs.model.__name}"
+            )
+        return qs, F(value)
+
+
+def AttributeOrderingFactory(model, fields=None, exclude_fields=None):
+    """Build ordering field for a given model.
+
+    Used to define an ordering field that is presented as an enum
+    """
+    if not exclude_fields:
+        exclude_fields = []
+
+    if not fields:
+        fields = [f.name for f in model._meta.fields if f.name not in exclude_fields]
+
+    field_enum = type(
+        f"Sortable{model.__name__}Attributes",
+        (Enum,),
+        {field.upper(): field for field in fields},
+    )
+
+    field_class = type(f"{model.__name__}AttributeField", (ChoiceField,), {})
+
+    ordering_class = type(
+        f"{model.__name__}AttributeOrdering",
+        (AttributeOrderingMixin, CalumaOrdering),
+        {"field_class": field_class, "_fields": fields},
+    )
+
+    @convert_form_field.register(field_class)
+    def to_enum(field):
+        registry = get_global_registry()
+        converted = registry.get_converted_field(field)
+
+        if converted:  # pragma: no cover
+            return converted
+
+        converted = field_enum()
+
+        registry.register_converted_field(field, converted)
+        return converted
+
+    return ordering_class()

--- a/caluma/core/tests/test_ordersets.py
+++ b/caluma/core/tests/test_ordersets.py
@@ -1,0 +1,72 @@
+import pytest
+
+from ..relay import extract_global_id
+
+
+@pytest.mark.parametrize("question__type", ["text"])
+def test_inversible_with_vars(db, schema_executor, document_factory, question):
+
+    doc_a, doc_b, doc_c = (
+        document_factory(meta={"foo": "a", "blah": "xxx"}),
+        document_factory(meta={"foo": "b", "blah": "xxx"}),
+        document_factory(meta={"foo": "c", "blah": "blub"}),
+    )
+
+    doc_a.answers.create(question=question, value="44")
+    doc_b.answers.create(question=question, value="33")
+    doc_c.answers.create(question=question, value="22")
+
+    query = """
+        query test_ordering($order: [DocumentOrderSetType]) {
+          allDocuments(order: $order) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+    """
+
+    doc_a_id = str(doc_a.id)
+    doc_b_id = str(doc_b.id)
+    doc_c_id = str(doc_c.id)
+
+    def result_ids(result):
+        return [
+            extract_global_id(n["node"]["id"])
+            for n in result.data["allDocuments"]["edges"]
+        ]
+
+    def get_ordered(ordering):
+        result = schema_executor(query, variables={"order": ordering})
+        assert not result.errors
+        return result_ids(result)
+
+    # ordering by answer value, forward.
+    ordered = get_ordered([{"answerValue": question.slug}])
+    assert ordered == [doc_c_id, doc_b_id, doc_a_id]
+
+    # ordering by answer value, backward.
+    ordered = get_ordered([{"answerValue": question.slug, "direction": "DESC"}])
+    assert ordered == [doc_a_id, doc_b_id, doc_c_id]
+
+    # order by meta key "blah" first, which contains the same value twice,
+    # then by the answer value, which orders the ambiguity between
+    # the first two same-value documents
+    ordered = get_ordered(
+        [{"meta": "blah"}, {"answerValue": question.slug, "direction": "DESC"}]
+    )
+    assert ordered == [doc_c_id, doc_a_id, doc_b_id]
+
+    # same, but secondary order goes backwards
+    ordered = get_ordered([{"meta": "blah"}, {"answerValue": question.slug}])
+    assert ordered == [doc_c_id, doc_b_id, doc_a_id]
+
+    # Just for coverage - sort by attribute
+    ordered = get_ordered([{"attribute": "FORM"}])
+
+    assert ordered == [
+        str(doc.id)
+        for doc in sorted([doc_c, doc_b, doc_a], key=lambda doc: doc.form.slug)
+    ]

--- a/caluma/form/ordering.py
+++ b/caluma/form/ordering.py
@@ -1,0 +1,65 @@
+from typing import Any, Tuple
+
+from django import forms
+from django.db.models import OuterRef, Subquery
+from django.db.models.expressions import F
+from django.db.models.query import QuerySet
+from rest_framework import exceptions
+
+from caluma.core.ordering import CalumaOrdering, OrderingFieldType
+from caluma.form.models import Answer, Question
+
+
+class AnswerValueOrdering(CalumaOrdering):
+    """Ordering filter for ordering documents by value of an answer.
+
+    This can also be used for ordering other things that contain documents,
+    such as cases, work items etc.
+    """
+
+    field_class = forms.CharField
+
+    def __init__(self, document_via=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._document_locator_prefix = (
+            "" if document_via is None else f"{document_via}__"
+        )
+
+    def get_ordering_value(
+        self, qs: QuerySet, value: Any
+    ) -> Tuple[QuerySet, OrderingFieldType]:
+        # First, join the requested answer, then annotate the QS accordingly.
+        # Last, return a field corresponding to the value
+        #
+        question = Question.objects.get(pk=value)
+        QUESTION_TYPE_TO_FIELD = {
+            Question.TYPE_INTEGER: "value",
+            Question.TYPE_FLOAT: "value",
+            Question.TYPE_DATE: "date",
+            Question.TYPE_CHOICE: "value",
+            Question.TYPE_TEXTAREA: "value",
+            Question.TYPE_TEXT: "value",
+            Question.TYPE_FILE: "file",
+            Question.TYPE_DYNAMIC_CHOICE: "value",
+            Question.TYPE_STATIC: "value",
+        }
+
+        try:
+            value_field = QUESTION_TYPE_TO_FIELD[question.type]
+        except KeyError:  # pragma: no cover
+            raise exceptions.ValidationError(
+                f"Question '{question.slug}' has unsupported type {question.type} for ordering"
+            )
+
+        answers_subquery = Subquery(
+            Answer.objects.filter(question=question, document=OuterRef("pk")).values(
+                value_field
+            )
+        )
+        ann_name = f"order_{value}"
+
+        qs = qs.annotate(**{ann_name: answers_subquery})
+
+        # TODO: respect document_via
+        return qs, F(ann_name)

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -694,7 +694,10 @@ class AnswerConnection(CountableConnectionBase):
 
 class Document(FormDjangoObjectType):
     answers = DjangoFilterSetConnectionField(
-        AnswerConnection, filterset_class=filters.AnswerFilterSet
+        AnswerConnection,
+        filterset_class=CollectionFilterSetFactory(
+            filters.AnswerFilterSet, orderset_class=filters.AnswerOrderSet
+        ),
     )
     meta = generic.GenericScalar()
 
@@ -892,14 +895,22 @@ def validate_document(info, document_global_id):
 
 class Query:
     all_forms = DjangoFilterConnectionField(
-        Form, filterset_class=CollectionFilterSetFactory(filters.FormFilterSet)
+        Form,
+        filterset_class=CollectionFilterSetFactory(
+            filters.FormFilterSet, orderset_class=filters.FormOrderSet
+        ),
     )
     all_questions = DjangoFilterSetConnectionField(
         QuestionConnection,
-        filterset_class=CollectionFilterSetFactory(filters.QuestionFilterSet),
+        filterset_class=CollectionFilterSetFactory(
+            filters.QuestionFilterSet, orderset_class=filters.QuestionOrderSet
+        ),
     )
     all_documents = DjangoFilterConnectionField(
-        Document, filterset_class=CollectionFilterSetFactory(filters.DocumentFilterSet)
+        Document,
+        filterset_class=CollectionFilterSetFactory(
+            filters.DocumentFilterSet, filters.DocumentOrderSet
+        ),
     )
     all_format_validators = ConnectionField(FormatValidatorConnection)
 

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots[
@@ -58,6 +57,18 @@ type AnswerEdge {
   cursor: String!
 }
 
+input AnswerFilterSetType {
+  question: ID
+  search: String
+  createdByUser: String
+  createdByGroup: String
+  metaHasKey: String
+  metaValue: [JSONValueFilterType]
+  orderBy: [AnswerOrdering]
+  questions: [ID]
+  invert: Boolean
+}
+
 enum AnswerHierarchyMode {
   DIRECT
   FAMILY
@@ -75,6 +86,12 @@ enum AnswerLookupMode {
   LT
 }
 
+input AnswerOrderSetType {
+  meta: String
+  attribute: SortableAnswerAttributes
+  direction: AscDesc
+}
+
 enum AnswerOrdering {
   CREATED_AT_ASC
   CREATED_AT_DESC
@@ -88,6 +105,11 @@ enum AnswerOrdering {
   META_TEST_KEY_DESC
   META_FOOBAR_ASC
   META_FOOBAR_DESC
+}
+
+enum AscDesc {
+  ASC
+  DESC
 }
 
 input CancelCaseInput {
@@ -113,7 +135,7 @@ type Case implements Node {
   status: CaseStatus!
   meta: GenericScalar
   document: Document
-  workItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, task: ID, case: ID, filter: [WorkItemFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [WorkItemOrdering], addressedGroups: [String], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType]): WorkItemConnection
+  workItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, task: ID, case: ID, orderBy: [WorkItemOrdering], filter: [WorkItemFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType]): WorkItemConnection
   parentWorkItem: WorkItem
 }
 
@@ -134,6 +156,7 @@ input CaseFilterSetType {
   createdByGroup: String
   metaHasKey: String
   metaValue: [JSONValueFilterType]
+  orderBy: [CaseOrdering]
   documentForm: String
   hasAnswer: [HasAnswerFilterType]
   searchAnswers: [SearchAnswersFilterType]
@@ -381,7 +404,7 @@ type Document implements Node {
   id: ID!
   form: Form!
   meta: GenericScalar
-  answers(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], question: ID, search: String, createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [AnswerOrdering], questions: [ID]): AnswerConnection
+  answers(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], question: ID, search: String, orderBy: [AnswerOrdering], filter: [AnswerFilterSetType], order: [AnswerOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, questions: [ID]): AnswerConnection
   case: Case
   workItem: WorkItem
 }
@@ -406,10 +429,18 @@ input DocumentFilterSetType {
   createdByGroup: String
   metaHasKey: String
   metaValue: [JSONValueFilterType]
+  orderBy: [DocumentOrdering]
   rootDocument: ID
   hasAnswer: [HasAnswerFilterType]
   searchAnswers: [SearchAnswersFilterType]
   invert: Boolean
+}
+
+input DocumentOrderSetType {
+  meta: String
+  answerValue: String
+  attribute: SortableDocumentAttributes
+  direction: AscDesc
 }
 
 enum DocumentOrdering {
@@ -608,6 +639,7 @@ type FormEdge {
 }
 
 input FormFilterSetType {
+  orderBy: [FormOrdering]
   slug: String
   name: String
   description: String
@@ -620,6 +652,12 @@ input FormFilterSetType {
   search: String
   slugs: [String]
   invert: Boolean
+}
+
+input FormOrderSetType {
+  meta: String
+  attribute: SortableFormAttributes
+  direction: AscDesc
 }
 
 enum FormOrdering {
@@ -1033,13 +1071,13 @@ type Query {
   documentAsOf(id: ID!, asOf: DateTime!): HistoricalDocument
   allDataSources(before: String, after: String, first: Int, last: Int): DataSourceConnection
   dataSource(name: String, before: String, after: String, first: Int, last: Int): DataSourceDataConnection
-  allWorkflows(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, filter: [WorkflowFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [WorkflowOrdering]): WorkflowConnection
-  allTasks(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, filter: [TaskFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [TaskOrdering]): TaskConnection
-  allCases(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], workflow: ID, filter: [CaseFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [CaseOrdering], documentForm: String, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType], status: [CaseStatusArgument], orderByQuestionAnswerValue: String): CaseConnection
-  allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, filter: [WorkItemFilterSetType], orderBy: [WorkItemOrdering], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType], task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
-  allForms(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, filter: [FormFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, slugs: [String]): FormConnection
-  allQuestions(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, filter: [QuestionFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, excludeForms: [ID], search: String, slugs: [String]): QuestionConnection
-  allDocuments(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], form: ID, forms: [ID], search: String, id: ID, filter: [DocumentFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [DocumentOrdering], rootDocument: ID, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType]): DocumentConnection
+  allWorkflows(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, orderBy: [WorkflowOrdering], filter: [WorkflowFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): WorkflowConnection
+  allTasks(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, orderBy: [TaskOrdering], filter: [TaskFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): TaskConnection
+  allCases(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], workflow: ID, orderBy: [CaseOrdering], filter: [CaseFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, documentForm: String, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType], status: [CaseStatusArgument], orderByQuestionAnswerValue: String): CaseConnection
+  allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], filter: [WorkItemFilterSetType], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType], task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
+  allForms(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, filter: [FormFilterSetType], order: [FormOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, slugs: [String]): FormConnection
+  allQuestions(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, filter: [QuestionFilterSetType], order: [QuestionOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, excludeForms: [ID], search: String, slugs: [String]): QuestionConnection
+  allDocuments(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], form: ID, forms: [ID], search: String, id: ID, orderBy: [DocumentOrdering], filter: [DocumentFilterSetType], order: [DocumentOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, rootDocument: ID, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType]): DocumentConnection
   allFormatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
   documentValidity(id: ID!, before: String, after: String, first: Int, last: Int): DocumentValidityConnection
   node(id: ID!): Node
@@ -1075,6 +1113,7 @@ type QuestionEdge {
 }
 
 input QuestionFilterSetType {
+  orderBy: [QuestionOrdering]
   slug: String
   label: String
   isRequired: String
@@ -1091,6 +1130,12 @@ input QuestionFilterSetType {
 }
 
 scalar QuestionJexl
+
+input QuestionOrderSetType {
+  meta: String
+  attribute: SortableQuestionAttributes
+  direction: AscDesc
+}
 
 enum QuestionOrdering {
   LABEL_ASC
@@ -1645,6 +1690,53 @@ type SimpleTask implements Task, Node {
   id: ID!
 }
 
+enum SortableAnswerAttributes {
+  CREATED_AT
+  MODIFIED_AT
+  CREATED_BY_USER
+  CREATED_BY_GROUP
+  QUESTION
+  VALUE
+  DOCUMENT
+  DATE
+  FILE
+}
+
+enum SortableDocumentAttributes {
+  CREATED_AT
+  MODIFIED_AT
+  CREATED_BY_USER
+  CREATED_BY_GROUP
+  FORM
+}
+
+enum SortableFormAttributes {
+  CREATED_AT
+  MODIFIED_AT
+  CREATED_BY_USER
+  CREATED_BY_GROUP
+  SLUG
+  NAME
+  DESCRIPTION
+  IS_PUBLISHED
+  IS_ARCHIVED
+}
+
+enum SortableQuestionAttributes {
+  CREATED_AT
+  MODIFIED_AT
+  CREATED_BY_USER
+  CREATED_BY_GROUP
+  SLUG
+  LABEL
+  TYPE
+  IS_REQUIRED
+  IS_HIDDEN
+  IS_ARCHIVED
+  PLACEHOLDER
+  INFO_TEXT
+}
+
 input StartCaseInput {
   workflow: ID!
   meta: JSONString
@@ -1761,6 +1853,7 @@ input TaskFilterSetType {
   metaHasKey: String
   metaValue: [JSONValueFilterType]
   search: String
+  orderBy: [TaskOrdering]
   invert: Boolean
 }
 
@@ -1895,6 +1988,7 @@ input WorkItemFilterSetType {
   createdByGroup: String
   metaHasKey: String
   metaValue: [JSONValueFilterType]
+  orderBy: [WorkItemOrdering]
   addressedGroups: [String]
   documentHasAnswer: [HasAnswerFilterType]
   caseDocumentHasAnswer: [HasAnswerFilterType]
@@ -1974,6 +2068,7 @@ input WorkflowFilterSetType {
   metaHasKey: String
   metaValue: [JSONValueFilterType]
   search: String
+  orderBy: [WorkflowOrdering]
   invert: Boolean
 }
 

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -135,7 +135,7 @@ type Case implements Node {
   status: CaseStatus!
   meta: GenericScalar
   document: Document
-  workItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, task: ID, case: ID, orderBy: [WorkItemOrdering], filter: [WorkItemFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType]): WorkItemConnection
+  workItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, task: ID, case: ID, orderBy: [WorkItemOrdering], filter: [WorkItemFilterSetType], order: [WorkItemOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType]): WorkItemConnection
   parentWorkItem: WorkItem
 }
 
@@ -163,6 +163,13 @@ input CaseFilterSetType {
   status: [CaseStatusArgument]
   orderByQuestionAnswerValue: String
   invert: Boolean
+}
+
+input CaseOrderSetType {
+  meta: String
+  attribute: SortableCaseAttributes
+  documentAnswer: String
+  direction: AscDesc
 }
 
 enum CaseOrdering {
@@ -1071,10 +1078,10 @@ type Query {
   documentAsOf(id: ID!, asOf: DateTime!): HistoricalDocument
   allDataSources(before: String, after: String, first: Int, last: Int): DataSourceConnection
   dataSource(name: String, before: String, after: String, first: Int, last: Int): DataSourceDataConnection
-  allWorkflows(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, orderBy: [WorkflowOrdering], filter: [WorkflowFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): WorkflowConnection
-  allTasks(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, orderBy: [TaskOrdering], filter: [TaskFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): TaskConnection
-  allCases(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], workflow: ID, orderBy: [CaseOrdering], filter: [CaseFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, documentForm: String, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType], status: [CaseStatusArgument], orderByQuestionAnswerValue: String): CaseConnection
-  allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], filter: [WorkItemFilterSetType], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType], task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
+  allWorkflows(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, orderBy: [WorkflowOrdering], filter: [WorkflowFilterSetType], order: [WorkflowOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): WorkflowConnection
+  allTasks(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, orderBy: [TaskOrdering], filter: [TaskFilterSetType], order: [TaskOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): TaskConnection
+  allCases(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], workflow: ID, orderBy: [CaseOrdering], filter: [CaseFilterSetType], order: [CaseOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, documentForm: String, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType], status: [CaseStatusArgument], orderByQuestionAnswerValue: String): CaseConnection
+  allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], filter: [WorkItemFilterSetType], order: [WorkItemOrderSetType], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType], task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
   allForms(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, filter: [FormFilterSetType], order: [FormOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, slugs: [String]): FormConnection
   allQuestions(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, filter: [QuestionFilterSetType], order: [QuestionOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, excludeForms: [ID], search: String, slugs: [String]): QuestionConnection
   allDocuments(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], form: ID, forms: [ID], search: String, id: ID, orderBy: [DocumentOrdering], filter: [DocumentFilterSetType], order: [DocumentOrderSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, rootDocument: ID, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType]): DocumentConnection
@@ -1702,6 +1709,18 @@ enum SortableAnswerAttributes {
   FILE
 }
 
+enum SortableCaseAttributes {
+  ALLOW_ALL_FORMS
+  CREATED_BY_GROUP
+  CREATED_BY_USER
+  DESCRIPTION
+  IS_ARCHIVED
+  IS_PUBLISHED
+  NAME
+  STATUS
+  SLUG
+}
+
 enum SortableDocumentAttributes {
   CREATED_AT
   MODIFIED_AT
@@ -1735,6 +1754,43 @@ enum SortableQuestionAttributes {
   IS_ARCHIVED
   PLACEHOLDER
   INFO_TEXT
+}
+
+enum SortableTaskAttributes {
+  ALLOW_ALL_FORMS
+  ADDRESS_GROUPS
+  LEAD_TIME
+  TYPE
+  CREATED_BY_GROUP
+  CREATED_BY_USER
+  DESCRIPTION
+  IS_ARCHIVED
+  IS_PUBLISHED
+  NAME
+  SLUG
+}
+
+enum SortableWorkItemAttributes {
+  ALLOW_ALL_FORMS
+  CREATED_BY_GROUP
+  CREATED_BY_USER
+  DESCRIPTION
+  IS_ARCHIVED
+  IS_PUBLISHED
+  NAME
+  STATUS
+  SLUG
+}
+
+enum SortableWorkflowAttributes {
+  ALLOW_ALL_FORMS
+  CREATED_BY_GROUP
+  CREATED_BY_USER
+  DESCRIPTION
+  IS_ARCHIVED
+  IS_PUBLISHED
+  NAME
+  SLUG
 }
 
 input StartCaseInput {
@@ -1855,6 +1911,12 @@ input TaskFilterSetType {
   search: String
   orderBy: [TaskOrdering]
   invert: Boolean
+}
+
+input TaskOrderSetType {
+  meta: String
+  attribute: SortableTaskAttributes
+  direction: AscDesc
 }
 
 enum TaskOrdering {
@@ -1996,6 +2058,15 @@ input WorkItemFilterSetType {
   invert: Boolean
 }
 
+input WorkItemOrderSetType {
+  meta: String
+  caseMeta: String
+  attribute: SortableWorkItemAttributes
+  documentAnswer: String
+  caseDocumentAnswer: String
+  direction: AscDesc
+}
+
 enum WorkItemOrdering {
   STATUS_ASC
   STATUS_DESC
@@ -2070,6 +2141,12 @@ input WorkflowFilterSetType {
   search: String
   orderBy: [WorkflowOrdering]
   invert: Boolean
+}
+
+input WorkflowOrderSetType {
+  meta: String
+  attribute: SortableWorkflowAttributes
+  direction: AscDesc
 }
 
 enum WorkflowOrdering {

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -113,7 +113,7 @@ type Case implements Node {
   status: CaseStatus!
   meta: GenericScalar
   document: Document
-  workItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, task: ID, case: ID, orderBy: [WorkItemOrdering], filter: [WorkItemFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType]): WorkItemConnection
+  workItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, task: ID, case: ID, filter: [WorkItemFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [WorkItemOrdering], addressedGroups: [String], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType]): WorkItemConnection
   parentWorkItem: WorkItem
 }
 
@@ -134,7 +134,6 @@ input CaseFilterSetType {
   createdByGroup: String
   metaHasKey: String
   metaValue: [JSONValueFilterType]
-  orderBy: [CaseOrdering]
   documentForm: String
   hasAnswer: [HasAnswerFilterType]
   searchAnswers: [SearchAnswersFilterType]
@@ -407,7 +406,6 @@ input DocumentFilterSetType {
   createdByGroup: String
   metaHasKey: String
   metaValue: [JSONValueFilterType]
-  orderBy: [DocumentOrdering]
   rootDocument: ID
   hasAnswer: [HasAnswerFilterType]
   searchAnswers: [SearchAnswersFilterType]
@@ -610,7 +608,6 @@ type FormEdge {
 }
 
 input FormFilterSetType {
-  orderBy: [FormOrdering]
   slug: String
   name: String
   description: String
@@ -1036,13 +1033,13 @@ type Query {
   documentAsOf(id: ID!, asOf: DateTime!): HistoricalDocument
   allDataSources(before: String, after: String, first: Int, last: Int): DataSourceConnection
   dataSource(name: String, before: String, after: String, first: Int, last: Int): DataSourceDataConnection
-  allWorkflows(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, orderBy: [WorkflowOrdering], filter: [WorkflowFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): WorkflowConnection
-  allTasks(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, orderBy: [TaskOrdering], filter: [TaskFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String): TaskConnection
-  allCases(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], workflow: ID, orderBy: [CaseOrdering], filter: [CaseFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, documentForm: String, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType], status: [CaseStatusArgument], orderByQuestionAnswerValue: String): CaseConnection
-  allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, orderBy: [WorkItemOrdering], filter: [WorkItemFilterSetType], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType], task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
+  allWorkflows(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, filter: [WorkflowFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [WorkflowOrdering]): WorkflowConnection
+  allTasks(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], slug: String, name: String, description: String, type: TaskTypeArgument, isArchived: Boolean, filter: [TaskFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, orderBy: [TaskOrdering]): TaskConnection
+  allCases(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], workflow: ID, filter: [CaseFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [CaseOrdering], documentForm: String, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType], status: [CaseStatusArgument], orderByQuestionAnswerValue: String): CaseConnection
+  allWorkItems(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], status: WorkItemStatusArgument, filter: [WorkItemFilterSetType], orderBy: [WorkItemOrdering], documentHasAnswer: [HasAnswerFilterType], caseDocumentHasAnswer: [HasAnswerFilterType], caseMetaValue: [JSONValueFilterType], task: ID, case: ID, createdByUser: String, createdByGroup: String, metaHasKey: String, addressedGroups: [String]): WorkItemConnection
   allForms(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [FormOrdering], slug: String, name: String, description: String, isPublished: Boolean, isArchived: Boolean, filter: [FormFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, search: String, slugs: [String]): FormConnection
   allQuestions(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [QuestionOrdering], slug: String, label: String, isRequired: String, isHidden: String, isArchived: Boolean, filter: [QuestionFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, excludeForms: [ID], search: String, slugs: [String]): QuestionConnection
-  allDocuments(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], form: ID, forms: [ID], search: String, id: ID, orderBy: [DocumentOrdering], filter: [DocumentFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, rootDocument: ID, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType]): DocumentConnection
+  allDocuments(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], form: ID, forms: [ID], search: String, id: ID, filter: [DocumentFilterSetType], createdByUser: String, createdByGroup: String, metaHasKey: String, orderBy: [DocumentOrdering], rootDocument: ID, hasAnswer: [HasAnswerFilterType], searchAnswers: [SearchAnswersFilterType]): DocumentConnection
   allFormatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
   documentValidity(id: ID!, before: String, after: String, first: Int, last: Int): DocumentValidityConnection
   node(id: ID!): Node
@@ -1078,7 +1075,6 @@ type QuestionEdge {
 }
 
 input QuestionFilterSetType {
-  orderBy: [QuestionOrdering]
   slug: String
   label: String
   isRequired: String
@@ -1765,7 +1761,6 @@ input TaskFilterSetType {
   metaHasKey: String
   metaValue: [JSONValueFilterType]
   search: String
-  orderBy: [TaskOrdering]
   invert: Boolean
 }
 
@@ -1900,7 +1895,6 @@ input WorkItemFilterSetType {
   createdByGroup: String
   metaHasKey: String
   metaValue: [JSONValueFilterType]
-  orderBy: [WorkItemOrdering]
   addressedGroups: [String]
   documentHasAnswer: [HasAnswerFilterType]
   caseDocumentHasAnswer: [HasAnswerFilterType]
@@ -1980,7 +1974,6 @@ input WorkflowFilterSetType {
   metaHasKey: String
   metaValue: [JSONValueFilterType]
   search: String
-  orderBy: [WorkflowOrdering]
   invert: Boolean
 }
 

--- a/caluma/workflow/filters.py
+++ b/caluma/workflow/filters.py
@@ -12,8 +12,10 @@ from ..core.filters import (
     StringListFilter,
     generate_list_filter_class,
 )
+from ..core.ordering import AttributeOrderingFactory, MetaFieldOrdering
 from ..form.filters import HasAnswerFilter, SearchAnswersFilter
 from ..form.models import Answer, Question
+from ..form.ordering import AnswerValueOrdering
 from . import models
 
 
@@ -42,6 +44,27 @@ class WorkflowFilterSet(MetaFilterSet):
     class Meta:
         model = models.Workflow
         fields = ("slug", "name", "description", "is_published", "is_archived")
+
+
+class WorkflowOrderSet(FilterSet):
+    meta = MetaFieldOrdering()
+    attribute = AttributeOrderingFactory(
+        models.Workflow,
+        fields=[
+            "allow_all_forms",
+            "created_by_group",
+            "created_by_user",
+            "description",
+            "is_archived",
+            "is_published",
+            "name",
+            "slug",
+        ],
+    )
+
+    class Meta:
+        model = models.Workflow
+        fields = ("meta", "attribute")
 
 
 class FlowFilterSet(FilterSet):
@@ -104,6 +127,29 @@ class CaseFilterSet(MetaFilterSet):
         fields = ("workflow",)
 
 
+class CaseOrderSet(FilterSet):
+    meta = MetaFieldOrdering()
+    attribute = AttributeOrderingFactory(
+        models.Case,
+        fields=[
+            "allow_all_forms",
+            "created_by_group",
+            "created_by_user",
+            "description",
+            "is_archived",
+            "is_published",
+            "name",
+            "status",
+            "slug",
+        ],
+    )
+    document_answer = AnswerValueOrdering(document_via="document")
+
+    class Meta:
+        model = models.Case
+        fields = ("meta", "attribute", "document_answer")
+
+
 class TaskFilterSet(MetaFilterSet):
     search = SearchFilter(fields=("slug", "name", "description"))
     order_by = OrderingFilter(
@@ -113,6 +159,30 @@ class TaskFilterSet(MetaFilterSet):
     class Meta:
         model = models.Task
         fields = ("slug", "name", "description", "type", "is_archived")
+
+
+class TaskOrderSet(FilterSet):
+    meta = MetaFieldOrdering()
+    attribute = AttributeOrderingFactory(
+        models.Task,
+        fields=[
+            "allow_all_forms",
+            "address_groups",
+            "lead_time",
+            "type",
+            "created_by_group",
+            "created_by_user",
+            "description",
+            "is_archived",
+            "is_published",
+            "name",
+            "slug",
+        ],
+    )
+
+    class Meta:
+        model = models.Task
+        fields = ("meta", "attribute")
 
 
 class WorkItemFilterSet(MetaFilterSet):
@@ -126,3 +196,34 @@ class WorkItemFilterSet(MetaFilterSet):
     class Meta:
         model = models.WorkItem
         fields = ("status", "task", "case")
+
+
+class WorkItemOrderSet(FilterSet):
+    meta = MetaFieldOrdering()
+    case_meta = MetaFieldOrdering(field_name="case__meta")
+    attribute = AttributeOrderingFactory(
+        models.WorkItem,
+        fields=[
+            "allow_all_forms",
+            "created_by_group",
+            "created_by_user",
+            "description",
+            "is_archived",
+            "is_published",
+            "name",
+            "status",
+            "slug",
+        ],
+    )
+    document_answer = AnswerValueOrdering(document_via="document")
+    case_document_answer = AnswerValueOrdering(document_via="case__document")
+
+    class Meta:
+        model = models.WorkItem
+        fields = (
+            "meta",
+            "case_meta",
+            "attribute",
+            "document_answer",
+            "case_document_answer",
+        )

--- a/caluma/workflow/schema.py
+++ b/caluma/workflow/schema.py
@@ -176,7 +176,10 @@ class WorkItem(DjangoObjectType):
 
 class Case(DjangoObjectType):
     work_items = DjangoFilterConnectionField(
-        WorkItem, filterset_class=CollectionFilterSetFactory(filters.WorkItemFilterSet)
+        WorkItem,
+        filterset_class=CollectionFilterSetFactory(
+            filters.WorkItemFilterSet, orderset_class=filters.WorkItemOrderSet
+        ),
     )
     meta = generic.GenericScalar()
 
@@ -295,15 +298,27 @@ class Mutation(object):
 
 class Query(object):
     all_workflows = DjangoFilterConnectionField(
-        Workflow, filterset_class=CollectionFilterSetFactory(filters.WorkflowFilterSet)
+        Workflow,
+        filterset_class=CollectionFilterSetFactory(
+            filters.WorkflowFilterSet, orderset_class=filters.WorkflowOrderSet
+        ),
     )
     all_tasks = DjangoFilterSetConnectionField(
         TaskConnection,
-        filterset_class=CollectionFilterSetFactory(filters.TaskFilterSet),
+        filterset_class=CollectionFilterSetFactory(
+            filters.TaskFilterSet, orderset_class=filters.TaskOrderSet
+        ),
     )
     all_cases = DjangoFilterConnectionField(
-        Case, filterset_class=CollectionFilterSetFactory(filters.CaseFilterSet)
+        Case,
+        filterset_class=CollectionFilterSetFactory(
+            filters.CaseFilterSet, orderset_class=filters.CaseOrderSet
+        ),
     )
+
     all_work_items = DjangoFilterConnectionField(
-        WorkItem, filterset_class=CollectionFilterSetFactory(filters.WorkItemFilterSet)
+        WorkItem,
+        filterset_class=CollectionFilterSetFactory(
+            filters.WorkItemFilterSet, orderset_class=filters.WorkItemOrderSet
+        ),
     )

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -91,24 +91,24 @@ So the above query would return all documents that have a question named "foo"
 with the value "bar", but exclude all documents from that list where another
 question "baz" has the value "hello".
 
-We also intend to syntactically separate ordering from filtering, which
-"traditionally" was the same: In REST APIs, you would have query strings
-that could configure both filtering and sorting, like this:
-`?foo=bar&ordering=blah`. GrahpQL doesn't really provide independent syntax for
-this either: `allDocuments(hasAnswer:{question:"foo",value:"bar"},orderBy=MODIFIED_AT_ASC)`
+#### Sorting
 
-Our future interface will separate those two concerns in a clean syntactic
-manner:
+The ordering/sorting functionality is also separated from filtering in a
+syntactic manner. This allows us to do "chained" ordering, for example
+sorting by field A, and if the values are equal, sorting by field B as
+well (potentially in another direction).
+
+For example, if you have documents whose form has a "first-name" and
+"last-name" question, you could do the following to sort by last name
+first, and then backwards by first name:
 
 ```graphql
 query foo {
   allDocuments(
-    filter: [
-      {hasAnswer: {question: "foo", value: "bar"}},
-      ...
-    ],
-    ordering: [
-       ...
+    filter: [ ... ],
+    order: [
+      {answerValue: "last-name",  direction:ASC},
+      {answerValue: "first-name", direction:DESC}
     ]
   ) {
      ...

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -90,3 +90,28 @@ query foo {
 So the above query would return all documents that have a question named "foo"
 with the value "bar", but exclude all documents from that list where another
 question "baz" has the value "hello".
+
+We also intend to syntactically separate ordering from filtering, which
+"traditionally" was the same: In REST APIs, you would have query strings
+that could configure both filtering and sorting, like this:
+`?foo=bar&ordering=blah`. GrahpQL doesn't really provide independent syntax for
+this either: `allDocuments(hasAnswer:{question:"foo",value:"bar"},orderBy=MODIFIED_AT_ASC)`
+
+Our future interface will separate those two concerns in a clean syntactic
+manner:
+
+```graphql
+query foo {
+  allDocuments(
+    filter: [
+      {hasAnswer: {question: "foo", value: "bar"}},
+      ...
+    ],
+    ordering: [
+       ...
+    ]
+  ) {
+     ...
+  }
+}
+```


### PR DESCRIPTION
We want to separate filtering and ordering syntactically, so it doesn't
make sense to allow filtering in the filter[] list in the first place.