### PR TITLE
chore(urls): move view and add urls.py to core

### DIFF
--- a/caluma/caluma_core/urls.py
+++ b/caluma/caluma_core/urls.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+from django.conf.urls import url
+
+from caluma.caluma_user.views import AuthenticationGraphQLView
+
+urlpatterns = [
+    url(r"", AuthenticationGraphQLView.as_view(graphiql=settings.DEBUG), name="graphql")
+]

--- a/caluma/caluma_user/views.py
+++ b/caluma/caluma_user/views.py
@@ -11,7 +11,7 @@ from django.utils.encoding import force_bytes, smart_text
 from graphene_django.views import GraphQLView, HttpError
 from rest_framework.authentication import get_authorization_header
 
-from . import models
+from caluma.caluma_user import models
 
 
 class HttpResponseUnauthorized(HttpResponse):

--- a/caluma/urls.py
+++ b/caluma/urls.py
@@ -1,12 +1,3 @@
-from django.conf import settings
-from django.conf.urls import url
+from django.conf.urls import include, url
 
-from .caluma_user.views import AuthenticationGraphQLView
-
-urlpatterns = [
-    url(
-        r"^graphql",
-        AuthenticationGraphQLView.as_view(graphiql=settings.DEBUG),
-        name="graphql",
-    )
-]
+urlpatterns = [url(r"^graphql", include("caluma.caluma_core.urls"))]

--- a/docs/django-apps.md
+++ b/docs/django-apps.md
@@ -80,6 +80,21 @@ if DEBUG:
 ```
 
 
+### urls.py
+
+Include the Caluma URLs (this example uses `graphql` as URL prefix):
+
+```python
+from django.conf.urls import include, url
+
+urlpatterns = [
+    # ...
+    url(r"^graphql", include("caluma.caluma_core.urls")),
+    # ...
+]
+```
+
+
 ## Supported interfaces
 
 See [interfaces](interfaces.md) for information about the officially supported API.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -277,6 +277,11 @@ All the schemas:
 * `caluma_form.schema`
 * `caluma_workflow.schema`
 
+## urls.py
+
+You can include the `graphql` endpoint into your `urls.py` from `caluma.caluma_core.urls`.
+
+
 ## Extensions base classes and decorators
 
 Further information about extensions and their utilities can be found [here](extending.md).


### PR DESCRIPTION
This commit moves the graphql view to the core app and renames it to
`CalumaGraphQLView`. Additionally it adds a `caluma_core.urls` that gets
included in the main `urls.py`.

This means third-party projects can include the caluma urls like this:

```python
from django.conf.urls import include, url

urlpatterns = [
    # ...
    url(r"", include("caluma.caluma_core.urls")),
    # ...
]
```