### PR TITLE
fix(pypi): fix loading of caluma settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV HOME=/home/caluma
 
 ENV PYTHONUNBUFFERED=1
 ENV APP_HOME=/app
-ENV DJANGO_SETTINGS_MODULE caluma.settings
+ENV DJANGO_SETTINGS_MODULE caluma.settings.django
 ENV UWSGI_INI /app/uwsgi.ini
 
 ARG REQUIREMENTS=requirements.txt

--- a/caluma/settings/__init__.py
+++ b/caluma/settings/__init__.py
@@ -1,1 +1,0 @@
-from .django import *  # noqa

--- a/caluma/wsgi.py
+++ b/caluma/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "caluma.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "caluma.settings.django")
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "caluma.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "caluma.settings.django")
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ line_length=88
 
 [tool:pytest]
 addopts = -n auto --reuse-db --randomly-seed=1521188766 --randomly-dont-reorganize
-DJANGO_SETTINGS_MODULE = caluma.settings
+DJANGO_SETTINGS_MODULE = caluma.settings.django
 env =
     META_FIELDS=test-key,foobar
     OIDC_USERINFO_ENDPOINT=mock://caluma.io/openid/userinfo


### PR DESCRIPTION
Because of the * import in `settings.__init__`, it's was not possible to
just load the caluma specific settings, without implicitly also loading
the django project settings.

This commit fixes that. The downside of this fix is, that the settings
module is not called `caluma.settings` anymore, but
`caluma.settings.django`.