### PR TITLE
fix(validation): the requiredness check needs local context

### DIFF
--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -3,7 +3,7 @@ import weakref
 from functools import singledispatch
 from typing import Optional
 
-from .models import Question
+from .models import AnswerDocument, Question
 
 
 def object_local_memoise(method):
@@ -112,14 +112,15 @@ class RowField(Field):
         if not self.answer:
             return []  # pragma: no cover
 
+        rows = AnswerDocument.objects.filter(answer=self.answer).order_by("sort")
         return [
             FieldSet(
-                row_doc,
+                ans_doc.document,
                 self.question.row_form,
                 question=self.question,
                 parent=self.parent(),
             )
-            for row_doc in self.answer.documents.all()
+            for ans_doc in rows
         ]
 
 


### PR DESCRIPTION
When validating row documents, a question may be "visible" in another
row and hidden in the current one. However the `visible_questions` list
is global and is used mainly to speed up database access.

When evaluating requiredness, we also need to check if the question is
visible *locally*.

Follow-Up to #1036