### PR TITLE
fix(jexl): answer transform shouldn't return value for hidden questions

### DIFF
--- a/caluma/caluma_form/jexl.py
+++ b/caluma/caluma_form/jexl.py
@@ -54,6 +54,8 @@ class QuestionJexl(JEXL):
         )
 
     def answer_transform(self, question):
+        if self.is_hidden(self._question(question)):
+            return None
         return self._structure.get_field(question).value()
 
     def validate(self, expression, **kwargs):


### PR DESCRIPTION
When a question is hidden, it's answer transform should not return a value,
even if an answer exists.