### PR TITLE
fix(filters): question id/slug should be of type id

### DIFF
--- a/caluma/form/filters.py
+++ b/caluma/form/filters.py
@@ -123,7 +123,7 @@ class AnswerHierarchyMode(Enum):
 class HasAnswerFilterType(InputObjectType):
     """Lookup type to search document structures."""
 
-    question = graphene.String(required=True)
+    question = graphene.ID(required=True)
     value = graphene.types.generic.GenericScalar(required=True)
     lookup = AnswerLookupMode()
     hierarchy = AnswerHierarchyMode()
@@ -262,7 +262,7 @@ class SearchLookupMode(Enum):
 class SearchAnswersFilterType(InputObjectType):
     """Lookup type to search in answers."""
 
-    questions = List(graphene.String)
+    questions = List(graphene.ID)
     value = graphene.types.generic.GenericScalar(required=True)
     lookup = SearchLookupMode(required=False)
 

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -754,7 +754,7 @@ scalar GenericScalar
 scalar GroupJexl
 
 input HasAnswerFilterType {
-  question: String!
+  question: ID!
   value: GenericScalar!
   lookup: AnswerLookupMode
   hierarchy: AnswerHierarchyMode
@@ -1700,7 +1700,7 @@ type SaveWorkflowPayload {
 }
 
 input SearchAnswersFilterType {
-  questions: [String]
+  questions: [ID]
   value: GenericScalar!
   lookup: SearchLookupMode
 }


### PR DESCRIPTION
Question slugs are strings, but should be presented as IDs,
as they are when used in mutations. This leads to duplicate
code in the clients when needing to pass the quesiton ID once
as string and once as ID.