### PR TITLE
chore(schema): remove obsolete excludes

### DIFF
--- a/caluma/caluma_form/historical_schema.py
+++ b/caluma/caluma_form/historical_schema.py
@@ -61,7 +61,7 @@ class HistoricalAnswerConnection(CountableConnectionBase):
 class HistoricalIntegerAnswer(IntegerAnswer):
     class Meta:
         model = models.Answer.history.model
-        exclude = ("document", "documents", "file", "date")
+        exclude = ("document", "file", "date")
         use_connection = False
         interfaces = (HistoricalAnswer, graphene.Node)
 
@@ -69,7 +69,7 @@ class HistoricalIntegerAnswer(IntegerAnswer):
 class HistoricalFloatAnswer(FloatAnswer):
     class Meta:
         model = models.Answer.history.model
-        exclude = ("document", "documents", "file", "date")
+        exclude = ("document", "file", "date")
         use_connection = False
         interfaces = (HistoricalAnswer, graphene.Node)
 
@@ -77,7 +77,7 @@ class HistoricalFloatAnswer(FloatAnswer):
 class HistoricalDateAnswer(DateAnswer):
     class Meta:
         model = models.Answer.history.model
-        exclude = ("document", "documents", "file")
+        exclude = ("document", "file")
         use_connection = False
         interfaces = (HistoricalAnswer, graphene.Node)
 
@@ -85,7 +85,7 @@ class HistoricalDateAnswer(DateAnswer):
 class HistoricalStringAnswer(StringAnswer):
     class Meta:
         model = models.Answer.history.model
-        exclude = ("document", "documents", "file", "date")
+        exclude = ("document", "file", "date")
         use_connection = False
         interfaces = (HistoricalAnswer, graphene.Node)
 
@@ -93,7 +93,7 @@ class HistoricalStringAnswer(StringAnswer):
 class HistoricalListAnswer(ListAnswer):
     class Meta:
         model = models.Answer.history.model
-        exclude = ("document", "documents", "file", "date")
+        exclude = ("document", "file", "date")
         use_connection = False
         interfaces = (HistoricalAnswer, graphene.Node)
 
@@ -137,7 +137,7 @@ class HistoricalFileAnswer(FileAnswer):
 
     class Meta:
         model = models.Answer.history.model
-        exclude = ("document", "documents", "date")
+        exclude = ("document", "date")
         use_connection = False
         interfaces = (HistoricalAnswer, graphene.Node)
 
@@ -202,7 +202,7 @@ class HistoricalTableAnswer(TableAnswer):
 
     class Meta:
         model = models.Answer.history.model
-        exclude = ("documents", "file", "date")
+        exclude = ("file", "date")
         use_connection = False
         interfaces = (HistoricalAnswer, graphene.Node)
 

--- a/caluma/caluma_form/schema.py
+++ b/caluma/caluma_form/schema.py
@@ -462,6 +462,12 @@ class FileQuestion(QuestionQuerysetMixin, FormDjangoObjectType):
 
 
 class StaticQuestion(QuestionQuerysetMixin, FormDjangoObjectType):
+    is_required = QuestionJexl(
+        required=True,
+        description="Required expression is only evaluated when question is not hidden."
+        " This should not be used for `StaticQuestion`, because it can never be satisfied.",
+    )
+
     class Meta:
         model = models.Question
         exclude = (
@@ -472,7 +478,6 @@ class StaticQuestion(QuestionQuerysetMixin, FormDjangoObjectType):
             "row_form",
             "sub_form",
             "placeholder",
-            "is_required",
             "format_validators",
             "dynamicoption_set",
         )
@@ -661,7 +666,7 @@ class IntegerAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
     class Meta:
         model = models.Answer
-        exclude = ("document", "documents", "file", "date", "dynamicoption_set")
+        exclude = ("document", "documents", "file", "date")
         use_connection = False
         interfaces = (Answer, graphene.Node)
 
@@ -671,7 +676,7 @@ class FloatAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
     class Meta:
         model = models.Answer
-        exclude = ("document", "documents", "file", "date", "dynamicoption_set")
+        exclude = ("document", "documents", "file", "date")
         use_connection = False
         interfaces = (Answer, graphene.Node)
 
@@ -684,7 +689,7 @@ class DateAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
     class Meta:
         model = models.Answer
-        exclude = ("document", "documents", "file", "dynamicoption_set")
+        exclude = ("document", "documents", "file")
         use_connection = False
         interfaces = (Answer, graphene.Node)
 
@@ -694,7 +699,7 @@ class StringAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
     class Meta:
         model = models.Answer
-        exclude = ("document", "documents", "file", "date", "dynamicoption_set")
+        exclude = ("document", "documents", "file", "date")
         use_connection = False
         interfaces = (Answer, graphene.Node)
 
@@ -704,7 +709,7 @@ class ListAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
     class Meta:
         model = models.Answer
-        exclude = ("document", "documents", "file", "date", "dynamicoption_set")
+        exclude = ("document", "documents", "file", "date")
         use_connection = False
         interfaces = (Answer, graphene.Node)
 
@@ -738,7 +743,7 @@ class TableAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
     class Meta:
         model = models.Answer
-        exclude = ("documents", "file", "date", "dynamicoption_set")
+        exclude = ("documents", "file", "date")
         use_connection = False
         interfaces = (Answer, graphene.Node)
 
@@ -763,7 +768,7 @@ class FileAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
     class Meta:
         model = models.Answer
-        exclude = ("document", "documents", "date", "dynamicoption_set")
+        exclude = ("document", "documents", "date")
         use_connection = False
         interfaces = (Answer, graphene.Node)
 

--- a/caluma/caluma_workflow/schema.py
+++ b/caluma/caluma_workflow/schema.py
@@ -95,7 +95,7 @@ class TaskQuerysetMixin(object):
 class SimpleTask(TaskQuerysetMixin, DjangoObjectType):
     class Meta:
         model = models.Task
-        exclude = ("task_flows", "work_items", "task", "form")
+        exclude = ("task_flows", "work_items", "form")
         use_connection = False
         interfaces = (Task, relay.Node)
 
@@ -103,7 +103,7 @@ class SimpleTask(TaskQuerysetMixin, DjangoObjectType):
 class CompleteWorkflowFormTask(TaskQuerysetMixin, DjangoObjectType):
     class Meta:
         model = models.Task
-        exclude = ("task_flows", "work_items", "task", "form")
+        exclude = ("task_flows", "work_items", "form")
         use_connection = False
         interfaces = (Task, relay.Node)
 

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -1861,6 +1861,7 @@ type StaticQuestion implements Question, Node {
   createdByGroup: String
   slug: String!
   label: String!
+  isRequired: QuestionJexl!
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
@@ -1870,7 +1871,6 @@ type StaticQuestion implements Question, Node {
   staticContent: String
   dataSource: String
   id: ID!
-  isRequired: QuestionJexl!
 }
 
 enum Status {


### PR DESCRIPTION
This commit removes obsolete `exclude` entries for some types.

Additionally it adds some info about the `is_required` field on
`StaticQuestion`.