### PR TITLE
fix(ordering): reintroduce ordering by deadline on work items

### DIFF
--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -1778,6 +1778,7 @@ enum SortableWorkItemAttributes {
   IS_ARCHIVED
   IS_PUBLISHED
   NAME
+  DEADLINE
   STATUS
   SLUG
 }

--- a/caluma/workflow/filters.py
+++ b/caluma/workflow/filters.py
@@ -211,6 +211,7 @@ class WorkItemOrderSet(FilterSet):
             "is_archived",
             "is_published",
             "name",
+            "deadline",
             "status",
             "slug",
         ],


### PR DESCRIPTION
Fixes #753 by allowing work items to be ordered by deadline again