### PR TITLE
chore: version bump to 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v5.1.0 (31 Jan 2020)
+
+### Feature
+
+* add hierarchical inspection classes (0d746594d9d14e23b7d90b359c8869b8d3ab7afc)
+  Useful for extension points and caluma-as-django-app
+
+### Fix
+
+* validation performance vastly improved (25570a9b220d773b5a1517bb4e0b40d27ed306f1)
+  form validation query count is roughly 10% of what it used to be
+
+
 # v5.0.0 (22 Jan 2020)
 
 

--- a/caluma/caluma_metadata.py
+++ b/caluma/caluma_metadata.py
@@ -2,4 +2,4 @@
 
 __title__ = "caluma"
 __description__ = "Caluma Service providing GraphQL API"
-__version__ = "5.0.0"
+__version__ = "5.1.0"


### PR DESCRIPTION
Note the features / fixes were marked as refactor/chore in git and
thus semantic-release didn't really want to create a new version.