### PR TITLE
docs(interface): add docs about usage of django apps and interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Caluma Service is the core part of the Caluma project providing a
 
 ### Installation
 
+NOTE: We recommend using Caluma as a dedicated service. However, it is possible to integrate
+Caluma into a django project. You can read about this [here](docs/django-apps.md).
+
 **Requirements**
 * docker
 * docker-compose
@@ -74,5 +77,6 @@ For further information on our license choice, you can read up on the [correspon
 * [Validation](docs/validation.md) - Validation of user input
 * [Extending Caluma](docs/extending.md) - Extensions: Data visibility and
   permissions
+* [Using Caluma as django apps](docs/django-apps.md)
 * [Maintainer's Handbook](docs/maintainers.md) - HOWTO for various maintainer's
   tasks

--- a/docs/django-apps.md
+++ b/docs/django-apps.md
@@ -1,0 +1,87 @@
+# Using Caluma as django apps
+
+## Disclaimer
+
+It is highly recommended to use Caluma as a dedicated service. However, there are usecases, where
+it might make sense to integrate Caluma into another django project.
+
+If you just want to get Caluma up and running, please see the documentation about [setting up
+the Caluma service](configuration.md).
+
+Please beware that Caluma only works with PostgreSQL, and requires the `psqlextra`
+backend to use the advanced features (such as JSON fields etc).
+
+## Installation
+
+Caluma is on PyPI, so you can just
+
+```shell
+pip install caluma
+```
+
+
+## Configuration
+
+### Installed apps
+
+Add the Caluma apps you want to use to your `INSTALLED_APPS`.
+
+Some notes about Caluma-internal dependencies:
+
+* `caluma_workflow` needs `caluma_form` to work correctly (as cases and work items point to documents)
+* `caluma_core` should always be installed when using Caluma (though, technically,
+  it would work without it, as core doesn't contain any models
+* `caluma_user` should always be added (same caveat as with core)
+
+```python
+INSTALLED_APPS = [
+    # ...
+    # Caluma and it's dependencies:
+    "caluma.caluma_core.apps.DefaultConfig",
+    "caluma.caluma_user.apps.DefaultConfig",
+    "caluma.caluma_form.apps.DefaultConfig",
+    "caluma.caluma_workflow.apps.DefaultConfig",
+    "caluma.caluma_data_source.apps.DefaultConfig",
+    "graphene_django",
+    "localized_fields",
+    "psqlextra",  # Caluma needs a PostgreSQL database using the psqlextra backend
+    "simple_history",
+    # ...
+]
+```
+
+### Settings
+
+Import the Caluma settings at the top of your `DJANGO_SETTINGS_MODULE`:
+
+```python
+from caluma.settings.caluma import *  # noqa
+```
+
+This will only load Caluma specific settings and no django specific ones (db, cache, etc.).
+
+Then you can configure caluma normally [using environment variables](configuration.md).
+
+
+### Database
+
+Caluma needs a PostgreSQL database using the `psqlextra` backend to use the advanced
+features (such as JSON fields etc).
+
+This is mandatory, that's why we tell you thrice.
+
+### Debug middleware
+
+It's recommended to add following lines to your settings file (after importing the caluma settings):
+
+```python
+# GraphQL
+if DEBUG:
+    GRAPHENE["MIDDLEWARE"].append("graphene_django.debug.DjangoDebugMiddleware")
+```
+
+
+## Supported interfaces
+
+See [interfaces](interfaces.md) for information about the officially supported API.
+

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1,0 +1,303 @@
+# Interfaces
+
+Here you find a list of interfaces we support and won't change without further notice.
+
+
+## Models
+
+We can't guarantee stability for whole models. However certain fields are considered stable.
+Changes in non-guaranteed fields won't receive prominent mention in release notes, for example,
+and won't trigger a major version bump (according to semver).
+
+For more information about a model and it's fields, please consult the source code.
+
+### General
+
+All models share a common set of fields:
+
+* `created_at`
+* `modified_at`
+* `created_by_user`
+* `created_by_group`
+* `history` --> manager for accessing historical records
+
+
+### caluma_form.models.Form
+This model contains the forms.
+
+#### Fields
+
+* `slug` / `pk`
+* `name`
+* `description`
+* `meta`
+* `is_published`
+* `is_archived`
+* `questions`
+* `source`
+
+
+### caluma_form.models.Question
+This model contains the questions.
+
+#### Fields
+
+* `slug` / `pk`
+* `label`
+* `type`
+* `is_required`
+* `is_hidden`
+* `is_archived`
+* `placeholder`
+* `info_text`
+* `static_content`
+* `configuration`
+* `meta`
+* `data_source`
+* `options`
+* `row_form`
+* `sub_form`
+* `source`
+* `format_validators`
+
+#### Properties
+
+* `min_length`
+* `max_length`
+* `max_value`
+* `min_value`
+
+
+### caluma_form.models.FormQuestion
+Intermediary table for the `Form` <--> `Question` m2m.
+
+#### Fields
+
+* `id` / `pk`
+* `form`
+* `question`
+* `sort`
+
+
+### caluma_form.models.Option
+This model contains the options used in choice and mutliple choice questions.
+
+#### Fields
+
+* `slug` / `pk`
+* `label`
+* `is_archived`
+* `meta`
+* `source`
+
+
+### caluma_form.models.QuestionOption
+Intermediary table for the `Question` <--> `Option` m2m.
+
+#### Fields
+
+* `id` / `pk`
+* `question`
+* `option`
+* `sort`
+
+
+### caluma_form.models.Document
+This model contains the documents.
+
+#### Fields
+
+* `id` / `pk`
+* `family`
+* `form`
+* `meta`
+
+
+### caluma_form.models.Answer
+This model contains the answers.
+
+#### Fields
+
+* `id` / `pk`
+* `question`
+* `value`
+* `meta`
+* `document`
+* `documents`
+* `date`
+* `file`
+
+
+### caluma_form.models.AnswerDocument
+Intermediary table for the `Answer` <--> `Document` m2m used in table answers.
+
+#### Fields
+
+* `id` / `pk`
+* `answer`
+* `document`
+* `sort`
+
+
+### caluma_form.models.File
+This model contains the file records used in file answers.
+
+#### Fields
+
+* `id` / `pk`
+* `name`
+
+#### Properties
+
+* `object_name`
+* `upload_url`
+* `download_url`
+* `metadata`
+
+
+### caluma_workflow.models.Task
+This model contains tasks.
+
+#### Fields
+
+* `slug` / `pk`
+* `name`
+* `description`
+* `type`
+* `meta`
+* `address_groups`
+* `is_archived`
+* `form`
+* `lead_time`
+* `is_multiple_instance`
+
+#### Methods
+
+* `calculate_deadline()`
+
+
+### caluma_workflow.models.Workflow
+This model contains workflows.
+
+#### Fields
+
+* `slug` / `pk`
+* `name`
+* `description`
+* `meta`
+* `is_published`
+* `is_archived`
+* `start_tasks`
+* `allow_all_forms`
+* `allow_forms`
+
+#### Properties
+
+* `flows`
+
+
+### caluma_workflow.models.Flow
+This model contains flows.
+
+#### Fields
+
+* `id` / `pk`
+* `next`
+
+
+### caluma_workflow.models.TaskFlow
+This model contains task flows.
+
+#### Fields
+
+* `id` / `pk`
+* `workflow`
+* `task`
+* `flow`
+
+
+### caluma_workflow.models.Case
+This model contains cases.
+
+#### Fields
+
+* `id` / `pk`
+* `closed_at`
+* `closed_by_user`
+* `closed_by_group`
+* `workflow`
+* `status`
+* `meta`
+* `document`
+
+
+### caluma_workflow.models.WorkItem
+This model contains work items.
+
+#### Fields
+
+* `id` / `pk`
+* `closed_at`
+* `closed_by_user`
+* `closed_by_group`
+* `deadline`
+* `task`
+* `status`
+* `meta`
+* `addressed_groups`
+* `assigned_users`
+* `case`
+* `child_case`
+* `document`
+
+
+### caluma_user.models.OIDCUser / caluma_user.models.AnonymousUser
+
+The user models are special in Caluma, as they are not stored in the database, but only
+available during the lifetime of a request.
+
+#### Fields
+
+* `claims`
+* `username`
+* `groups`
+* `token`
+* `is_authenticated`
+
+#### Properties
+
+* `group`
+
+
+## Schema
+
+All the schemas:
+
+* `caluma_data_source.schema`
+* `caluma_form.schema`
+* `caluma_workflow.schema`
+
+## Extensions base classes and decorators
+
+Further information about extensions and their utilities can be found [here](extending.md).
+
+For completeness, they are listed here:
+
+* `caluma_core.mutation.Mutation`
+* `caluma_core.permissions.AllowAny`
+* `caluma_core.permissions.BasePermission`
+* `caluma_core.permissions.object_permission_for`
+* `caluma_core.permissions.permission_for`
+* `caluma_core.validations.BaseValidation`
+* `caluma_core.validations.validation_for`
+* `caluma_core.visibilities.Any`
+* `caluma_core.visibilities.BaseVisibility`
+* `caluma_core.visibilities.filter_queryset_for`
+* `caluma_core.visibilities.Union`
+* `caluma_data_source.data_source.BaseDataSource`
+* `caluma_data_source.utils.data_source_cache`
+* `caluma_user.permissions.CreatedByGroup`
+* `caluma_user.permissions.IsAuthenticated`
+* `caluma_user.visibilities.Authenticated`
+* `caluma_user.visibilities.CreatedByGroup`
+* `caluma_workflow.visibilities.AddressedGroups`


### PR DESCRIPTION
This commit adds some documentation about

* using the caluma django apps inside an existing django project
* supported interfaces.

Related to #940
Closes #941