### PR TITLE
feat: Extend JEXL

### DIFF
--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -31,6 +31,12 @@ class Element:
     def children(self):  # pragma: no cover
         return []
 
+    def root(self):
+        parent = self.parent()
+        if parent:
+            return parent.root()
+        return self
+
     def get(self, name, default=None):
         out = getattr(self, name)
 

--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -31,6 +31,16 @@ class Element:
     def children(self):  # pragma: no cover
         return []
 
+    def get(self, name, default=None):
+        out = getattr(self, name)
+
+        # if a method is requested, execute it before continuing
+        if callable(out):
+            out = out()
+        if isinstance(out, Element):
+            return out
+        return str(out)
+
 
 class Field(Element):
     def __init__(self, document, form, question, answer=None, parent=None):

--- a/caluma/caluma_form/tests/test_jexl.py
+++ b/caluma/caluma_form/tests/test_jexl.py
@@ -159,9 +159,10 @@ def test_reference_missing_question(
 @pytest.mark.parametrize(
     "question,expr,expectation,features",
     [
-        ("sub_question", "structure.form == 'sub_form'", True, "subform"),
-        ("sub_question", "structure.parent.form == 'top_form'", True, "subform"),
-        ("column", "structure.parent.form == 'top_form'", True, "table"),
+        ("sub_question", "info.form == 'sub_form'", True, "subform"),
+        ("sub_question", "info.parent.form == 'top_form'", True, "subform"),
+        ("column", "info.parent.form == 'top_form'", True, "table"),
+        ("column", "info.root.form == 'top_form'", True, "table"),
     ],
 )
 def test_new_jexl_expressions(
@@ -202,7 +203,7 @@ def test_new_jexl_expressions(
         try:
             validator.validate(document, info)
             return True
-        except validators.CustomValidationError:
+        except validators.CustomValidationError:  # pragma: no cover
             return False
 
     assert do_check() == expectation

--- a/caluma/caluma_form/tests/test_jexl.py
+++ b/caluma/caluma_form/tests/test_jexl.py
@@ -154,3 +154,55 @@ def test_reference_missing_question(
 
     with pytest.raises(QuestionMissing):
         validator.validate(topdoc, info)
+
+
+@pytest.mark.parametrize(
+    "question,expr,expectation,features",
+    [
+        ("sub_question", "structure.form == 'sub_form'", True, "subform"),
+        ("sub_question", "structure.parent.form == 'top_form'", True, "subform"),
+        ("column", "structure.parent.form == 'top_form'", True, "table"),
+    ],
+)
+def test_new_jexl_expressions(
+    question, expr, expectation, features, info, form_and_document
+):
+    """Evaluate a JEXL expression in the context of a full document.
+
+    The given JEXL expression is evaluated in the context of the given
+    question within a structured document. The expression's value (boolean)
+    is then returned. The document is generated with the following structure:
+
+    * form: top_form
+       * question: top_question
+       * question: table [enabled by putting 'table' in features param]
+           * row_form: row_form
+               * question: column
+       * question: form_question [enabled by putting 'subform' in features param]
+           * sub_form: sub_form
+               * question: sub_question
+    """
+
+    use_table = "table" in features
+    use_subform = "subform" in features
+
+    form, document, questions, answers = form_and_document(
+        use_table=use_table, use_subform=use_subform
+    )
+
+    # expression test method: we delete an answer and set it's is_hidden
+    # to an expression to be tested. If the expression evaluates to True,
+    # we won't have a ValidationError.
+    answers[question].delete()
+    questions[question].is_hidden = expr
+    questions[question].save()
+
+    def do_check():
+        validator = validators.DocumentValidator()
+        try:
+            validator.validate(document, info)
+            return True
+        except validators.CustomValidationError:
+            return False
+
+    assert do_check() == expectation


### PR DESCRIPTION
Extend and cleanup JEXL evaluation, so more information can be accessed.

This is considered a proposal. Implementation details, especially regarding the "new" JEXL syntax now introduced, are open for discussion.

New with this PR, you'll have access to an `info` object in question JEXL expressions that provides some useful information:

  - `info.root.form` - Same as `form`, gives the root form's slug
  - `info.form` - The direct form where the question resides. Could be a row
    form if the question is within a table, or a FormQuestion's form, etc.
  - `info.parent.form` - The form above the current form. May be useful in
    deeply nested structures.

While we're at it, I've also started documenting the other things we have, such as the `form` variable and our custom transforms and operators. The idea is to build up a comprehensive JEXL guide that both frontend and backend may refer to for consistency.

I've also added a fixture to build a full document/form structure. This will be used to clean up some existing tests in a follow-up PR.