### PR TITLE
fix(data_sources): fix validation of dynamic answers

### DIFF
--- a/caluma/caluma_data_source/data_source_handlers.py
+++ b/caluma/caluma_data_source/data_source_handlers.py
@@ -4,19 +4,13 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 from localized_fields.value import LocalizedValue
 
+from caluma.utils import is_iterable_and_no_string
+
 DataSource = namedtuple("DataSource", ["name", "info"])
 
 
 class DataSourceException(Exception):
     pass
-
-
-def is_iterable_and_no_string(value):
-    try:
-        iter(value)
-        return not isinstance(value, str)
-    except TypeError:
-        return False
 
 
 class Data:

--- a/caluma/caluma_data_source/data_sources.py
+++ b/caluma/caluma_data_source/data_sources.py
@@ -1,6 +1,7 @@
 import logging
 
 from caluma.caluma_form.models import DynamicOption
+from caluma.utils import is_iterable_and_no_string
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ class BaseDataSource:
     def validate_answer_value(self, value, document, question, info):
         for data in self.get_data(info):
             label = data
-            if isinstance(data, list):
+            if is_iterable_and_no_string(data):
                 label = data[-1]
                 data = data[0]
             if str(data) == value:

--- a/caluma/caluma_data_source/tests/data_sources.py
+++ b/caluma/caluma_data_source/tests/data_sources.py
@@ -12,9 +12,9 @@ class MyDataSource(BaseDataSource):
     def get_data(self, info):
         return [
             1,
-            5.5,
+            (5.5,),
             "sdkj",
-            ["value", "info"],
+            ("value", "info"),
             ["something"],
             [
                 "translated_value",

--- a/caluma/caluma_data_source/tests/test_data_source.py
+++ b/caluma/caluma_data_source/tests/test_data_source.py
@@ -69,9 +69,9 @@ def test_fetch_data_from_data_source(snapshot, schema_executor, data_source_sett
     snapshot.assert_match(result.data)
     assert cache.get("data_source_MyDataSource") == [
         1,
-        5.5,
+        (5.5,),
         "sdkj",
-        ["value", "info"],
+        ("value", "info"),
         ["something"],
         [
             "translated_value",

--- a/caluma/utils.py
+++ b/caluma/utils.py
@@ -1,0 +1,6 @@
+def is_iterable_and_no_string(value):
+    try:
+        iter(value)
+        return not isinstance(value, str)
+    except TypeError:
+        return False


### PR DESCRIPTION
The documentation states, not only lists are allowed inside `get_data()`
results, but also other iterables. This was not true.

This commit makes sure, that also tuples and other iterables are
correctly handled.