### PR TITLE
feat: make created_by_group settable

### DIFF
--- a/caluma/caluma_core/validations.py
+++ b/caluma/caluma_core/validations.py
@@ -31,7 +31,7 @@ class BaseValidation(object):
     A custom validation class could look like this:
     ```
     >>> from caluma.caluma_form.schema import SaveForm
-    ... from caluma.mutation import Mutation
+    ... from caluma.caluma_core.mutation import Mutation
     ... from rest_framework import exceptions
     ...
     ... class CustomValidation(BaseValidation):
@@ -42,8 +42,8 @@ class BaseValidation(object):
     ...
     ...     @validation_for(SaveForm)
     ...     def validate_save_form(self, mutation, data, info):
-    ...         if data['meta'] and info.context.group != 'admin':
-    ...           raise exceptions.ValidationException('May not change meta on form')
+    ...         if data['meta'] and 'admin' not in info.context.user.groups:
+    ...             raise exceptions.ValidationException('May not change meta on form')
     ...         return data
     """
 

--- a/caluma/caluma_user/models.py
+++ b/caluma/caluma_user/models.py
@@ -7,13 +7,10 @@ class BaseUser:  # pragma: no cover
     def __init__(self):
         self.username = None
         self.groups = []
+        self.group = None
         self.token = None
         self.claims = {}
         self.is_authenticated = False
-
-    @property
-    def group(self):
-        raise NotImplementedError
 
     def __getattribute__(self, name):
         if name in ["userinfo", "introspection"]:
@@ -29,10 +26,6 @@ class BaseUser:  # pragma: no cover
 
 
 class AnonymousUser(BaseUser):
-    @property
-    def group(self):
-        return None
-
     def __str__(self):
         return "AnonymousUser"
 
@@ -44,6 +37,7 @@ class OIDCUser(BaseUser):
         self.claims, self.claims_source = self._get_claims(userinfo, introspection)
         self.username = self.claims[settings.OIDC_USERNAME_CLAIM]
         self.groups = self.claims.get(settings.OIDC_GROUPS_CLAIM)
+        self.group = self.groups[0] if self.groups else None
         self.token = token
         self.is_authenticated = True
 
@@ -56,10 +50,6 @@ class OIDCUser(BaseUser):
         elif introspection is not None:
             result = (introspection, "introspection")
         return result
-
-    @property
-    def group(self):
-        return self.groups[0] if self.groups else None
 
     def __str__(self):
         return self.username


### PR DESCRIPTION
This commit simplifies manual setting of the `created_by_group` field
from within validations.

Before, in order to override the chosen group, one had to prepend it to
the list `OIDCUser.groups`. Now, one can just set the property:
`user.group = "foo"`.

Closes #614