### PR TITLE
docs: explain how to use pipenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+/Pipfile
+/Pipfile.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,9 +71,20 @@ pre-commit install
 ```
 
 ### Setup commit-msg hook
+
 If you want to have your commit message automatically linted, execute below commands:
 
 ```bash
 npm install @commitlint/{config-conventional,cli}
 ln -s "$(pwd)/commit-msg" .git/hooks/commit-msg
+```
+
+### Using pipenv
+
+Docker is the way to run and test caluma, but you can install the requirements
+for your IDE/editor using pipenv:
+
+```bash
+pipenv --three install -r requirements.txt
+pipenv install -d -r requirements-dev.txt
 ```


### PR DESCRIPTION
I first thought it makes no sense because we use docker, but I needed to install the packages for my editor. So its nice to have the commands in the documentation.