### PR TITLE
chore(deps): update to graphene-django v2.7.1

### DIFF
--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -507,50 +507,6 @@ class DjangoFilterConnectionField(
         queryset.query.select_related = default_queryset.query.select_related
         return queryset
 
-    @classmethod
-    def connection_resolver(
-        cls,
-        resolver,
-        connection,
-        default_manager,
-        max_limit,
-        enforce_first_or_last,
-        filterset_class,
-        filtering_args,
-        root,
-        info,
-        **args,
-    ):
-        # building form within filterset class is a performance hit
-        # and should only be done if there are actual filter arguments
-        filter_kwargs = {k: v for k, v in args.items() if k in filtering_args}
-        if not filter_kwargs:
-            # skip parent DjangoFilterConnetionField which does filtering and directly
-            # go to its parent
-            return super(filter.DjangoFilterConnectionField, cls).connection_resolver(
-                resolver,
-                connection,
-                default_manager.get_queryset(),
-                max_limit,
-                enforce_first_or_last,
-                root,
-                info,
-                **args,
-            )
-
-        return super().connection_resolver(
-            resolver,
-            connection,
-            default_manager,
-            max_limit,
-            enforce_first_or_last,
-            filterset_class,
-            filtering_args,
-            root,
-            info,
-            **args,
-        )
-
 
 class DjangoFilterSetConnectionField(DjangoFilterConnectionField):
     @property

--- a/caluma/core/filters.py
+++ b/caluma/core/filters.py
@@ -498,15 +498,6 @@ class DjangoFilterConnectionField(
     def filterset_class(self):
         return self._provided_filterset_class
 
-    @classmethod
-    def merge_querysets(cls, default_queryset, queryset):
-        queryset = super().merge_querysets(default_queryset, queryset)
-        # avoid query explosion of single relationships
-        # may be removed once following issue is fixed:
-        # https://github.com/graphql-python/graphene-django/issues/57
-        queryset.query.select_related = default_queryset.query.select_related
-        return queryset
-
 
 class DjangoFilterSetConnectionField(DjangoFilterConnectionField):
     @property

--- a/caluma/core/types.py
+++ b/caluma/core/types.py
@@ -68,15 +68,9 @@ class DjangoConnectionField(DjangoConnectionField):
     """
 
     @classmethod
-    def resolve_connection(cls, connection, default_manager, args, iterable):
-        if iterable is None:
-            iterable = default_manager
+    def resolve_connection(cls, connection, args, iterable):
         iterable = maybe_queryset(iterable)
         if isinstance(iterable, QuerySet):
-            if iterable.model.objects is not default_manager:
-                default_queryset = maybe_queryset(default_manager)
-                iterable = cls.merge_querysets(default_queryset, iterable)
-
             # only query count on database when pagination is needed
             # resolve_connection may be removed again once following issue is fixed:
             # https://github.com/graphql-python/graphene-django/issues/177

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ django-postgres-extra==1.22
 djangorestframework==3.10.3
 django_simple_history==2.8.0
 graphene==2.1.8
-graphene-django==2.6.0
+graphene-django==2.7.1
 graphql-core==2.2.1
-graphql-relay==2.0.0
+graphql-relay==2.0.1
 idna==2.8
 minio==5.0.5
 psycopg2-binary==2.8.4


### PR DESCRIPTION
* Remove insignificant performance hack. Performance profiling is known to have a variance of 20% - 40%, only improvements of %50+ should be considered, especially when hacking the internals
of another library.

* Update to graphene v2.0.1 since graphene-django v2.7.1 depends on that version.

* Adapt to refactoring of DjangoConnectionField. We inject our version of
  connection_from_list, connection_from_list_slice.

Replaces #837