### PR TITLE
add pipenv workflow for local development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+os: "linux"
+
 python:
   - "3.6"
 
@@ -25,20 +27,27 @@ before_install:
 
   # set UID to run docker service with
   - echo "UID=$(id --user)" > .env
+jobs:
+  include:
+    - env: BUILD_TYPE=standard
+      install:
+        - docker-compose up -d --build
+        - npm install @commitlint/{config-conventional,travis-cli}
 
-install:
-  - docker-compose up -d --build
-  - npm install @commitlint/{config-conventional,travis-cli}
-
-script:
-  - docker-compose exec caluma black --check .
-  - docker-compose exec caluma flake8
-  - ./node_modules/.bin/commitlint-travis
-  - docker-compose exec caluma ./manage.py makemigrations --check --dry-run --no-input
-  - docker-compose exec caluma pytest --no-cov-on-fail --cov --create-db -vv
-  - docker-compose exec caluma reuse lint
-after_success:
-  - git config --global user.name "semantic-release (via TravisCI)"
-  - git config --global user.email "semantic-release@travis"
-  - pip install python-semantic-release
-  - semantic-release publish
+      script:
+        - docker-compose exec caluma black --check .
+        - docker-compose exec caluma flake8
+        - ./node_modules/.bin/commitlint-travis
+        - docker-compose exec caluma ./manage.py makemigrations --check --dry-run --no-input
+        - docker-compose exec caluma pytest --no-cov-on-fail --cov --create-db -vv
+        - docker-compose exec caluma reuse lint
+      after_success:
+        - git config --global user.name "semantic-release (via TravisCI)"
+        - git config --global user.email "semantic-release@travis"
+        - pip install python-semantic-release
+        - semantic-release publish
+    - env:
+        BUILD_TYPE=pipenv
+        PIPENV_IGNORE_VIRTUALENVS=1
+      install: python3 setup.py pipenv
+      script: pipenv run pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,26 @@ Docker is the way to run and test caluma, but you can install the requirements
 for your IDE/editor using pipenv:
 
 ```bash
-pipenv --three install -r requirements.txt
+pipenv install --python 3.6 -r requirements.txt
 pipenv install -d -r requirements-dev.txt
 ```
+
+You can also run tests without the caluma-container:
+
+```bash
+echo UID=$(id --user) > .env
+echo ENV=dev >> .env
+docker-compose up -d db
+pipenv install --python 3.6 -r requirements.txt
+pipenv install -d -r requirements-dev.txt
+pipenv shell
+pytest
+```
+
+or you can use the setup.py command:
+
+```bash
+python3 setup.py pipenv
+```
+
+You can add any configuration supported by the caluma-container to the .env file.

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,46 @@
 """Setuptools package definition."""
 
+import distutils.cmd
+import os
+
 from setuptools import find_packages, setup
 
 version = {}
 with open("caluma/caluma_metadata.py") as fp:
     exec(fp.read(), version)
 
+pipenv_setup = """
+echo UID=$(id --user) > .env
+echo ENV=dev >> .env
+docker-compose up -d db
+rm -f Pipfile*
+touch Pipfile
+pipenv install --python 3.6 -r requirements.txt
+pipenv install -d -r requirements-dev.txt
+""".strip().splitlines()
+
+
+class PipenvCommand(distutils.cmd.Command):
+    description = "setup local development with pipenv"
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        for cmd in pipenv_setup:
+            assert os.system(cmd) == 0
+        print(
+            "\npipenv run pytest      runs the tests"
+            "\npipenv shell           enters the virtualenv"
+        )
+
+
 setup(
+    cmdclass={"pipenv": PipenvCommand},
     name=version["__title__"],
     version=version["__version__"],
     description=version["__description__"],


### PR DESCRIPTION
This kind of just happend:

1. I needed a way to install the environment for my editor, so that completion works, pipenv was very easy to use

2. Then managing the dependencies and running multiple databases for #814 was a pain, so I started to use pipenv for development

3. Then @sbor23 asked how to do local development and I defined a proper workflow

4. Then I realized that there are certain common mistakes, so I coded the setup of pipenv in setup.py

5. And after all this, it made sense to also test in the pipenv, so there are no surprises for developers deciding do local development