### PR TITLE
fix(graph*-3.0): only accepts integer or string as id

### DIFF
--- a/caluma/caluma_data_source/tests/test_data_source.py
+++ b/caluma/caluma_data_source/tests/test_data_source.py
@@ -238,7 +238,7 @@ def test_data_sources_stores_user(
     variables = {
         "input": {
             "question": question.slug,
-            "document": document.id,
+            "document": str(document.id),
             "value": "something",
         }
     }


### PR DESCRIPTION
#814 creates a lot of chicken and egg problems. I want to at least push simple fixes to caluma.

The graph*-3.0 projects try to validate all inputs and prevent all implicit conversion.