### PR TITLE
chore(release): remove semantic-release from pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,6 @@ jobs:
         - docker-compose exec caluma ./manage.py makemigrations --check --dry-run --no-input
         - docker-compose exec caluma pytest --no-cov-on-fail --cov --create-db -vv
         - docker-compose exec caluma reuse lint
-      after_success:
-        - git config --global user.name "semantic-release (via TravisCI)"
-        - git config --global user.email "semantic-release@travis"
-        - pip install python-semantic-release
-        - semantic-release publish
     - env:
         BUILD_TYPE=pipenv
         PIPENV_IGNORE_VIRTUALENVS=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,8 +68,3 @@ omit=
     caluma/wsgi.py
     caluma/caluma_metadata.py
 show_missing = True
-
-[semantic_release]
-version_variable=caluma/caluma_metadata.py:__version__
-branch=release
-upload_to_pypi=False


### PR DESCRIPTION
We had too much trouble with automatic releases not detecting breaking
changes. That's why we decided to go back to manual releasing and using
`python-semantic-release` just as support tool for writing release
notes.