### PR TITLE
chore(docs): use websave fonts for svgs

### DIFF
--- a/docs/exam-design.svg
+++ b/docs/exam-design.svg
@@ -1,150 +1,71 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="Ebene_1"
-   data-name="Ebene 1"
-   viewBox="0 0 247.25 80.35"
-   version="1.1"
-   sodipodi:docname="exam-design.svg"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14">
-  <metadata
-     id="metadata45">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1173"
-     id="namedview43"
-     showgrid="false"
-     inkscape:zoom="3.2717094"
-     inkscape:cx="166.71898"
-     inkscape:cy="19.639571"
-     inkscape:window-x="0"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Ebene_1" />
-  <defs
-     id="defs4">
-    <style
-       id="style2">.cls-1,.cls-5{font-size:10px;}.cls-1,.cls-4{fill:#222221;}.cls-1{font-family:Oxygen-Regular, Oxygen;}.cls-2,.cls-3,.cls-8{fill:none;stroke-miterlimit:10;}.cls-2{stroke:#222221;}.cls-3{stroke:#636363;}.cls-3,.cls-8{stroke-width:0.5px;}.cls-5{fill:#636363;font-family:sans-serif;}.cls-6{letter-spacing:-0.01em;}.cls-7{fill:#020201;}.cls-8{stroke:#fff;}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="353.15" height="103.05" viewBox="0 0 353.15 103.05">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 14px;
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-1, .cls-4 {
+        fill: #222221;
+      }
+
+      .cls-2, .cls-3, .cls-5 {
+        fill: none;
+        stroke-miterlimit: 10;
+      }
+
+      .cls-2 {
+        stroke: #222221;
+      }
+
+      .cls-3 {
+        stroke: #636362;
+      }
+
+      .cls-3, .cls-5 {
+        stroke-width: 0.5px;
+      }
+
+      .cls-5 {
+        stroke: #fff;
+      }
+
+      .cls-6 {
+        font-size: 10px;
+        fill: #636362;
+        font-family: Courier, Courier;
+      }
+    </style>
   </defs>
-  <title
-     id="title6">exam-design</title>
-  <text
-     class="cls-1"
-     transform="translate(42.35 49.95)"
-     id="text8">
-    <tspan
-       style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-       id="tspan4582">Fill out exam</tspan>
-  </text>
-  <rect
-     class="cls-2"
-     x="31.06"
-     y="28.43"
-     width="80"
-     height="36"
-     id="rect10" />
-  <rect
-     class="cls-3"
-     x="0.25"
-     y="0.25"
-     width="246.75"
-     height="79.85"
-     id="rect12" />
-  <line
-     class="cls-2"
-     x1="111.06"
-     y1="46.43"
-     x2="130.99"
-     y2="46.43"
-     id="line14" />
-  <polygon
-     class="cls-4"
-     points="130.12 49.42 135.3 46.43 130.12 43.44 130.12 49.42"
-     id="polygon16" />
-  <text
-     class="cls-5"
-     transform="translate(6.84 14.51)"
-     id="text18">
-    <tspan
-       style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-       id="tspan4586">Exam</tspan>
-  </text>
-  <text
-     class="cls-1"
-     transform="translate(145.19 49.95)"
-     id="text24">
-    <tspan
-       style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-       id="tspan4584">Correct exam</tspan>
-  </text>
-  <rect
-     class="cls-2"
-     x="135.21"
-     y="28.43"
-     width="80"
-     height="36"
-     id="rect26" />
-  <circle
-     class="cls-7"
-     cx="11.72"
-     cy="46.06"
-     r="4.89"
-     id="circle28" />
-  <circle
-     class="cls-7"
-     cx="236.15"
-     cy="46.43"
-     r="4.89"
-     id="circle30" />
-  <line
-     class="cls-2"
-     x1="9.48"
-     y1="46.06"
-     x2="26.75"
-     y2="46.06"
-     id="line32" />
-  <polygon
-     class="cls-4"
-     points="25.88 49.05 31.06 46.06 25.88 43.07 25.88 49.05"
-     id="polygon34" />
-  <line
-     class="cls-2"
-     x1="215.21"
-     y1="46.43"
-     x2="226.94"
-     y2="46.43"
-     id="line36" />
-  <polygon
-     class="cls-4"
-     points="226.06 49.42 231.24 46.43 226.06 43.44 226.06 49.42"
-     id="polygon38" />
-  <circle
-     class="cls-8"
-     cx="236.15"
-     cy="46.43"
-     r="4.17"
-     id="circle40" />
+  <title>exam-Element 1</title>
+  <g id="Ebene_2" data-name="Ebene 2">
+    <g id="Ebene_1-2" data-name="Ebene 1">
+      <text class="cls-1" transform="translate(61.76 59.71)">Fill out exam</text>
+      <rect class="cls-2" x="44.28" y="28.95" width="114.33" height="51.45"/>
+      <rect class="cls-3" x="0.25" y="0.25" width="352.65" height="102.55"/>
+      <g>
+        <line class="cls-2" x1="158.61" y1="54.68" x2="188.95" y2="54.68"/>
+        <polygon class="cls-4" points="188.08 57.67 193.26 54.68 188.08 51.69 188.08 57.67"/>
+      </g>
+      <text class="cls-1" transform="translate(208.29 59.71)">Correct exam</text>
+      <rect class="cls-2" x="193.13" y="28.95" width="114.33" height="51.45"/>
+      <circle cx="16.65" cy="54.16" r="6.98"/>
+      <g>
+        <line class="cls-2" x1="13.44" y1="54.16" x2="39.97" y2="54.16"/>
+        <polygon class="cls-4" points="39.1 57.15 44.28 54.16 39.1 51.16 39.1 57.15"/>
+      </g>
+      <g>
+        <line class="cls-2" x1="307.46" y1="54.68" x2="326.07" y2="54.68"/>
+        <polygon class="cls-4" points="325.19 57.67 330.38 54.68 325.19 51.69 325.19 57.67"/>
+      </g>
+      <g>
+        <circle cx="337.39" cy="54.68" r="6.98"/>
+        <circle class="cls-5" cx="337.39" cy="54.68" r="5.96"/>
+      </g>
+      <text class="cls-6" transform="translate(46.83 39.84)">Task</text>
+      <text class="cls-6" transform="translate(196.94 39.84)">Task</text>
+      <text class="cls-6" transform="translate(6.5 14.07)">Workflow</text>
+    </g>
+  </g>
 </svg>

--- a/docs/exam-execution-1.svg
+++ b/docs/exam-execution-1.svg
@@ -1,132 +1,54 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 247.25 72.26"
-   version="1.1"
-   id="svg79"
-   sodipodi:docname="exam-execution-1.svg"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14">
-  <metadata
-     id="metadata83">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1173"
-     id="namedview81"
-     showgrid="false"
-     inkscape:zoom="4.6916077"
-     inkscape:cx="123.41713"
-     inkscape:cy="28.897344"
-     inkscape:window-x="0"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Ebene_1-2" />
-  <defs
-     id="defs49">
-    <style
-       id="style47">.cls-1{font-size:10px;fill:#222221;font-family:Oxygen-Regular, Oxygen;}.cls-2,.cls-3,.cls-4,.cls-5{fill:none;stroke:#636363;stroke-miterlimit:10;}.cls-3{stroke-dasharray:9.46 3.78;}.cls-4{stroke-dasharray:8.13 3.25;}.cls-5{stroke-width:0.5px;}.cls-6{font-size:7px;fill:#636363;font-family:monospace;}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="353.15" height="103.05" viewBox="0 0 353.15 103.05">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 14px;
+        fill: #222221;
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-2, .cls-3, .cls-4, .cls-5 {
+        fill: none;
+        stroke: #636362;
+        stroke-miterlimit: 10;
+      }
+
+      .cls-3 {
+        stroke-dasharray: 10.23 4.09;
+      }
+
+      .cls-4 {
+        stroke-dasharray: 9.01 3.6;
+      }
+
+      .cls-5 {
+        stroke-width: 0.5px;
+      }
+
+      .cls-6 {
+        font-size: 10px;
+        fill: #636362;
+        font-family: Courier, Courier;
+      }
+    </style>
   </defs>
-  <title
-     id="title51">Element 1</title>
-  <g
-     id="Ebene_2"
-     data-name="Ebene 2">
-    <g
-       id="Ebene_1-2"
-       data-name="Ebene 1">
-      <text
-         class="cls-1"
-         transform="translate(42.35 41.86)"
-         id="text53">Fill out exam</text>
-      <polyline
-         class="cls-2"
-         points="111.06 51.33 111.06 56.33 106.06 56.33"
-         id="polyline55" />
-      <line
-         class="cls-3"
-         x1="102.27"
-         y1="56.33"
-         x2="37.95"
-         y2="56.33"
-         id="line57" />
-      <polyline
-         class="cls-2"
-         points="36.06 56.33 31.06 56.33 31.06 51.33"
-         id="polyline59" />
-      <line
-         class="cls-4"
-         x1="31.06"
-         y1="48.08"
-         x2="31.06"
-         y2="26.96"
-         id="line61" />
-      <polyline
-         class="cls-2"
-         points="31.06 25.33 31.06 20.33 36.06 20.33"
-         id="polyline63" />
-      <line
-         class="cls-3"
-         x1="39.84"
-         y1="20.33"
-         x2="104.16"
-         y2="20.33"
-         id="line65" />
-      <polyline
-         class="cls-2"
-         points="106.06 20.33 111.06 20.33 111.06 25.33"
-         id="polyline67" />
-      <line
-         class="cls-4"
-         x1="111.06"
-         y1="28.58"
-         x2="111.06"
-         y2="49.71"
-         id="line69" />
-      <rect
-         class="cls-5"
-         x="0.25"
-         y="0.25"
-         width="246.75"
-         height="71.76"
-         id="rect71" />
-      <text
-         class="cls-6"
-         transform="translate(32.84 27.95)"
-         id="text73">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4578">Work Item</tspan>
-      </text>
-      <text
-         class="cls-6"
-         transform="translate(4.62 9.92)"
-         id="text75">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4580">Case</tspan>
-      </text>
+  <title>exam-Element 4</title>
+  <g id="Ebene_2" data-name="Ebene 2">
+    <g id="Ebene_1-2" data-name="Ebene 1">
+      <text class="cls-1" transform="translate(61.76 59.71)">Fill out exam</text>
+      <g>
+        <polyline class="cls-2" points="158.61 75.4 158.61 80.4 153.61 80.4"/>
+        <line class="cls-3" x1="149.52" y1="80.4" x2="51.32" y2="80.4"/>
+        <polyline class="cls-2" points="49.28 80.4 44.28 80.4 44.28 75.4"/>
+        <line class="cls-4" x1="44.28" y1="71.8" x2="44.28" y2="35.75"/>
+        <polyline class="cls-2" points="44.28 33.95 44.28 28.95 49.28 28.95"/>
+        <line class="cls-3" x1="53.37" y1="28.95" x2="151.56" y2="28.95"/>
+        <polyline class="cls-2" points="153.61 28.95 158.61 28.95 158.61 33.95"/>
+        <line class="cls-4" x1="158.61" y1="37.56" x2="158.61" y2="73.6"/>
+      </g>
+      <rect class="cls-5" x="0.25" y="0.25" width="352.65" height="102.55"/>
+      <text class="cls-6" transform="translate(46.83 39.84)">Work Item</text>
+      <text class="cls-6" transform="translate(6.5 14.08)">Case</text>
     </g>
   </g>
 </svg>

--- a/docs/exam-execution-2.svg
+++ b/docs/exam-execution-2.svg
@@ -1,242 +1,102 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 247.25 72.26"
-   version="1.1"
-   id="svg153"
-   sodipodi:docname="exam-execution-2.svg"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14">
-  <metadata
-     id="metadata157">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1173"
-     id="namedview155"
-     showgrid="false"
-     inkscape:zoom="2.3458038"
-     inkscape:cx="143.87048"
-     inkscape:cy="-13.210397"
-     inkscape:window-x="0"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Ebene_1-2" />
-  <defs
-     id="defs87">
-    <style
-       id="style85">.cls-1{font-size:10px;font-family:Oxygen-Regular, Oxygen;}.cls-1,.cls-11{fill:#222221;}.cls-2,.cls-3,.cls-4,.cls-5,.cls-6{fill:none;stroke:#636363;}.cls-10,.cls-2,.cls-3,.cls-4,.cls-5,.cls-6{stroke-miterlimit:10;}.cls-3{stroke-dasharray:9.46 3.78;}.cls-4{stroke-dasharray:8.13 3.25;}.cls-5{stroke-width:0.5px;}.cls-6{stroke-dasharray:5.52 2.21;}.cls-7,.cls-9{fill:#636363;}.cls-8{letter-spacing:-0.01em;}.cls-11,.cls-9{font-size:7px;}.cls-9{font-family:monospace;}.cls-10{fill:#fff;stroke:#020201;stroke-width:0.75px;}.cls-11{font-family:ZapfDingbatsITC, Zapf Dingbats;}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="353.15" height="103.05" viewBox="0 0 353.15 103.05">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 14px;
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-1, .cls-10 {
+        fill: #222221;
+      }
+
+      .cls-2, .cls-3, .cls-4, .cls-5, .cls-6 {
+        fill: none;
+        stroke: #636362;
+      }
+
+      .cls-2, .cls-3, .cls-4, .cls-5, .cls-6, .cls-9 {
+        stroke-miterlimit: 10;
+      }
+
+      .cls-3 {
+        stroke-dasharray: 10.23 4.09;
+      }
+
+      .cls-4 {
+        stroke-dasharray: 9.01 3.6;
+      }
+
+      .cls-5 {
+        stroke-width: 0.5px;
+      }
+
+      .cls-6 {
+        stroke-dasharray: 11.3 4.52;
+      }
+
+      .cls-7, .cls-8 {
+        fill: #636362;
+      }
+
+      .cls-10, .cls-8 {
+        font-size: 10px;
+      }
+
+      .cls-8 {
+        font-family: Courier, Courier;
+      }
+
+      .cls-9 {
+        fill: #fff;
+        stroke: #000;
+        stroke-width: 0.75px;
+      }
+
+      .cls-10 {
+        font-family: ZapfDingbatsITC, Zapf Dingbats;
+      }
+    </style>
   </defs>
-  <title
-     id="title89">exam-executionElement 3</title>
-  <g
-     id="Ebene_2"
-     data-name="Ebene 2">
-    <g
-       id="Ebene_1-2"
-       data-name="Ebene 1">
-      <text
-         class="cls-1"
-         transform="translate(42.35 41.86)"
-         id="text91">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4568">Fill out exam</tspan>
-      </text>
-      <polyline
-         class="cls-2"
-         points="111.06 51.33 111.06 56.33 106.06 56.33"
-         id="polyline93" />
-      <line
-         class="cls-3"
-         x1="102.27"
-         y1="56.33"
-         x2="37.95"
-         y2="56.33"
-         id="line95" />
-      <polyline
-         class="cls-2"
-         points="36.06 56.33 31.06 56.33 31.06 51.33"
-         id="polyline97" />
-      <line
-         class="cls-4"
-         x1="31.06"
-         y1="48.08"
-         x2="31.06"
-         y2="26.96"
-         id="line99" />
-      <polyline
-         class="cls-2"
-         points="31.06 25.33 31.06 20.33 36.06 20.33"
-         id="polyline101" />
-      <line
-         class="cls-3"
-         x1="39.84"
-         y1="20.33"
-         x2="104.16"
-         y2="20.33"
-         id="line103" />
-      <polyline
-         class="cls-2"
-         points="106.06 20.33 111.06 20.33 111.06 25.33"
-         id="polyline105" />
-      <line
-         class="cls-4"
-         x1="111.06"
-         y1="28.58"
-         x2="111.06"
-         y2="49.71"
-         id="line107" />
-      <rect
-         class="cls-5"
-         x="0.25"
-         y="0.25"
-         width="246.75"
-         height="71.76"
-         id="rect109" />
-      <line
-         class="cls-2"
-         x1="111.06"
-         y1="38.33"
-         x2="116.06"
-         y2="38.33"
-         id="line111" />
-      <line
-         class="cls-6"
-         x1="118.26"
-         y1="38.33"
-         x2="124.89"
-         y2="38.33"
-         id="line113" />
-      <line
-         class="cls-2"
-         x1="125.99"
-         y1="38.33"
-         x2="130.99"
-         y2="38.33"
-         id="line115" />
-      <polygon
-         class="cls-7"
-         points="130.12 41.33 135.3 38.33 130.12 35.34 130.12 41.33"
-         id="polygon117" />
-      <text
-         class="cls-1"
-         transform="translate(145.19,41.86)"
-         id="text123"
-         style="font-size:10px;font-family:Oxygen-Regular, Oxygen;fill:#222221">
-        <tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif"
-           id="tspan4572">Correct exam</tspan>
-      </text>
-      <polyline
-         class="cls-2"
-         points="215.21 51.33 215.21 56.33 210.21 56.33"
-         id="polyline125" />
-      <line
-         class="cls-3"
-         x1="206.43"
-         y1="56.33"
-         x2="142.1"
-         y2="56.33"
-         id="line127" />
-      <polyline
-         class="cls-2"
-         points="140.21 56.33 135.21 56.33 135.21 51.33"
-         id="polyline129" />
-      <line
-         class="cls-4"
-         x1="135.21"
-         y1="48.08"
-         x2="135.21"
-         y2="26.96"
-         id="line131" />
-      <polyline
-         class="cls-2"
-         points="135.21 25.33 135.21 20.33 140.21 20.33"
-         id="polyline133" />
-      <line
-         class="cls-3"
-         x1="143.99"
-         y1="20.33"
-         x2="208.32"
-         y2="20.33"
-         id="line135" />
-      <polyline
-         class="cls-2"
-         points="210.21 20.33 215.21 20.33 215.21 25.33"
-         id="polyline137" />
-      <line
-         class="cls-4"
-         x1="215.21"
-         y1="28.58"
-         x2="215.21"
-         y2="49.71"
-         id="line139" />
-      <text
-         class="cls-9"
-         transform="translate(32.84 27.95)"
-         id="text141">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4566">Work Item</tspan>
-      </text>
-      <text
-         class="cls-9"
-         transform="translate(137.87 27.95)"
-         id="text143">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4570">Work Item</tspan>
-      </text>
-      <text
-         class="cls-9"
-         transform="translate(4.62 9.92)"
-         id="text145">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4564">Case</tspan>
-      </text>
-      <circle
-         class="cls-10"
-         cx="111.06"
-         cy="56.33"
-         r="5.21"
-         id="circle147" />
-      <text
-         class="cls-11"
-         transform="translate(108.09 58.91)"
-         id="text149">✔</text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:25px;font-family:Sans;-inkscape-font-specification:'Sans, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="181.61443"
-         y="39.855766"
-         id="text4576"><tspan
-           sodipodi:role="line"
-           id="tspan4574"
-           x="181.61443"
-           y="39.855766"> </tspan></text>
+  <title>exam-Element 3</title>
+  <g id="Ebene_2" data-name="Ebene 2">
+    <g id="Ebene_1-2" data-name="Ebene 1">
+      <text class="cls-1" transform="translate(61.76 59.71)">Fill out exam</text>
+      <g>
+        <polyline class="cls-2" points="158.61 75.4 158.61 80.4 153.61 80.4"/>
+        <line class="cls-3" x1="149.52" y1="80.4" x2="51.32" y2="80.4"/>
+        <polyline class="cls-2" points="49.28 80.4 44.28 80.4 44.28 75.4"/>
+        <line class="cls-4" x1="44.28" y1="71.8" x2="44.28" y2="35.75"/>
+        <polyline class="cls-2" points="44.28 33.95 44.28 28.95 49.28 28.95"/>
+        <line class="cls-3" x1="53.37" y1="28.95" x2="151.56" y2="28.95"/>
+        <polyline class="cls-2" points="153.61 28.95 158.61 28.95 158.61 33.95"/>
+        <line class="cls-4" x1="158.61" y1="37.56" x2="158.61" y2="73.6"/>
+      </g>
+      <rect class="cls-5" x="0.25" y="0.25" width="352.65" height="102.55"/>
+      <g>
+        <line class="cls-2" x1="158.61" y1="54.68" x2="163.61" y2="54.68"/>
+        <line class="cls-6" x1="168.13" y1="54.68" x2="181.69" y2="54.68"/>
+        <line class="cls-2" x1="183.95" y1="54.68" x2="188.95" y2="54.68"/>
+        <polygon class="cls-7" points="188.08 57.67 193.26 54.68 188.08 51.69 188.08 57.67"/>
+      </g>
+      <text class="cls-1" transform="translate(208.29 59.71)">Correct exam</text>
+      <g>
+        <polyline class="cls-2" points="307.46 75.4 307.46 80.4 302.46 80.4"/>
+        <line class="cls-3" x1="298.37" y1="80.4" x2="200.18" y2="80.4"/>
+        <polyline class="cls-2" points="198.13 80.4 193.13 80.4 193.13 75.4"/>
+        <line class="cls-4" x1="193.13" y1="71.8" x2="193.13" y2="35.75"/>
+        <polyline class="cls-2" points="193.13 33.95 193.13 28.95 198.13 28.95"/>
+        <line class="cls-3" x1="202.22" y1="28.95" x2="300.42" y2="28.95"/>
+        <polyline class="cls-2" points="302.46 28.95 307.46 28.95 307.46 33.95"/>
+        <line class="cls-4" x1="307.46" y1="37.56" x2="307.46" y2="73.6"/>
+      </g>
+      <text class="cls-8" transform="translate(46.83 39.84)">Work Item</text>
+      <text class="cls-8" transform="translate(196.94 39.84)">Work Item</text>
+      <text class="cls-8" transform="translate(6.5 14.07)">Case</text>
+      <g>
+        <circle class="cls-9" cx="158.61" cy="80.4" r="7.45"/>
+        <text class="cls-10" transform="translate(154.38 84.09)">✔</text>
+      </g>
     </g>
   </g>
 </svg>

--- a/docs/exam-execution-3.svg
+++ b/docs/exam-execution-3.svg
@@ -1,237 +1,110 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 252.59 77.59"
-   version="1.1"
-   id="svg235"
-   sodipodi:docname="exam-execution-3.svg"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14">
-  <metadata
-     id="metadata239">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1666"
-     inkscape:window-height="1065"
-     id="namedview237"
-     showgrid="false"
-     inkscape:lockguides="true"
-     inkscape:zoom="2.2962113"
-     inkscape:cx="-10.145421"
-     inkscape:cy="53.13043"
-     inkscape:window-x="0"
-     inkscape:window-y="24"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="Ebene_1-2" />
-  <defs
-     id="defs161">
-    <style
-       id="style159">.cls-1{font-size:10px;font-family:Oxygen-Regular, Oxygen;}.cls-1,.cls-11{fill:#222221;}.cls-2,.cls-3,.cls-4,.cls-5,.cls-6{fill:none;stroke:#636363;}.cls-10,.cls-2,.cls-3,.cls-4,.cls-5,.cls-6{stroke-miterlimit:10;}.cls-3{stroke-dasharray:9.46 3.78;}.cls-4{stroke-dasharray:8.13 3.25;}.cls-5{stroke-width:0.5px;}.cls-6{stroke-dasharray:5.52 2.21;}.cls-7,.cls-9{fill:#636363;}.cls-8{letter-spacing:-0.01em;}.cls-11,.cls-9{font-size:7px;}.cls-9{font-family:monospace;}.cls-10{fill:#fff;stroke:#020201;stroke-width:0.75px;}.cls-11{font-family:ZapfDingbatsITC, Zapf Dingbats;}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="360.72" height="110.62" viewBox="0 0 360.72 110.62">
+  <defs>
+    <style>
+      .cls-1 {
+        font-size: 14px;
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-1, .cls-10 {
+        fill: #222221;
+      }
+
+      .cls-2, .cls-3, .cls-4, .cls-5, .cls-6 {
+        fill: none;
+        stroke: #636362;
+      }
+
+      .cls-2, .cls-3, .cls-4, .cls-5, .cls-6, .cls-9 {
+        stroke-miterlimit: 10;
+      }
+
+      .cls-3 {
+        stroke-dasharray: 10.23 4.09;
+      }
+
+      .cls-4 {
+        stroke-dasharray: 9.01 3.6;
+      }
+
+      .cls-5 {
+        stroke-width: 0.5px;
+      }
+
+      .cls-6 {
+        stroke-dasharray: 11.3 4.52;
+      }
+
+      .cls-7, .cls-8 {
+        fill: #636362;
+      }
+
+      .cls-10, .cls-8 {
+        font-size: 10px;
+      }
+
+      .cls-8 {
+        font-family: Courier, Courier;
+      }
+
+      .cls-9 {
+        fill: #fff;
+        stroke: #000;
+        stroke-width: 0.75px;
+      }
+
+      .cls-10 {
+        font-family: ZapfDingbatsITC, Zapf Dingbats;
+      }
+    </style>
   </defs>
-  <title
-     id="title163">exam-execution-Element 4</title>
-  <g
-     id="Ebene_2"
-     data-name="Ebene 2">
-    <g
-       id="Ebene_1-2"
-       data-name="Ebene 1">
-      <text
-         class="cls-1"
-         transform="translate(42.35 41.86)"
-         id="text165"
-         style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">Fill out exam</text>
-      <polyline
-         class="cls-2"
-         points="111.06 51.33 111.06 56.33 106.06 56.33"
-         id="polyline167" />
-      <line
-         class="cls-3"
-         x1="102.27"
-         y1="56.33"
-         x2="37.95"
-         y2="56.33"
-         id="line169" />
-      <polyline
-         class="cls-2"
-         points="36.06 56.33 31.06 56.33 31.06 51.33"
-         id="polyline171" />
-      <line
-         class="cls-4"
-         x1="31.06"
-         y1="48.08"
-         x2="31.06"
-         y2="26.96"
-         id="line173" />
-      <polyline
-         class="cls-2"
-         points="31.06 25.33 31.06 20.33 36.06 20.33"
-         id="polyline175" />
-      <line
-         class="cls-3"
-         x1="39.84"
-         y1="20.33"
-         x2="104.16"
-         y2="20.33"
-         id="line177" />
-      <polyline
-         class="cls-2"
-         points="106.06 20.33 111.06 20.33 111.06 25.33"
-         id="polyline179" />
-      <line
-         class="cls-4"
-         x1="111.06"
-         y1="28.58"
-         x2="111.06"
-         y2="49.71"
-         id="line181" />
-      <rect
-         class="cls-5"
-         x="0.25"
-         y="0.25"
-         width="246.75"
-         height="71.76"
-         id="rect183" />
-      <line
-         class="cls-2"
-         x1="111.06"
-         y1="38.33"
-         x2="116.06"
-         y2="38.33"
-         id="line185" />
-      <line
-         class="cls-6"
-         x1="118.26"
-         y1="38.33"
-         x2="124.89"
-         y2="38.33"
-         id="line187" />
-      <line
-         class="cls-2"
-         x1="125.99"
-         y1="38.33"
-         x2="130.99"
-         y2="38.33"
-         id="line189" />
-      <polygon
-         class="cls-7"
-         points="130.12 41.33 135.3 38.33 130.12 35.34 130.12 41.33"
-         id="polygon191" />
-      <text
-         class="cls-1"
-         transform="translate(145.19,41.86)"
-         id="text197"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10px;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#222221">Correct exam</text>
-      <polyline
-         class="cls-2"
-         points="215.21 51.33 215.21 56.33 210.21 56.33"
-         id="polyline199" />
-      <line
-         class="cls-3"
-         x1="206.43"
-         y1="56.33"
-         x2="142.1"
-         y2="56.33"
-         id="line201" />
-      <polyline
-         class="cls-2"
-         points="140.21 56.33 135.21 56.33 135.21 51.33"
-         id="polyline203" />
-      <line
-         class="cls-4"
-         x1="135.21"
-         y1="48.08"
-         x2="135.21"
-         y2="26.96"
-         id="line205" />
-      <polyline
-         class="cls-2"
-         points="135.21 25.33 135.21 20.33 140.21 20.33"
-         id="polyline207" />
-      <line
-         class="cls-3"
-         x1="143.99"
-         y1="20.33"
-         x2="208.32"
-         y2="20.33"
-         id="line209" />
-      <polyline
-         class="cls-2"
-         points="210.21 20.33 215.21 20.33 215.21 25.33"
-         id="polyline211" />
-      <line
-         class="cls-4"
-         x1="215.21"
-         y1="28.58"
-         x2="215.21"
-         y2="49.71"
-         id="line213" />
-      <text
-         class="cls-9"
-         transform="translate(32.84 27.95)"
-         id="text215"
-         style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">Work Item</text>
-      <text
-         class="cls-9"
-         transform="translate(137.87 27.95)"
-         id="text217"
-         style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">Work Item</text>
-      <text
-         class="cls-9"
-         transform="translate(4.62 9.92)"
-         id="text219"
-         style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;">Case</text>
-      <circle
-         class="cls-10"
-         cx="111.06"
-         cy="56.33"
-         r="5.21"
-         id="circle221" />
-      <text
-         class="cls-11"
-         transform="translate(108.09 58.91)"
-         id="text223">✔</text>
-      <circle
-         class="cls-10"
-         cx="215.21"
-         cy="56.33"
-         r="5.21"
-         id="circle225" />
-      <text
-         class="cls-11"
-         transform="translate(212.25 58.91)"
-         id="text227">✔</text>
-      <circle
-         class="cls-10"
-         cx="247"
-         cy="72.01"
-         r="5.21"
-         id="circle229" />
-      <text
-         class="cls-11"
-         transform="translate(244.04 74.58)"
-         id="text231">✔</text>
+  <title>exam-Element 2</title>
+  <g id="Ebene_2" data-name="Ebene 2">
+    <g id="Ebene_1-2" data-name="Ebene 1">
+      <text class="cls-1" transform="translate(61.76 59.71)">Fill out exam</text>
+      <g>
+        <polyline class="cls-2" points="158.61 75.4 158.61 80.4 153.61 80.4"/>
+        <line class="cls-3" x1="149.52" y1="80.4" x2="51.32" y2="80.4"/>
+        <polyline class="cls-2" points="49.28 80.4 44.28 80.4 44.28 75.4"/>
+        <line class="cls-4" x1="44.28" y1="71.8" x2="44.28" y2="35.75"/>
+        <polyline class="cls-2" points="44.28 33.95 44.28 28.95 49.28 28.95"/>
+        <line class="cls-3" x1="53.37" y1="28.95" x2="151.56" y2="28.95"/>
+        <polyline class="cls-2" points="153.61 28.95 158.61 28.95 158.61 33.95"/>
+        <line class="cls-4" x1="158.61" y1="37.56" x2="158.61" y2="73.6"/>
+      </g>
+      <rect class="cls-5" x="0.25" y="0.25" width="352.65" height="102.55"/>
+      <g>
+        <line class="cls-2" x1="158.61" y1="54.68" x2="163.61" y2="54.68"/>
+        <line class="cls-6" x1="168.13" y1="54.68" x2="181.69" y2="54.68"/>
+        <line class="cls-2" x1="183.95" y1="54.68" x2="188.95" y2="54.68"/>
+        <polygon class="cls-7" points="188.08 57.67 193.26 54.68 188.08 51.69 188.08 57.67"/>
+      </g>
+      <text class="cls-1" transform="translate(208.29 59.71)">Correct exam</text>
+      <g>
+        <polyline class="cls-2" points="307.46 75.4 307.46 80.4 302.46 80.4"/>
+        <line class="cls-3" x1="298.37" y1="80.4" x2="200.18" y2="80.4"/>
+        <polyline class="cls-2" points="198.13 80.4 193.13 80.4 193.13 75.4"/>
+        <line class="cls-4" x1="193.13" y1="71.8" x2="193.13" y2="35.75"/>
+        <polyline class="cls-2" points="193.13 33.95 193.13 28.95 198.13 28.95"/>
+        <line class="cls-3" x1="202.22" y1="28.95" x2="300.42" y2="28.95"/>
+        <polyline class="cls-2" points="302.46 28.95 307.46 28.95 307.46 33.95"/>
+        <line class="cls-4" x1="307.46" y1="37.56" x2="307.46" y2="73.6"/>
+      </g>
+      <text class="cls-8" transform="translate(46.83 39.84)">Work Item</text>
+      <text class="cls-8" transform="translate(196.94 39.84)">Work Item</text>
+      <text class="cls-8" transform="translate(6.5 14.07)">Case</text>
+      <g>
+        <circle class="cls-9" cx="158.61" cy="80.4" r="7.45"/>
+        <text class="cls-10" transform="translate(154.38 84.09)">✔</text>
+      </g>
+      <g>
+        <circle class="cls-9" cx="307.46" cy="80.4" r="7.45"/>
+        <text class="cls-10" transform="translate(303.23 84.09)">✔</text>
+      </g>
+      <g>
+        <circle class="cls-9" cx="352.9" cy="102.8" r="7.45"/>
+        <text class="cls-10" transform="translate(348.66 106.49)">✔</text>
+      </g>
     </g>
   </g>
 </svg>

--- a/docs/exam-execution-4.svg
+++ b/docs/exam-execution-4.svg
@@ -1,416 +1,146 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 423.88 77.99"
-   version="1.1"
-   id="svg373"
-   sodipodi:docname="exam-execution-4.svg"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14">
-  <metadata
-     id="metadata377">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1416"
-     inkscape:window-height="943"
-     id="namedview375"
-     showgrid="false"
-     inkscape:zoom="1.9350851"
-     inkscape:cx="153.72923"
-     inkscape:cy="57.795266"
-     inkscape:window-x="504"
-     inkscape:window-y="254"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="Ebene_1-2" />
-  <defs
-     id="defs243">
-    <style
-       id="style241">.cls-1,.cls-2,.cls-3,.cls-4,.cls-5,.cls-7{fill:none;stroke:#636363;}.cls-1,.cls-2,.cls-3,.cls-4,.cls-5,.cls-7,.cls-9{stroke-miterlimit:10;}.cls-2{stroke-dasharray:10.87 4.35;}.cls-3{stroke-dasharray:8.13 3.25;}.cls-4{stroke-width:0.5px;}.cls-5{stroke-dasharray:5.52 2.21;}.cls-6,.cls-8{fill:#636363;}.cls-7{stroke-dasharray:10.39 4.16;}.cls-10,.cls-8{font-size:7px;}.cls-8{font-family:monospace;}.cls-9{fill:#fff;stroke:#020201;stroke-width:0.75px;}.cls-10{fill:#222221;font-family:ZapfDingbatsITC, Zapf Dingbats;}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="605.59" height="111.19" viewBox="0 0 605.59 111.19">
+  <defs>
+    <style>
+      .cls-1, .cls-2, .cls-3, .cls-4, .cls-5, .cls-7 {
+        fill: none;
+        stroke: #636362;
+      }
+
+      .cls-1, .cls-2, .cls-3, .cls-4, .cls-5, .cls-7, .cls-9 {
+        stroke-miterlimit: 10;
+      }
+
+      .cls-2 {
+        stroke-dasharray: 9 3.6;
+      }
+
+      .cls-3 {
+        stroke-dasharray: 9.01 3.6;
+      }
+
+      .cls-4 {
+        stroke-width: 0.5px;
+      }
+
+      .cls-5 {
+        stroke-dasharray: 11.3 4.52;
+      }
+
+      .cls-6, .cls-8 {
+        fill: #636362;
+      }
+
+      .cls-7 {
+        stroke-dasharray: 11.27 4.51;
+      }
+
+      .cls-10, .cls-8 {
+        font-size: 10px;
+      }
+
+      .cls-8 {
+        font-family: Courier, Courier;
+      }
+
+      .cls-9 {
+        fill: #fff;
+        stroke: #000;
+        stroke-width: 0.75px;
+      }
+
+      .cls-10 {
+        fill: #222221;
+        font-family: ZapfDingbatsITC, Zapf Dingbats;
+      }
+    </style>
   </defs>
-  <title
-     id="title245">exam-execution-Element 7</title>
-  <g
-     id="Ebene_2"
-     data-name="Ebene 2">
-    <g
-       id="Ebene_1-2"
-       data-name="Ebene 1">
-      <polyline
-         class="cls-1"
-         points="54.36 51.73 54.36 56.73 49.36 56.73"
-         id="polyline247" />
-      <line
-         class="cls-2"
-         x1="45.01"
-         y1="56.73"
-         x2="16.74"
-         y2="56.73"
-         id="line249" />
-      <polyline
-         class="cls-1"
-         points="14.57 56.73 9.57 56.73 9.57 51.73"
-         id="polyline251" />
-      <line
-         class="cls-3"
-         x1="9.57"
-         y1="48.48"
-         x2="9.57"
-         y2="27.36"
-         id="line253" />
-      <polyline
-         class="cls-1"
-         points="9.57 25.73 9.57 20.73 14.57 20.73"
-         id="polyline255" />
-      <line
-         class="cls-2"
-         x1="18.92"
-         y1="20.73"
-         x2="47.19"
-         y2="20.73"
-         id="line257" />
-      <polyline
-         class="cls-1"
-         points="49.36 20.73 54.36 20.73 54.36 25.73"
-         id="polyline259" />
-      <line
-         class="cls-3"
-         x1="54.36"
-         y1="28.98"
-         x2="54.36"
-         y2="50.11"
-         id="line261" />
-      <rect
-         class="cls-4"
-         x="0.25"
-         y="0.65"
-         width="133.17"
-         height="71.76"
-         id="rect263" />
-      <line
-         class="cls-1"
-         x1="54.36"
-         y1="38.73"
-         x2="59.36"
-         y2="38.73"
-         id="line265" />
-      <line
-         class="cls-5"
-         x1="61.57"
-         y1="38.73"
-         x2="68.2"
-         y2="38.73"
-         id="line267" />
-      <line
-         class="cls-1"
-         x1="69.3"
-         y1="38.73"
-         x2="74.3"
-         y2="38.73"
-         id="line269" />
-      <polygon
-         class="cls-6"
-         points="73.43 41.73 78.61 38.73 73.43 35.74 73.43 41.73"
-         id="polygon271" />
-      <polyline
-         class="cls-1"
-         points="121.77 51.73 121.77 56.73 116.77 56.73"
-         id="polyline273" />
-      <line
-         class="cls-7"
-         x1="112.62"
-         y1="56.73"
-         x2="85.59"
-         y2="56.73"
-         id="line275" />
-      <polyline
-         class="cls-1"
-         points="83.52 56.73 78.52 56.73 78.52 51.73"
-         id="polyline277" />
-      <line
-         class="cls-3"
-         x1="78.52"
-         y1="48.48"
-         x2="78.52"
-         y2="27.36"
-         id="line279" />
-      <polyline
-         class="cls-1"
-         points="78.52 25.73 78.52 20.73 83.52 20.73"
-         id="polyline281" />
-      <line
-         class="cls-7"
-         x1="87.67"
-         y1="20.73"
-         x2="114.7"
-         y2="20.73"
-         id="line283" />
-      <polyline
-         class="cls-1"
-         points="116.77 20.73 121.77 20.73 121.77 25.73"
-         id="polyline285" />
-      <line
-         class="cls-3"
-         x1="121.77"
-         y1="28.98"
-         x2="121.77"
-         y2="50.11"
-         id="line287" />
-      <text
-         class="cls-8"
-         transform="translate(5.13 10.32)"
-         id="text289">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4558">Case #1</tspan>
-      </text>
-      <circle
-         class="cls-9"
-         cx="54.36"
-         cy="56.73"
-         r="5.21"
-         id="circle291" />
-      <text
-         class="cls-10"
-         transform="translate(51.4 59.31)"
-         id="text293">✔</text>
-      <circle
-         class="cls-9"
-         cx="121.77"
-         cy="56.73"
-         r="5.21"
-         id="circle295" />
-      <text
-         class="cls-10"
-         transform="translate(118.81 59.31)"
-         id="text297">✔</text>
-      <circle
-         class="cls-9"
-         cx="133.42"
-         cy="72.4"
-         r="5.21"
-         id="circle299" />
-      <text
-         class="cls-10"
-         transform="translate(130.46 74.98)"
-         id="text301">✔</text>
-      <polyline
-         class="cls-1"
-         points="199.97 51.73 199.97 56.73 194.97 56.73"
-         id="polyline303" />
-      <line
-         class="cls-2"
-         x1="190.62"
-         y1="56.73"
-         x2="162.35"
-         y2="56.73"
-         id="line305" />
-      <polyline
-         class="cls-1"
-         points="160.18 56.73 155.18 56.73 155.18 51.73"
-         id="polyline307" />
-      <line
-         class="cls-3"
-         x1="155.18"
-         y1="48.48"
-         x2="155.18"
-         y2="27.36"
-         id="line309" />
-      <polyline
-         class="cls-1"
-         points="155.18 25.73 155.18 20.73 160.18 20.73"
-         id="polyline311" />
-      <line
-         class="cls-2"
-         x1="164.53"
-         y1="20.73"
-         x2="192.8"
-         y2="20.73"
-         id="line313" />
-      <polyline
-         class="cls-1"
-         points="194.97 20.73 199.97 20.73 199.97 25.73"
-         id="polyline315" />
-      <line
-         class="cls-3"
-         x1="199.97"
-         y1="28.98"
-         x2="199.97"
-         y2="50.11"
-         id="line317" />
-      <rect
-         class="cls-4"
-         x="145.86"
-         y="0.65"
-         width="133.17"
-         height="71.76"
-         id="rect319" />
-      <text
-         class="cls-8"
-         transform="translate(150.74 10.32)"
-         id="text321">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4560">Case #2</tspan>
-      </text>
-      <polyline
-         class="cls-1"
-         points="344.58 51.33 344.58 56.33 339.58 56.33"
-         id="polyline323" />
-      <line
-         class="cls-2"
-         x1="335.23"
-         y1="56.33"
-         x2="306.96"
-         y2="56.33"
-         id="line325" />
-      <polyline
-         class="cls-1"
-         points="304.78 56.33 299.78 56.33 299.78 51.33"
-         id="polyline327" />
-      <line
-         class="cls-3"
-         x1="299.78"
-         y1="48.08"
-         x2="299.78"
-         y2="26.96"
-         id="line329" />
-      <polyline
-         class="cls-1"
-         points="299.78 25.33 299.78 20.33 304.78 20.33"
-         id="polyline331" />
-      <line
-         class="cls-2"
-         x1="309.13"
-         y1="20.33"
-         x2="337.4"
-         y2="20.33"
-         id="line333" />
-      <polyline
-         class="cls-1"
-         points="339.58 20.33 344.58 20.33 344.58 25.33"
-         id="polyline335" />
-      <line
-         class="cls-3"
-         x1="344.58"
-         y1="28.58"
-         x2="344.58"
-         y2="49.71"
-         id="line337" />
-      <rect
-         class="cls-4"
-         x="290.47"
-         y="0.25"
-         width="133.17"
-         height="71.76"
-         id="rect339" />
-      <line
-         class="cls-1"
-         x1="344.58"
-         y1="38.33"
-         x2="349.58"
-         y2="38.33"
-         id="line341" />
-      <line
-         class="cls-5"
-         x1="351.79"
-         y1="38.33"
-         x2="358.41"
-         y2="38.33"
-         id="line343" />
-      <line
-         class="cls-1"
-         x1="359.52"
-         y1="38.33"
-         x2="364.52"
-         y2="38.33"
-         id="line345" />
-      <polygon
-         class="cls-6"
-         points="363.64 41.33 368.82 38.33 363.64 35.34 363.64 41.33"
-         id="polygon347" />
-      <polyline
-         class="cls-1"
-         points="411.99 51.33 411.99 56.33 406.99 56.33"
-         id="polyline349" />
-      <line
-         class="cls-7"
-         x1="402.83"
-         y1="56.33"
-         x2="375.81"
-         y2="56.33"
-         id="line351" />
-      <polyline
-         class="cls-1"
-         points="373.73 56.33 368.73 56.33 368.73 51.33"
-         id="polyline353" />
-      <line
-         class="cls-3"
-         x1="368.73"
-         y1="48.08"
-         x2="368.73"
-         y2="26.96"
-         id="line355" />
-      <polyline
-         class="cls-1"
-         points="368.73 25.33 368.73 20.33 373.73 20.33"
-         id="polyline357" />
-      <line
-         class="cls-7"
-         x1="377.89"
-         y1="20.33"
-         x2="404.91"
-         y2="20.33"
-         id="line359" />
-      <polyline
-         class="cls-1"
-         points="406.99 20.33 411.99 20.33 411.99 25.33"
-         id="polyline361" />
-      <line
-         class="cls-3"
-         x1="411.99"
-         y1="28.58"
-         x2="411.99"
-         y2="49.71"
-         id="line363" />
-      <text
-         class="cls-8"
-         transform="translate(295.35 9.92)"
-         id="text365">
-        <tspan
-           style="-inkscape-font-specification:sans-serif;font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal"
-           id="tspan4562">Case #3</tspan>
-      </text>
-      <circle
-         class="cls-9"
-         cx="344.58"
-         cy="56.33"
-         r="5.21"
-         id="circle367" />
-      <text
-         class="cls-10"
-         transform="translate(341.62 58.91)"
-         id="text369">✔</text>
+  <title>exam-Element 5</title>
+  <g id="Ebene_2" data-name="Ebene 2">
+    <g id="Ebene_1-2" data-name="Ebene 1">
+      <g>
+        <polyline class="cls-1" points="77.58 75.97 77.58 80.97 72.58 80.97"/>
+        <line class="cls-2" x1="68.98" y1="80.97" x2="20.37" y2="80.97"/>
+        <polyline class="cls-1" points="18.57 80.97 13.57 80.97 13.57 75.97"/>
+        <line class="cls-3" x1="13.57" y1="72.37" x2="13.57" y2="36.33"/>
+        <polyline class="cls-1" points="13.57 34.52 13.57 29.52 18.57 29.52"/>
+        <line class="cls-2" x1="22.17" y1="29.52" x2="70.78" y2="29.52"/>
+        <polyline class="cls-1" points="72.58 29.52 77.58 29.52 77.58 34.52"/>
+        <line class="cls-3" x1="77.59" y1="38.13" x2="77.59" y2="74.17"/>
+      </g>
+      <rect class="cls-4" x="0.25" y="0.82" width="190.32" height="102.55"/>
+      <g>
+        <line class="cls-1" x1="77.59" y1="55.25" x2="82.59" y2="55.25"/>
+        <line class="cls-5" x1="87.11" y1="55.25" x2="100.67" y2="55.25"/>
+        <line class="cls-1" x1="102.93" y1="55.25" x2="107.93" y2="55.25"/>
+        <polygon class="cls-6" points="107.05 58.24 112.23 55.25 107.05 52.26 107.05 58.24"/>
+      </g>
+      <g>
+        <polyline class="cls-1" points="173.93 75.97 173.93 80.97 168.93 80.97"/>
+        <line class="cls-7" x1="164.42" y1="80.97" x2="119.36" y2="80.97"/>
+        <polyline class="cls-1" points="117.11 80.97 112.11 80.97 112.11 75.97"/>
+        <line class="cls-3" x1="112.1" y1="72.37" x2="112.1" y2="36.33"/>
+        <polyline class="cls-1" points="112.11 34.52 112.11 29.52 117.11 29.52"/>
+        <line class="cls-7" x1="121.61" y1="29.52" x2="166.68" y2="29.52"/>
+        <polyline class="cls-1" points="168.93 29.52 173.93 29.52 173.93 34.52"/>
+        <line class="cls-3" x1="173.93" y1="38.13" x2="173.93" y2="74.17"/>
+      </g>
+      <text class="cls-8" transform="translate(7.23 14.65)">Case #1</text>
+      <g>
+        <circle class="cls-9" cx="77.59" cy="80.97" r="7.45"/>
+        <text class="cls-10" transform="translate(73.35 84.66)">✔</text>
+      </g>
+      <g>
+        <circle class="cls-9" cx="173.93" cy="80.97" r="7.45"/>
+        <text class="cls-10" transform="translate(169.69 84.66)">✔</text>
+      </g>
+      <g>
+        <circle class="cls-9" cx="190.57" cy="103.37" r="7.45"/>
+        <text class="cls-10" transform="translate(186.34 107.06)">✔</text>
+      </g>
+      <g>
+        <polyline class="cls-1" points="285.68 75.97 285.68 80.97 280.68 80.97"/>
+        <line class="cls-2" x1="277.08" y1="80.97" x2="228.47" y2="80.97"/>
+        <polyline class="cls-1" points="226.67 80.97 221.67 80.97 221.67 75.97"/>
+        <line class="cls-3" x1="221.67" y1="72.37" x2="221.67" y2="36.33"/>
+        <polyline class="cls-1" points="221.67 34.52 221.67 29.52 226.67 29.52"/>
+        <line class="cls-2" x1="230.27" y1="29.52" x2="278.88" y2="29.52"/>
+        <polyline class="cls-1" points="280.68 29.52 285.68 29.52 285.68 34.52"/>
+        <line class="cls-3" x1="285.68" y1="38.13" x2="285.68" y2="74.17"/>
+      </g>
+      <rect class="cls-4" x="208.35" y="0.82" width="190.32" height="102.55"/>
+      <text class="cls-8" transform="translate(215.33 14.65)">Case #2</text>
+      <g>
+        <polyline class="cls-1" points="492.35 75.4 492.35 80.4 487.35 80.4"/>
+        <line class="cls-2" x1="483.75" y1="80.4" x2="435.14" y2="80.4"/>
+        <polyline class="cls-1" points="433.33 80.4 428.33 80.4 428.33 75.4"/>
+        <line class="cls-3" x1="428.33" y1="71.8" x2="428.33" y2="35.75"/>
+        <polyline class="cls-1" points="428.33 33.95 428.33 28.95 433.33 28.95"/>
+        <line class="cls-2" x1="436.94" y1="28.95" x2="485.55" y2="28.95"/>
+        <polyline class="cls-1" points="487.35 28.95 492.35 28.95 492.35 33.95"/>
+        <line class="cls-3" x1="492.35" y1="37.56" x2="492.35" y2="73.6"/>
+      </g>
+      <rect class="cls-4" x="415.02" y="0.25" width="190.32" height="102.55"/>
+      <g>
+        <line class="cls-1" x1="492.35" y1="54.68" x2="497.35" y2="54.68"/>
+        <line class="cls-5" x1="501.87" y1="54.68" x2="515.44" y2="54.68"/>
+        <line class="cls-1" x1="517.7" y1="54.68" x2="522.7" y2="54.68"/>
+        <polygon class="cls-6" points="521.82 57.67 527 54.68 521.82 51.69 521.82 57.67"/>
+      </g>
+      <g>
+        <polyline class="cls-1" points="588.7 75.4 588.7 80.4 583.7 80.4"/>
+        <line class="cls-7" x1="579.19" y1="80.4" x2="534.12" y2="80.4"/>
+        <polyline class="cls-1" points="531.87 80.4 526.87 80.4 526.87 75.4"/>
+        <line class="cls-3" x1="526.87" y1="71.8" x2="526.87" y2="35.75"/>
+        <polyline class="cls-1" points="526.87 33.95 526.87 28.95 531.87 28.95"/>
+        <line class="cls-7" x1="536.38" y1="28.95" x2="581.44" y2="28.95"/>
+        <polyline class="cls-1" points="583.7 28.95 588.7 28.95 588.7 33.95"/>
+        <line class="cls-3" x1="588.69" y1="37.56" x2="588.69" y2="73.6"/>
+      </g>
+      <text class="cls-8" transform="translate(421.99 14.08)">Case #3</text>
+      <g>
+        <circle class="cls-9" cx="492.35" cy="80.4" r="7.45"/>
+        <text class="cls-10" transform="translate(488.12 84.09)">✔</text>
+      </g>
     </g>
   </g>
 </svg>

--- a/docs/workflow-entities.svg
+++ b/docs/workflow-entities.svg
@@ -1,220 +1,78 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="Ebene_1"
-   data-name="Ebene 1"
-   viewBox="0 0 204.15 126.55"
-   version="1.1"
-   sodipodi:docname="workflow-entities.svg"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14">
-  <metadata
-     id="metadata448">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1173"
-     id="namedview446"
-     showgrid="false"
-     inkscape:zoom="1.4205242"
-     inkscape:cx="-45.405775"
-     inkscape:cy="63.275002"
-     inkscape:window-x="0"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Ebene_1" />
-  <defs
-     id="defs381">
-    <style
-       id="style379">.cls-1,.cls-4{fill:#222221;}.cls-2,.cls-3,.cls-7{fill:none;stroke-miterlimit:10;}.cls-2,.cls-3{stroke:#979a97;stroke-width:0.5px;}.cls-3{stroke-dasharray:4 2;}.cls-4{font-size:12px;font-family:Oxygen-Regular, Oxygen;}.cls-5{letter-spacing:-0.02em;}.cls-6{letter-spacing:0em;}.cls-7{stroke:#222221;}.cls-8{letter-spacing:-0.02em;}.cls-9{letter-spacing:-0.01em;}.cls-10{font-size:10px;fill:#5e605d;font-family:sans-serif;}.cls-11{letter-spacing:-0.01em;}</style>
+<svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" height="200px" viewBox="0 0 204.15 126.55">
+  <defs>
+    <style>
+      .cls-1, .cls-4 {
+        fill: #222221;
+      }
+
+      .cls-2, .cls-3, .cls-6 {
+        fill: none;
+        stroke-miterlimit: 10;
+      }
+
+      .cls-2, .cls-3 {
+        stroke: #979a97;
+        stroke-width: 0.5px;
+      }
+
+      .cls-3 {
+        stroke-dasharray: 4 2;
+      }
+
+      .cls-4 {
+        font-size: 12px;
+        font-family: ArialMT, Arial;
+      }
+
+      .cls-5 {
+        letter-spacing: -0.02em;
+      }
+
+      .cls-6 {
+        stroke: #222221;
+      }
+
+      .cls-7 {
+        letter-spacing: -0.11em;
+      }
+
+      .cls-8 {
+        font-size: 10px;
+        fill: #5e605d;
+        font-family: Arial-ItalicMT, Arial;
+        font-style: italic;
+      }
+    </style>
   </defs>
-  <title
-     id="title383">workflow-entities</title>
-  <line
-     class="cls-1"
-     x1="101.92"
-     x2="101.92"
-     y2="126.05"
-     id="line385"
-     style="" />
-  <line
-     class="cls-2"
-     x1="101.92"
-     x2="101.92"
-     y2="2"
-     id="line387"
-     style="" />
-  <line
-     class="cls-3"
-     x1="101.92"
-     y1="4"
-     x2="101.92"
-     y2="123.05"
-     id="line389"
-     style="" />
-  <line
-     class="cls-2"
-     x1="101.92"
-     y1="124.05"
-     x2="101.92"
-     y2="126.05"
-     id="line391"
-     style="" />
-  <text
-     class="cls-4"
-     transform="translate(14.15 46.58)"
-     id="text401"
-     style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">
-    <tspan
-       class="cls-5"
-       id="tspan393"
-       style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">W</tspan>
-    <tspan
-       x="11.53"
-       y="0"
-       id="tspan395"
-       style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">orkfl</tspan>
-    <tspan
-       class="cls-6"
-       x="36.29"
-       y="0"
-       id="tspan397"
-       style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">o</tspan>
-    <tspan
-       x="43.28"
-       y="0"
-       id="tspan399"
-       style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">w</tspan>
-  </text>
-  <rect
-     class="cls-7"
-     x="0.5"
-     y="25.05"
-     width="80"
-     height="36"
-     id="rect403"
-     style="" />
-  <text
-     class="cls-4"
-     transform="translate(150.62 46.58)"
-     id="text405"
-     style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">Case</text>
-  <rect
-     class="cls-7"
-     x="123.65"
-     y="25.05"
-     width="80"
-     height="36"
-     id="rect407"
-     style="" />
-  <text
-     class="cls-4"
-     transform="translate(28.33 111.58)"
-     id="text413"
-     style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">
-    <tspan
-       class="cls-8"
-       id="tspan409"
-       style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">T</tspan>
-    <tspan
-       x="6.22"
-       y="0"
-       id="tspan411"
-       style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">ask</tspan>
-  </text>
-  <rect
-     class="cls-7"
-     x="0.5"
-     y="90.05"
-     width="80"
-     height="36"
-     id="rect415"
-     style="" />
-  <text
-     class="cls-4"
-     transform="translate(135.57,111.58)"
-     id="text425"
-     style="font-size:11.33333333px;font-family:sans-serif;fill:#222221;-inkscape-font-specification:'sans-serif, Normal';font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">WorkItem</text>
-  <rect
-     class="cls-7"
-     x="123.65"
-     y="90.05"
-     width="80"
-     height="36"
-     id="rect427"
-     style="" />
-  <line
-     class="cls-7"
-     x1="40.5"
-     y1="61.05"
-     x2="40.5"
-     y2="90.05"
-     id="line429"
-     style="" />
-  <line
-     class="cls-7"
-     x1="163.65"
-     y1="61.05"
-     x2="163.65"
-     y2="90.05"
-     id="line431"
-     style="" />
-  <line
-     class="cls-7"
-     x1="80.5"
-     y1="43.05"
-     x2="123.65"
-     y2="43.05"
-     id="line433"
-     style="" />
-  <line
-     class="cls-7"
-     x1="80.35"
-     y1="108.05"
-     x2="123.5"
-     y2="108.05"
-     id="line435"
-     style="" />
-  <text
-     class="cls-10"
-     transform="translate(0.5 11.14)"
-     id="text437"
-     style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">Design</text>
-  <text
-     class="cls-10"
-     transform="translate(123.5 11.14)"
-     id="text443"
-     style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">E<tspan
-   class="cls-11"
-   x="5.58"
-   y="0"
-   id="tspan439"
-   style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">x</tspan>
-<tspan
-   x="10.45"
-   y="0"
-   id="tspan441"
-   style="-inkscape-font-specification:'sans-serif, Normal';font-family:sans-serif;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:11.33333333px;text-anchor:start;text-align:start;writing-mode:lr;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;">ecution</tspan>
-</text>
+  <title>workflow-entities</title>
+  <g>
+    <line class="cls-1" x1="101.92" x2="101.92" y2="126.05"/>
+    <g>
+      <line class="cls-2" x1="101.92" x2="101.92" y2="2"/>
+      <line class="cls-3" x1="101.92" y1="4" x2="101.92" y2="123.05"/>
+      <line class="cls-2" x1="101.92" y1="124.05" x2="101.92" y2="126.05"/>
+    </g>
+  </g>
+  <g>
+    <text class="cls-4" transform="translate(15.94 46.58)"><tspan class="cls-5">W</tspan><tspan x="11.11" y="0">orkflow</tspan></text>
+    <rect class="cls-6" x="0.5" y="25.05" width="80" height="36"/>
+  </g>
+  <g>
+    <text class="cls-4" transform="translate(149.65 46.58)">Case</text>
+    <rect class="cls-6" x="123.65" y="25.05" width="80" height="36"/>
+  </g>
+  <g>
+    <text class="cls-4" transform="translate(28.16 111.58)"><tspan class="cls-7">T</tspan><tspan x="6" y="0">ask</tspan></text>
+    <rect class="cls-6" x="0.5" y="90.05" width="80" height="36"/>
+    <g>
+      <text class="cls-4" transform="translate(136.43 111.58)"><tspan class="cls-5">W</tspan><tspan x="11.11" y="0">ork Item</tspan></text>
+      <rect class="cls-6" x="123.65" y="90.05" width="80" height="36"/>
+    </g>
+  </g>
+  <line class="cls-6" x1="40.5" y1="61.05" x2="40.5" y2="90.05"/>
+  <line class="cls-6" x1="163.65" y1="61.05" x2="163.65" y2="90.05"/>
+  <line class="cls-6" x1="80.5" y1="43.05" x2="123.65" y2="43.05"/>
+  <line class="cls-6" x1="80.35" y1="108.05" x2="123.5" y2="108.05"/>
+  <text class="cls-8" transform="translate(0.5 11.14)">Design</text>
+  <text class="cls-8" transform="translate(123.5 11.14)">Execution</text>
 </svg>


### PR DESCRIPTION
Since I still had rendering issues with the current SVGs, I replaced the fonts by web-safe fonts.