### PR TITLE
feat(permissions): make permission decorators chainable

### DIFF
--- a/caluma/core/tests/test_permissions.py
+++ b/caluma/core/tests/test_permissions.py
@@ -91,3 +91,62 @@ def test_custom_permission_override_has_object_permission_with_duplicates(db, in
 
     with pytest.raises(ImproperlyConfigured):
         CustomPermission()
+
+
+def test_custom_permission_override_has_permission_with_multiple_mutations(
+    db, history_mock, info
+):
+    FakeModel = get_fake_model(model_base=models.UUIDModel)
+
+    class Serializer(serializers.ModelSerializer):
+        class Meta:
+            model = FakeModel
+            fields = "__all__"
+
+    class CustomMutation(Mutation):
+        class Meta:
+            serializer_class = Serializer
+
+    class AnotherMutation(Mutation):
+        class Meta:
+            serializer_class = Serializer
+
+    class CustomPermission(BasePermission):
+        @permission_for(CustomMutation)
+        @permission_for(AnotherMutation)
+        def has_permission_for_both_mutations(self, mutation, info):  # pragma: no cover
+            return False
+
+    assert not CustomPermission().has_permission(CustomMutation, info)
+    assert not CustomPermission().has_permission(AnotherMutation, info)
+
+
+def test_custom_permission_override_has_object_permission_with_multiple_mutations(
+    db, history_mock, info
+):
+    FakeModel = get_fake_model(model_base=models.UUIDModel)
+    instance = FakeModel.objects.create()
+
+    class Serializer(serializers.ModelSerializer):
+        class Meta:
+            model = FakeModel
+            fields = "__all__"
+
+    class CustomMutation(Mutation):
+        class Meta:
+            serializer_class = Serializer
+
+    class AnotherMutation(Mutation):
+        class Meta:
+            serializer_class = Serializer
+
+    class CustomPermission(BasePermission):
+        @object_permission_for(CustomMutation)
+        @object_permission_for(AnotherMutation)
+        def has_object_permission_for_both_mutations(
+            self, mutation, info, instance
+        ):  # pragma: no cover
+            return False
+
+    assert not CustomPermission().has_object_permission(CustomMutation, info, instance)
+    assert not CustomPermission().has_object_permission(AnotherMutation, info, instance)


### PR DESCRIPTION
Before, the `has_permission` and `has_object_permission` decorators
would need a separate function for each Mutation.
Now, the same function can be decorated for multiple mutations, reducing
the amount of code if some mutations share the same permission logic.

Example:
```python
class CustomPermission(BasePermission):

    @has_permission(FirstMutation)
    @has_permission(SecondMutation)
    def has_permission_for_both(self, mutation, info):
        return False
```