### PR TITLE
fix(ordering): fix ordering by question value

### DIFF
--- a/caluma/form/ordering.py
+++ b/caluma/form/ordering.py
@@ -53,9 +53,10 @@ class AnswerValueOrdering(CalumaOrdering):
             )
 
         answers_subquery = Subquery(
-            Answer.objects.filter(question=question, document=OuterRef("pk")).values(
-                value_field
-            )
+            Answer.objects.filter(
+                question=question,
+                document=OuterRef(f"{self._document_locator_prefix}pk"),
+            ).values(value_field)
         )
         ann_name = f"order_{value}"
 


### PR DESCRIPTION
Ordering by answer value only worked directly on documents,
as the order-by value was joined naively to the outer "pk"
instead of the pk of the document table.

This fixes the problem so that everything that's ordered
by an answer value is now working correctly