### PR TITLE
feat(form): allow Answers with empty value

### DIFF
--- a/caluma/form/historical_schema.py
+++ b/caluma/form/historical_schema.py
@@ -125,7 +125,7 @@ class HistoricalFile(ObjectType):
 class HistoricalFileAnswer(FileAnswer):
     value = graphene.Field(
         HistoricalFile,
-        required=True,
+        required=False,
         as_of=graphene.types.datetime.DateTime(required=True),
     )
 
@@ -175,7 +175,7 @@ class HistoricalDocument(FormDjangoObjectType):
 class HistoricalTableAnswer(TableAnswer):
     value = graphene.List(
         HistoricalDocument,
-        required=True,
+        required=False,
         as_of=graphene.types.datetime.DateTime(required=True),
     )
 

--- a/caluma/form/schema.py
+++ b/caluma/form/schema.py
@@ -657,7 +657,7 @@ class AnswerQuerysetMixin(object):
 
 
 class IntegerAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
-    value = graphene.Int(required=True)
+    value = graphene.Int()
 
     class Meta:
         model = models.Answer
@@ -667,7 +667,7 @@ class IntegerAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
 
 class FloatAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
-    value = graphene.Float(required=True)
+    value = graphene.Float()
 
     class Meta:
         model = models.Answer
@@ -677,7 +677,7 @@ class FloatAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
 
 class DateAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
-    value = graphene.types.datetime.Date(required=True)
+    value = graphene.types.datetime.Date()
 
     def resolve_value(self, info, **args):
         return self.date
@@ -690,7 +690,7 @@ class DateAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
 
 class StringAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
-    value = graphene.String(required=True)
+    value = graphene.String()
 
     class Meta:
         model = models.Answer
@@ -700,7 +700,7 @@ class StringAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
 
 class ListAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
-    value = graphene.List(graphene.String, required=True)
+    value = graphene.List(graphene.String)
 
     class Meta:
         model = models.Answer
@@ -731,7 +731,7 @@ class Document(FormDjangoObjectType):
 
 
 class TableAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
-    value = graphene.List(Document, required=True)
+    value = graphene.List(Document)
 
     def resolve_value(self, info, **args):
         return self.documents.order_by("-answerdocument__sort")

--- a/caluma/form/serializers.py
+++ b/caluma/form/serializers.py
@@ -464,6 +464,8 @@ class DocumentSerializer(serializers.ModelSerializer):
 
 class SaveAnswerSerializer(serializers.ModelSerializer):
     def validate(self, data):
+        if "value" not in data:
+            data["value"] = None
         validators.AnswerValidator().validate(**data, info=self.context["info"])
         return super().validate(data)
 
@@ -473,35 +475,35 @@ class SaveAnswerSerializer(serializers.ModelSerializer):
 
 
 class SaveDocumentStringAnswerSerializer(SaveAnswerSerializer):
-    value = CharField(trim_whitespace=False, allow_blank=True)
+    value = CharField(trim_whitespace=False, allow_blank=True, required=False)
 
     class Meta(SaveAnswerSerializer.Meta):
         pass
 
 
 class SaveDocumentListAnswerSerializer(SaveAnswerSerializer):
-    value = ListField(child=CharField())
+    value = ListField(child=CharField(), required=False)
 
     class Meta(SaveAnswerSerializer.Meta):
         pass
 
 
 class SaveDocumentIntegerAnswerSerializer(SaveAnswerSerializer):
-    value = IntegerField()
+    value = IntegerField(required=False)
 
     class Meta(SaveAnswerSerializer.Meta):
         pass
 
 
 class SaveDocumentFloatAnswerSerializer(SaveAnswerSerializer):
-    value = FloatField()
+    value = FloatField(required=False)
 
     class Meta(SaveAnswerSerializer.Meta):
         pass
 
 
 class SaveDocumentDateAnswerSerializer(SaveAnswerSerializer):
-    value = DateField(source="date")
+    value = DateField(source="date", required=False)
 
     class Meta(SaveAnswerSerializer.Meta):
         pass
@@ -512,7 +514,7 @@ class SaveDocumentTableAnswerSerializer(SaveAnswerSerializer):
         source="documents",
         queryset=models.Document.objects,
         many=True,
-        required=True,
+        required=False,
         help_text="List of document IDs representing the rows in the table.",
     )
 
@@ -598,8 +600,8 @@ class SaveDocumentTableAnswerSerializer(SaveAnswerSerializer):
 
 
 class SaveDocumentFileAnswerSerializer(SaveAnswerSerializer):
-    value = CharField(write_only=True, source="file")
-    value_id = PrimaryKeyRelatedField(read_only=True, source="file")
+    value = CharField(write_only=True, source="file", required=False)
+    value_id = PrimaryKeyRelatedField(read_only=True, source="file", required=False)
 
     def set_file(self, validated_data):
         file_name = validated_data.get("file")

--- a/caluma/form/tests/snapshots/snap_test_document.py
+++ b/caluma/form/tests/snapshots/snap_test_document.py
@@ -6,258 +6,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots[
-    "test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentIntegerAnswer": {
-        "answer": {"__typename": "IntegerAnswer", "integerValue": 1},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentIntegerAnswer": {
-        "answer": {"__typename": "IntegerAnswer", "integerValue": 1},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentFloatAnswer": {
-        "answer": {"__typename": "FloatAnswer", "floatValue": 2.1},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentFloatAnswer": {
-        "answer": {"__typename": "FloatAnswer", "floatValue": 2.1},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentDateAnswer": {
-        "answer": {"__typename": "DateAnswer", "dateValue": "2019-02-22"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentDateAnswer": {
-        "answer": {"__typename": "DateAnswer", "dateValue": "2019-02-22"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentFileAnswer": {
-        "answer": {
-            "__typename": "FileAnswer",
-            "fileValue": {
-                "name": "some-file.pdf",
-                "uploadUrl": "http://minio/upload-url",
-            },
-        },
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentFileAnswer": {
-        "answer": {
-            "__typename": "FileAnswer",
-            "fileValue": {
-                "name": "some-file.pdf",
-                "uploadUrl": "http://minio/upload-url",
-            },
-        },
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentFileAnswer": {
-        "answer": {
-            "__typename": "FileAnswer",
-            "fileValue": {
-                "name": "not-exist.pdf",
-                "uploadUrl": "http://minio/upload-url",
-            },
-        },
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentFileAnswer": {
-        "answer": {
-            "__typename": "FileAnswer",
-            "fileValue": {
-                "name": "not-exist.pdf",
-                "uploadUrl": "http://minio/upload-url",
-            },
-        },
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentTableAnswer": {
-        "answer": {
-            "__typename": "TableAnswer",
-            "table_value": [
-                {"form": {"slug": "suggest-traditional"}},
-                {"form": {"slug": "suggest-traditional"}},
-            ],
-        },
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentTableAnswer": {
-        "answer": {
-            "__typename": "TableAnswer",
-            "table_value": [
-                {"form": {"slug": "suggest-traditional"}},
-                {"form": {"slug": "suggest-traditional"}},
-            ],
-        },
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentListAnswer": {
-        "answer": {"__typename": "ListAnswer", "listValue": ["option-slug"]},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentListAnswer": {
-        "answer": {"__typename": "ListAnswer", "listValue": ["option-slug"]},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "option-slug"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "option-slug"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
-        "clientMutationId": "testid",
-    }
-}
-
-snapshots[
-    "test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
-] = {
-    "saveDocumentStringAnswer": {
-        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
-        "clientMutationId": "testid",
-    }
-}
-
 snapshots["test_query_all_documents[integer-None-1-None] 1"] = {
     "allDocuments": {
         "edges": [
@@ -591,6 +339,222 @@ snapshots[
 }
 
 snapshots[
+    "test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentIntegerAnswer": {
+        "answer": {"__typename": "IntegerAnswer", "integerValue": 1},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentIntegerAnswer": {
+        "answer": {"__typename": "IntegerAnswer", "integerValue": 1},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentFloatAnswer": {
+        "answer": {"__typename": "FloatAnswer", "floatValue": 2.1},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentFloatAnswer": {
+        "answer": {"__typename": "FloatAnswer", "floatValue": 2.1},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentDateAnswer": {
+        "answer": {"__typename": "DateAnswer", "dateValue": "2019-02-22"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentDateAnswer": {
+        "answer": {"__typename": "DateAnswer", "dateValue": "2019-02-22"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentFileAnswer": {
+        "answer": {
+            "__typename": "FileAnswer",
+            "fileValue": {
+                "name": "some-file.pdf",
+                "uploadUrl": "http://minio/upload-url",
+            },
+        },
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentFileAnswer": {
+        "answer": {
+            "__typename": "FileAnswer",
+            "fileValue": {
+                "name": "some-file.pdf",
+                "uploadUrl": "http://minio/upload-url",
+            },
+        },
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentFileAnswer": {
+        "answer": {
+            "__typename": "FileAnswer",
+            "fileValue": {
+                "name": "not-exist.pdf",
+                "uploadUrl": "http://minio/upload-url",
+            },
+        },
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentFileAnswer": {
+        "answer": {
+            "__typename": "FileAnswer",
+            "fileValue": {
+                "name": "not-exist.pdf",
+                "uploadUrl": "http://minio/upload-url",
+            },
+        },
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentTableAnswer": {
+        "answer": {
+            "__typename": "TableAnswer",
+            "table_value": [
+                {"form": {"slug": "suggest-traditional"}},
+                {"form": {"slug": "suggest-traditional"}},
+            ],
+        },
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentTableAnswer": {
+        "answer": {
+            "__typename": "TableAnswer",
+            "table_value": [
+                {"form": {"slug": "suggest-traditional"}},
+                {"form": {"slug": "suggest-traditional"}},
+            ],
+        },
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "Test"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentListAnswer": {
+        "answer": {"__typename": "ListAnswer", "listValue": ["option-slug"]},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentListAnswer": {
+        "answer": {"__typename": "ListAnswer", "listValue": ["option-slug"]},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "option-slug"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "option-slug"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
     "test_save_document_answer[dynamic_multiple_choice-question__configuration19-MyDataSource-question__format_validators19-answer__value19-None-SaveDocumentListAnswer-True-option-slug-True] 1"
 ] = {
     "saveDocumentListAnswer": {
@@ -623,5 +587,55 @@ snapshots[
     "saveDocumentStringAnswer": {
         "answer": {"__typename": "StringAnswer", "stringValue": "5.5"},
         "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots[
+    "test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False] 1"
+] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": "test@example.com"},
+        "clientMutationId": "testid",
+    }
+}
+
+snapshots["test_save_document_answer_empty[text-false-None-True] 1"] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": None},
+        "clientMutationId": None,
+    }
+}
+
+snapshots["test_save_document_answer_empty[text-false-None-False] 1"] = {
+    "saveDocumentStringAnswer": {
+        "answer": {"__typename": "StringAnswer", "stringValue": None},
+        "clientMutationId": None,
     }
 }

--- a/caluma/form/tests/snapshots/snap_test_filter_by_answer.py
+++ b/caluma/form/tests/snapshots/snap_test_filter_by_answer.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots["test_query_all_questions[multiple_choice-search_value0-matching-None] 1"] = {
@@ -4786,6 +4785,460 @@ snapshots["test_query_all_questions[choice-a-nomatch-INTERSECTS] 1"] = {
     """,
         "variables": {
             "hasAnswer": [{"lookup": "INTERSECTS", "question": "choice", "value": "a"}]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots[
+    "test_query_all_questions[multiple_choice-search_value0-matching-ISNULL] 1"
+] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {"lookup": "ISNULL", "question": "multiple_choice", "value": ["a", "b"]}
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots[
+    "test_query_all_questions[multiple_choice-search_value0-nomatch-ISNULL] 1"
+] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {"lookup": "ISNULL", "question": "multiple_choice", "value": ["a", "b"]}
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[integer-10-matching-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "DIRECT",
+                    "lookup": "ISNULL",
+                    "question": "integer",
+                    "value": 10,
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[integer-10-nomatch-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "DIRECT",
+                    "lookup": "ISNULL",
+                    "question": "integer",
+                    "value": 10,
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[text-foo-matching-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "DIRECT",
+                    "lookup": "ISNULL",
+                    "question": "text",
+                    "value": "foo",
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[text-foo-nomatch-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "DIRECT",
+                    "lookup": "ISNULL",
+                    "question": "text",
+                    "value": "foo",
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[textarea-foo-matching-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "FAMILY",
+                    "lookup": "ISNULL",
+                    "question": "textarea",
+                    "value": "foo",
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[textarea-foo-nomatch-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "FAMILY",
+                    "lookup": "ISNULL",
+                    "question": "textarea",
+                    "value": "foo",
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[float-11.5-matching-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "FAMILY",
+                    "lookup": "ISNULL",
+                    "question": "float",
+                    "value": 11.5,
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[float-11.5-nomatch-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "FAMILY",
+                    "lookup": "ISNULL",
+                    "question": "float",
+                    "value": 11.5,
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots[
+    "test_query_all_questions[datetime-2018-05-09T14:54:51.728786-matching-ISNULL] 1"
+] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "FAMILY",
+                    "lookup": "ISNULL",
+                    "question": "datetime",
+                    "value": "2018-05-09T14:54:51.728786",
+                }
+            ]
+        },
+    },
+    "response": {
+        "data": {"allDocuments": None},
+        "errors": "[GraphQLLocatedError('Question matching query does not exist.',)]",
+    },
+}
+
+snapshots[
+    "test_query_all_questions[datetime-2018-05-09T14:54:51.728786-nomatch-ISNULL] 1"
+] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "FAMILY",
+                    "lookup": "ISNULL",
+                    "question": "datetime",
+                    "value": "2018-05-09T14:54:51.728786",
+                }
+            ]
+        },
+    },
+    "response": {
+        "data": {"allDocuments": None},
+        "errors": "[GraphQLLocatedError('Question matching query does not exist.',)]",
+    },
+}
+
+snapshots["test_query_all_questions[date-2018-05-09-matching-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "DIRECT",
+                    "lookup": "ISNULL",
+                    "question": "date",
+                    "value": "2018-05-09",
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[date-2018-05-09-nomatch-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [
+                {
+                    "hierarchy": "DIRECT",
+                    "lookup": "ISNULL",
+                    "question": "date",
+                    "value": "2018-05-09",
+                }
+            ]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[choice-a-matching-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [{"lookup": "ISNULL", "question": "choice", "value": "a"}]
+        },
+    },
+    "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},
+}
+
+snapshots["test_query_all_questions[choice-a-nomatch-ISNULL] 1"] = {
+    "request": {
+        "query": """
+        query asdf ($hasAnswer: [HasAnswerFilterType]!) {
+          allDocuments(hasAnswer: $hasAnswer) {
+            edges {
+              node {
+                form {
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """,
+        "variables": {
+            "hasAnswer": [{"lookup": "ISNULL", "question": "choice", "value": "a"}]
         },
     },
     "response": {"data": {"allDocuments": {"edges": []}}, "errors": "None"},

--- a/caluma/form/tests/test_validators.py
+++ b/caluma/form/tests/test_validators.py
@@ -313,8 +313,16 @@ def test_validate_data_source(
     [
         (Question.TYPE_MULTIPLE_CHOICE, None, []),
         (Question.TYPE_DYNAMIC_MULTIPLE_CHOICE, None, []),
+        (Question.TYPE_TEXT, None, None),
+        (Question.TYPE_TEXT, "", ""),
+        (Question.TYPE_INTEGER, None, None),
+        (Question.TYPE_FLOAT, None, None),
+        (Question.TYPE_DATE, None, None),
+        (Question.TYPE_FILE, None, None),
+        (Question.TYPE_TEXTAREA, None, None),
     ],
 )
+@pytest.mark.parametrize("answer__date,answer__file", [(None, None)])
 def test_validate_empty_answers(
     db,
     form_question,
@@ -382,6 +390,36 @@ def test_validate_required_integer_0(
     answer_factory(document=document, value=0, question=form_question.question)
 
     DocumentValidator().validate(document, info)
+
+
+@pytest.mark.parametrize(
+    "question__type,answer__value",
+    [
+        (Question.TYPE_MULTIPLE_CHOICE, None),
+        (Question.TYPE_MULTIPLE_CHOICE, []),
+        (Question.TYPE_DYNAMIC_MULTIPLE_CHOICE, None),
+        (Question.TYPE_DYNAMIC_MULTIPLE_CHOICE, []),
+        (Question.TYPE_TEXT, None),
+        (Question.TYPE_TEXT, ""),
+        (Question.TYPE_INTEGER, None),
+        (Question.TYPE_FLOAT, None),
+        (Question.TYPE_DATE, None),
+        (Question.TYPE_FILE, None),
+        (Question.TYPE_TEXTAREA, None),
+        (Question.TYPE_TABLE, None),
+        (Question.TYPE_TABLE, []),
+        (Question.TYPE_CHOICE, None),
+        (Question.TYPE_DYNAMIC_CHOICE, None),
+    ],
+)
+@pytest.mark.parametrize(
+    "answer__date,answer__file,question__is_required", [(None, None, "true")]
+)
+def test_validate_required_empty_answers(
+    db, info, form_question, document, answer, question
+):
+    with pytest.raises(ValidationError):
+        DocumentValidator().validate(document, info)
 
 
 @pytest.mark.parametrize("question__is_hidden", ["true", "false"])

--- a/caluma/form/validators.py
+++ b/caluma/form/validators.py
@@ -249,7 +249,8 @@ class DocumentValidator:
             ]
 
         elif answer.question.type == Question.TYPE_FILE:
-            return answer.file.name
+            if answer.file:
+                return answer.file.name
         elif answer.question.type == Question.TYPE_DATE:
             return answer.date
 

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -80,6 +80,7 @@ enum AnswerLookupMode {
   CONTAINS
   ICONTAINS
   INTERSECTS
+  ISNULL
   GTE
   GT
   LTE
@@ -358,7 +359,7 @@ type DateAnswer implements Answer, Node {
   createdByGroup: String
   id: ID!
   question: Question!
-  value: Date!
+  value: Date
   meta: GenericScalar!
   date: Date
 }
@@ -592,7 +593,7 @@ type FloatAnswer implements Answer, Node {
   createdByGroup: String
   id: ID!
   question: Question!
-  value: Float!
+  value: Float
   meta: GenericScalar!
 }
 
@@ -755,7 +756,7 @@ scalar GroupJexl
 
 input HasAnswerFilterType {
   question: ID!
-  value: GenericScalar!
+  value: GenericScalar
   lookup: AnswerLookupMode
   hierarchy: AnswerHierarchyMode
 }
@@ -790,7 +791,7 @@ type HistoricalDateAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value: Date!
+  value: Date
   meta: GenericScalar!
   date: Date
   historyUserId: String
@@ -833,7 +834,7 @@ type HistoricalFileAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value(asOf: DateTime!): HistoricalFile!
+  value(asOf: DateTime!): HistoricalFile
   meta: GenericScalar!
   historyUserId: String
   question: Question!
@@ -850,7 +851,7 @@ type HistoricalFloatAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value: Float!
+  value: Float
   meta: GenericScalar!
   historyUserId: String
   question: Question!
@@ -866,7 +867,7 @@ type HistoricalIntegerAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value: Int!
+  value: Int
   meta: GenericScalar!
   historyUserId: String
   question: Question!
@@ -882,7 +883,7 @@ type HistoricalListAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value: [String]!
+  value: [String]
   meta: GenericScalar!
   historyUserId: String
   question: Question!
@@ -898,7 +899,7 @@ type HistoricalStringAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value: String!
+  value: String
   meta: GenericScalar!
   historyUserId: String
   question: Question!
@@ -914,7 +915,7 @@ type HistoricalTableAnswer implements HistoricalAnswer, Node {
   createdByUser: String
   createdByGroup: String
   id: ID!
-  value(asOf: DateTime!): [HistoricalDocument]!
+  value(asOf: DateTime!): [HistoricalDocument]
   meta: GenericScalar!
   historyUserId: String
   question: Question!
@@ -932,7 +933,7 @@ type IntegerAnswer implements Answer, Node {
   createdByGroup: String
   id: ID!
   question: Question!
-  value: Int!
+  value: Int
   meta: GenericScalar!
 }
 
@@ -982,7 +983,7 @@ type ListAnswer implements Answer, Node {
   createdByGroup: String
   id: ID!
   question: Question!
-  value: [String]!
+  value: [String]
   meta: GenericScalar!
 }
 
@@ -1330,7 +1331,7 @@ input SaveDocumentDateAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: Date!
+  value: Date
   clientMutationId: String
 }
 
@@ -1343,7 +1344,7 @@ input SaveDocumentFileAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: String!
+  value: String
   valueId: ID
   clientMutationId: String
 }
@@ -1357,7 +1358,7 @@ input SaveDocumentFloatAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: Float!
+  value: Float
   clientMutationId: String
 }
 
@@ -1377,7 +1378,7 @@ input SaveDocumentIntegerAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: Int!
+  value: Int
   clientMutationId: String
 }
 
@@ -1390,7 +1391,7 @@ input SaveDocumentListAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: [String]!
+  value: [String]
   clientMutationId: String
 }
 
@@ -1408,7 +1409,7 @@ input SaveDocumentStringAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: String!
+  value: String
   clientMutationId: String
 }
 
@@ -1421,7 +1422,7 @@ input SaveDocumentTableAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: [ID]!
+  value: [ID]
   clientMutationId: String
 }
 
@@ -1881,7 +1882,7 @@ type StringAnswer implements Answer, Node {
   createdByGroup: String
   id: ID!
   question: Question!
-  value: String!
+  value: String
   meta: GenericScalar!
 }
 
@@ -1892,7 +1893,7 @@ type TableAnswer implements Answer, Node {
   createdByGroup: String
   id: ID!
   question: Question!
-  value: [Document]!
+  value: [Document]
   meta: GenericScalar!
   document: Document!
 }


### PR DESCRIPTION
This commit adds the possibility to save/query Answers with `null`
values.

It also adds a new lookup mode `ISNULL` to the `HasAnswerFilter`. If
this lookup mode is used, the provided `value` (if any) is ignored.

Since graphql-core doesn't support `null` literals yet, the way for setting
the value of an Answer to `None` is to omit the `value` field
altogether.

Closes #790 and #800 

BREAKING CHANGE: `Answers` are now allowed to have `null` values.