### PR TITLE
Fix answer transform in table rows

### DIFF
--- a/caluma/caluma_form/tests/test_jexl.py
+++ b/caluma/caluma_form/tests/test_jexl.py
@@ -347,3 +347,37 @@ def test_answer_transform_on_hidden_question_types(
     )
 
     assert qj.is_hidden(questions["form_question"])
+
+
+def test_answer_transform_in_tables(info, form_and_document, form_question_factory):
+    # Bug test: When a JEXL expression references two answers, and one of them
+    # is hidden, the `answer` transform must return None for the hidden question
+    # to ensure correct evaluation.
+
+    form, document, questions, answers = form_and_document(
+        use_table=True, use_subform=False
+    )
+
+    table_question = questions["table_question"]
+
+    question_col1 = questions["column"]
+    question_col2 = form_question_factory(
+        form=table_question.row_form,
+        question__slug="column2",
+        question__is_required="'column'|answer == 5",
+    ).question
+
+    table_answer = answers["table_question"]
+
+    ans_doc_1 = table_answer.documents.first()
+    ans_doc_2 = table_answer.documents.create(form=table_question.row_form)
+
+    ans_row1_col1 = ans_doc_1.answers.get(question_id="column")
+    ans_row2_col1 = ans_doc_2.answers.create(question_id="column", value=5)
+
+    validator = validators.DocumentValidator()
+
+    # we expect this to fail, as in the second row, the 'column' answer is 5,
+    # so 'column2' should be required
+    with pytest.raises(validators.CustomValidationError):
+        validator.validate(document, info)


### PR DESCRIPTION
When evaluating a JEXL expression (is_required / is_hidden in questions),
we need to make sure that the context is set to the correct form /
field set.  Otherwise, we may end up with cross talk between table rows,
for example, as the answer transform would just fetch the first answer,
which may be from another row than what we're currently looking at.

While we're at it, also fix the caching behaviour during evaluation: The
cache key used must be local to the document of the answer, as otherwise
the value might be wrong for table answers (assume row 1 evaluated to
another result than row 2 would, then we wouldn't notice)