### PR TITLE
fix(validation): handle is_required correctly in nested questions

### DIFF
--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -299,7 +299,7 @@ class DocumentValidator:
                 elif question.type == Question.TYPE_TABLE:
                     # We need to validate presence in at least one row, but only
                     # if the table question is required.
-                    if not field.children():
+                    if is_required and not field.children():
                         raise CustomValidationError(
                             f"no rows in {question.slug}", slugs=[question.slug]
                         )
@@ -312,8 +312,7 @@ class DocumentValidator:
                         required_but_empty.append(question.slug)
 
             except CustomValidationError as exc:
-                if is_required:
-                    required_but_empty.extend(exc.slugs)
+                required_but_empty.extend(exc.slugs)
 
             except (jexl.QuestionMissing, exceptions.ValidationError):
                 raise


### PR DESCRIPTION
When a form question is not required, it should not swallow up any
requiredness errors from missing answers below it.

Also, a non-required table question should not lament missing rows
if it is not required itself.