### PR TITLE
chore(license): switch main license to GPL-3.0-or-later

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -31,4 +31,4 @@ License: CC0-1.0
 # Source code of caluma
 Files: caluma/*.py docs/*
 Copyright: 2019 Adfinis SyGroup AG <info@adfinis-sygroup.ch>
-License: AGPL-3.0-or-later
+License: GPL-3.0-or-later

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU AFFERO GENERAL PUBLIC LICENSE
-                       Version 3, 19 November 2007
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,15 +7,17 @@
 
                             Preamble
 
-  The GNU Affero General Public License is a free, copyleft license for
-software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-our General Public Licenses are intended to guarantee your freedom to
+the GNU General Public License is intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -24,34 +26,44 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  Developers that use our General Public Licenses protect your rights
-with two steps: (1) assert copyright on the software, and (2) offer
-you this License which gives you legal permission to copy, distribute
-and/or modify the software.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
-  A secondary benefit of defending all users' freedom is that
-improvements made in alternate versions of the program, if they
-receive widespread use, become available for other developers to
-incorporate.  Many developers of free software are heartened and
-encouraged by the resulting cooperation.  However, in the case of
-software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and
-letting the public access it on a server without ever releasing its
-source code to the public.
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  The GNU Affero General Public License is designed specifically to
-ensure that, in such cases, the modified source code becomes available
-to the community.  It requires the operator of a network server to
-provide the source code of the modified version running there to the
-users of that server.  Therefore, public use of a modified version, on
-a publicly accessible server, gives the public access to the source
-code of the modified version.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  An older license, called the Affero General Public License and
-published by Affero, was designed to accomplish similar goals.  This is
-a different license, not a version of the Affero GPL, but Affero has
-released a new version of the Affero GPL which permits relicensing under
-this license.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -60,7 +72,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU Affero General Public License.
+  "This License" refers to version 3 of the GNU General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -537,45 +549,35 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Remote Network Interaction; Use with the GNU General Public License.
-
-  Notwithstanding any other provision of this License, if you modify the
-Program, your modified version must prominently offer all users
-interacting with it remotely through a computer network (if your version
-supports such interaction) an opportunity to receive the Corresponding
-Source of your version by providing access to the Corresponding Source
-from a network server at no charge, through some standard or customary
-means of facilitating copying of software.  This Corresponding Source
-shall include the Corresponding Source for any work covered by version 3
-of the GNU General Public License that is incorporated pursuant to the
-following paragraph.
+  13. Use with the GNU Affero General Public License.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU General Public License into a single
+under version 3 of the GNU Affero General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the work with which it is combined will remain governed by version
-3 of the GNU General Public License.
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time.  Such new versions
-will be similar in spirit to the present version, but may differ in detail to
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU Affero General
+Program specifies that a certain numbered version of the GNU General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU Affero General Public License, you may choose any version ever published
+GNU General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that proxy's
+versions of the GNU General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -633,29 +635,40 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
+    it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
+    GNU General Public License for more details.
 
-    You should have received a copy of the GNU Affero General Public License
+    You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source.  For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code.  There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
+For more information on this, and how to apply and follow the GNU GPL, see
 <https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/LICENSES/GPL-3.0-or-later.txt
+++ b/LICENSES/GPL-3.0-or-later.txt
@@ -1,23 +1,24 @@
-GNU AFFERO GENERAL PUBLIC LICENSE
+GNU GENERAL PUBLIC LICENSE
 
-Version 3, 19 November 2007
+Version 3, 29 June 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+Copyright © 2007 Free Software Foundation, Inc. <https://fsf.org/>
 
 Everyone is permitted to copy and distribute verbatim copies of this license
 document, but changing it is not allowed.
 
 Preamble
 
-The GNU Affero General Public License is a free, copyleft license for software
-and other kinds of works, specifically designed to ensure cooperation with
-the community in the case of network server software.
+The GNU General Public License is a free, copyleft license for software and
+other kinds of works.
 
 The licenses for most software and other practical works are designed to take
-away your freedom to share and change the works. By contrast, our General
-Public Licenses are intended to guarantee your freedom to share and change
-all versions of a program--to make sure it remains free software for all its
-users.
+away your freedom to share and change the works. By contrast, the GNU General
+Public License is intended to guarantee your freedom to share and change all
+versions of a program--to make sure it remains free software for all its users.
+We, the Free Software Foundation, use the GNU General Public License for most
+of our software; it applies also to any other work released this way by its
+authors. You can apply it to your programs, too.
 
 When we speak of free software, we are referring to freedom, not price. Our
 General Public Licenses are designed to make sure that you have the freedom
@@ -26,30 +27,41 @@ you receive source code or can get it if you want it, that you can change
 the software or use pieces of it in new free programs, and that you know you
 can do these things.
 
-Developers that use our General Public Licenses protect your rights with two
-steps: (1) assert copyright on the software, and (2) offer you this License
-which gives you legal permission to copy, distribute and/or modify the software.
+To protect your rights, we need to prevent others from denying you these rights
+or asking you to surrender the rights. Therefore, you have certain responsibilities
+if you distribute copies of the software, or if you modify it: responsibilities
+to respect the freedom of others.
 
-A secondary benefit of defending all users' freedom is that improvements made
-in alternate versions of the program, if they receive widespread use, become
-available for other developers to incorporate. Many developers of free software
-are heartened and encouraged by the resulting cooperation. However, in the
-case of software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and letting
-the public access it on a server without ever releasing its source code to
-the public.
+For example, if you distribute copies of such a program, whether gratis or
+for a fee, you must pass on to the recipients the same freedoms that you received.
+You must make sure that they, too, receive or can get the source code. And
+you must show them these terms so they know their rights.
 
-The GNU Affero General Public License is designed specifically to ensure that,
-in such cases, the modified source code becomes available to the community.
-It requires the operator of a network server to provide the source code of
-the modified version running there to the users of that server. Therefore,
-public use of a modified version, on a publicly accessible server, gives the
-public access to the source code of the modified version.
+Developers that use the GNU GPL protect your rights with two steps: (1) assert
+copyright on the software, and (2) offer you this License giving you legal
+permission to copy, distribute and/or modify it.
 
-An older license, called the Affero General Public License and published by
-Affero, was designed to accomplish similar goals. This is a different license,
-not a version of the Affero GPL, but Affero has released a new version of
-the Affero GPL which permits relicensing under this license.
+For the developers' and authors' protection, the GPL clearly explains that
+there is no warranty for this free software. For both users' and authors'
+sake, the GPL requires that modified versions be marked as changed, so that
+their problems will not be attributed erroneously to authors of previous versions.
+
+Some devices are designed to deny users access to install or run modified
+versions of the software inside them, although the manufacturer can do so.
+This is fundamentally incompatible with the aim of protecting users' freedom
+to change the software. The systematic pattern of such abuse occurs in the
+area of products for individuals to use, which is precisely where it is most
+unacceptable. Therefore, we have designed this version of the GPL to prohibit
+the practice for those products. If such problems arise substantially in other
+domains, we stand ready to extend this provision to those domains in future
+versions of the GPL, as needed to protect the freedom of users.
+
+Finally, every program is threatened constantly by software patents. States
+should not allow patents to restrict development and use of software on general-purpose
+computers, but in those that do, we wish to avoid the special danger that
+patents applied to a free program could make it effectively proprietary. To
+prevent this, the GPL assures that patents cannot be used to render the program
+non-free.
 
 The precise terms and conditions for copying, distribution and modification
 follow.
@@ -58,7 +70,7 @@ TERMS AND CONDITIONS
 
    0. Definitions.
 
-   "This License" refers to version 3 of the GNU Affero General Public License.
+   "This License" refers to version 3 of the GNU General Public License.
 
 "Copyright" also means copyright-like laws that apply to other kinds of works,
 such as semiconductor masks.
@@ -123,9 +135,8 @@ those activities but which are not part of the work. For example, Corresponding
 Source includes interface definition files associated with source files for
 the work, and the source code for shared libraries and dynamically linked
 subprograms that the work is specifically designed to require, such as by
-intimate data communication or control flow between those
-
-   subprograms and other parts of the work.
+intimate data communication or control flow between those subprograms and
+other parts of the work.
 
 The Corresponding Source need not include anything that users can regenerate
 automatically from other parts of the Corresponding Source.
@@ -440,7 +451,7 @@ of its contributor version.
 
 In the following three paragraphs, a "patent license" is any express agreement
 or commitment, however denominated, not to enforce a patent (such as an express
-permission to practice a patent or covenant not to s ue for patent infringement).
+permission to practice a patent or covenant not to sue for patent infringement).
 To "grant" such a patent license to a party means to make such an agreement
 or commitment not to enforce a patent against the party.
 
@@ -451,13 +462,11 @@ network server or other readily accessible means, then you must either (1)
 cause the Corresponding Source to be so available, or (2) arrange to deprive
 yourself of the benefit of the patent license for this particular work, or
 (3) arrange, in a manner consistent with the requirements of this License,
-to extend the patent
-
-license to downstream recipients. "Knowingly relying" means you have actual
-knowledge that, but for the patent license, your conveying the covered work
-in a country, or your recipient's use of the covered work in a country, would
-infringe one or more identifiable patents in that country that you have reason
-to believe are valid.
+to extend the patent license to downstream recipients. "Knowingly relying"
+means you have actual knowledge that, but for the patent license, your conveying
+the covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that country
+that you have reason to believe are valid.
 
 If, pursuant to or in connection with a single transaction or arrangement,
 you convey, or propagate by procuring conveyance of, a covered work, and grant
@@ -490,49 +499,39 @@ If conditions are imposed on you (whether by court order, agreement or otherwise
 that contradict the conditions of this License, they do not excuse you from
 the conditions of this License. If you cannot convey a covered work so as
 to satisfy simultaneously your obligations under this License and any other
-pertinent obligations, then as a consequence you may
+pertinent obligations, then as a consequence you may not convey it at all.
+For example, if you agree to terms that obligate you to collect a royalty
+for further conveying from those to whom you convey the Program, the only
+way you could satisfy both those terms and this License would be to refrain
+entirely from conveying the Program.
 
-not convey it at all. For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey the
-Program, the only way you could satisfy both those terms and this License
-would be to refrain entirely from conveying the Program.
-
-   13. Remote Network Interaction; Use with the GNU General Public License.
-
-Notwithstanding any other provision of this License, if you modify the Program,
-your modified version must prominently offer all users interacting with it
-remotely through a computer network (if your version supports such interaction)
-an opportunity to receive the Corresponding Source of your version by providing
-access to the Corresponding Source from a network server at no charge, through
-some standard or customary means of facilitating copying of software. This
-Corresponding Source shall include the Corresponding Source for any work covered
-by version 3 of the GNU General Public License that is incorporated pursuant
-to the following paragraph.
+   13. Use with the GNU Affero General Public License.
 
 Notwithstanding any other provision of this License, you have permission to
 link or combine any covered work with a work licensed under version 3 of the
-GNU General Public License into a single combined work, and to convey the
-resulting work. The terms of this License will continue to apply to the part
-which is the covered work, but the work with which it is combined will remain
-governed by version 3 of the GNU General Public License.
+GNU Affero General Public License into a single combined work, and to convey
+the resulting work. The terms of this License will continue to apply to the
+part which is the covered work, but the special requirements of the GNU Affero
+General Public License, section 13, concerning interaction through a network
+will apply to the combination as such.
 
    14. Revised Versions of this License.
 
 The Free Software Foundation may publish revised and/or new versions of the
-GNU Affero General Public License from time to time. Such new versions will
-be similar in spirit to the present version, but may differ in detail to address
-new problems or concerns.
+GNU General Public License from time to time. Such new versions will be similar
+in spirit to the present version, but may differ in detail to address new
+problems or concerns.
 
 Each version is given a distinguishing version number. If the Program specifies
-that a certain numbered version of the GNU Affero General Public License "or
-any later version" applies to it, you have the option of following the terms
-and conditions either of that numbered version or of any later version published
+that a certain numbered version of the GNU General Public License "or any
+later version" applies to it, you have the option of following the terms and
+conditions either of that numbered version or of any later version published
 by the Free Software Foundation. If the Program does not specify a version
-number of the GNU Affero General Public License, you may choose any version
-ever published by the Free Software Foundation.
+number of the GNU General Public License, you may choose any version ever
+published by the Free Software Foundation.
 
 If the Program specifies that a proxy can decide which future versions of
-the GNU Affero General Public License can be used, that proxy's public statement
+the GNU General Public License can be used, that proxy's public statement
 of acceptance of a version permanently authorizes you to choose that version
 for the Program.
 
@@ -587,27 +586,40 @@ pointer to where the full notice is found.
 Copyright (C) <year> <name of author>
 
 This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU Affero General Public License as published by the Free
-Software Foundation, either version 3 of the License, or (at your option)
-any later version.
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
 
 This program is distributed in the hope that it will be useful, but WITHOUT
 ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
-details.
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-You should have received a copy of the GNU Affero General Public License along
-with this program. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License along with
+this program. If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If your software can interact with users remotely through a computer network,
-you should also make sure that it provides a way for users to get its source.
-For example, if your program is a web application, its interface could display
-a "Source" link that leads users to an archive of the code. There are many
-ways you could offer source, and different solutions will be better for different
-programs; see section 13 for the specific requirements.
+If the program does terminal interaction, make it output a short notice like
+this when it starts in an interactive mode:
+
+<program> Copyright (C) <year> <name of author>
+
+This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+
+This is free software, and you are welcome to redistribute it under certain
+conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License. Of course, your program's commands might
+be different; for a GUI interface, you would use an "about box".
 
 You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary. For
-more information on this, and how to apply and follow the GNU AGPL, see <https://www.gnu.org/licenses/>.
+more information on this, and how to apply and follow the GNU GPL, see <https://www.gnu.org/licenses/>.
+
+The GNU General Public License does not permit incorporating your program
+into proprietary programs. If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library. If this is what you want to do, use the GNU Lesser General Public
+License instead of this License. But first, please read <https://www.gnu.org/
+licenses /why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/projectcaluma/caluma.svg?branch=master)](https://travis-ci.com/projectcaluma/caluma)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen.svg)](https://github.com/projectcaluma/caluma/blob/master/.coveragerc#L5)
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
-[![License: AGPL-3.0](https://img.shields.io/github/license/projectcaluma/caluma)](https://opensource.org/licenses/AGPL-3.0)
+[![License: GPL-3.0-or-later](https://img.shields.io/github/license/projectcaluma/caluma)](https://spdx.org/licenses/GPL-3.0-or-later.html)
 
 A collaborative form editing service.
 
@@ -55,39 +55,9 @@ an example.
 
 ## License
 
-Code released under the [AGPL v3 license](LICENSE).
+Code released under the [GPL-3.0-or-later license](LICENSE).
 
-Some words regarding the license choice:
-
-The AGPL is a rather strict license. In addition to the GNU GPL, you are
-required to provide your changes in the source code not only to the "direct"
-user, but to users accessing the software via a network as well.
-
-For you as a user or integrator, this does not affect you too much: As long
-as you don't modify Caluma itself, you don't need to treat it in any other
-way than how you would other software, as the source is readily available on
-Github.
-
-What it does is that it gives us the motivation to use the official interfaces
-that Caluma provides. We want to keep clean interfaces, and want to motivate
-other users to do the same, despite that it would sometimes be easier to hack
-into the code directly to make it do what you want.
-
-It also protects the project against a large-scale SaaS provider "taking"
-Caluma, modifying it and providing an enhanced, incompatible version of it,
-making money off of it without giving back to the community
-([SaaS
-loophole](https://resources.whitesourcesoftware.com/blog-whitesource/the-saas-loophole-in-gpl-open-source-licenses))
-
-While we explicitly don't mind you making a living off your Caluma offering, we
-want the project to profit if you add some enhancements, so everybody can enjoy
-them.
-
-One could argue that the extensions (like visibility, permissions, etc) are
-"linked" and thus would need to be shared to the end user. This would not be in your
-interest however. We consider those modules as configuration. Sharing these is
-not required.
-
+For further information on our license choice, you can read up on the [corresponding GitHub issue](https://github.com/projectcaluma/caluma/issues/751#issuecomment-547974930).
 
 ## Further reading
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     version=version["__version__"],
     description=version["__description__"],
     url="https://projectcaluma.github.io/",
-    license="License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    license="License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     packages=find_packages(),
 )


### PR DESCRIPTION
Based on the discussion in issue #751, we reevaluated our goals. We want

-  diverse uses and integration of Caluma
-  Caluma to remain public as Free Software
-  an active community
-  to guarantee mutual benefit to our contributors

We found that the definitions in AGPL aren't as clearcut as we wished; therefore, we want to switch to GPL-3.0-or-later. GPL will support all of our goals, with a minor draw-back: Not every last modification is guaranteed to end up in public. Which isn't that bad and it resolves all discussion about configuration.