### PR TITLE
refactor: remove method that's not used anymore

### DIFF
--- a/caluma/core/jexl.py
+++ b/caluma/core/jexl.py
@@ -65,10 +65,6 @@ class JEXL(pyjexl.JEXL):
         )
         return parsed_expression
 
-    def analyze(self, expression, analyzer_class):
-        # some common shortcuts, no need to invoke JEXL engine for real
-        return super().analyze(expression, analyzer_class)
-
     def validate(self, expression, ValidatingAnalyzerClass=ValidatingAnalyzer):
         try:
             for res in self.analyze(expression, ValidatingAnalyzerClass):


### PR DESCRIPTION
This method used to contain some shortcut logic, but now it
just passes the call to super(), which we can just as well leave out

