### PR TITLE
feat(arch): move business logic for case creation to custom manager

### DIFF
--- a/caluma/caluma_workflow/managers.py
+++ b/caluma/caluma_workflow/managers.py
@@ -1,0 +1,92 @@
+from django.db.models import Manager
+
+from caluma.caluma_core.events import send_event
+from caluma.caluma_user.models import BaseUser
+
+from ..caluma_form.models import Document
+from . import events, models, utils
+
+
+class CaseManager(Manager):
+    def _validate(self, data):
+        form = data.get("form")
+        workflow = data.get("workflow")
+
+        if form:
+            if (
+                not workflow.allow_all_forms
+                and not workflow.allow_forms.filter(pk=form.pk).exists()
+            ):
+                raise Exception(
+                    f"Workflow {workflow.pk} does not allow to start case with form {form.pk}"
+                )
+
+        return data
+
+    def _pre_create(self, validated_data, user):
+        parent_work_item = validated_data.get("parent_work_item")
+        validated_data["status"] = models.Case.STATUS_RUNNING
+
+        form = validated_data.pop("form", None)
+        if form:
+            validated_data["document"] = Document.objects.create(
+                form=form, created_by_user=user.username, created_by_group=user.group
+            )
+
+        if parent_work_item:
+            case = parent_work_item.case
+            while hasattr(case, "parent_work_item"):
+                case = case.parent_work_item.case
+            validated_data["family"] = case
+
+        return validated_data
+
+    def _post_create(self, case, user, parent_work_item):
+        # Django doesn't save reverse one-to-one relationships automatically:
+        # https://code.djangoproject.com/ticket/18638
+        if parent_work_item:
+            parent_work_item.child_case = case
+            parent_work_item.save()
+
+        workflow = case.workflow
+        tasks = workflow.start_tasks.all()
+
+        work_items = utils.bulk_create_work_items(tasks, case, user)
+
+        send_event(events.created_case, sender="case_post_create", case=case)
+        for work_item in work_items:  # pragma: no cover
+            send_event(
+                events.created_work_item, sender="case_post_create", work_item=work_item
+            )
+
+        return case
+
+    def start(self, *args, **kwargs):
+        """
+        Start a case of a given workflow (just like `saveCase`).
+
+        Similar to Case.objects.create(), but with the same business logic as used in
+        the `saveCase` mutation.
+
+        All model relationships must be passed as resolved instances instead of primary keys.
+
+        Usage example:
+        ```py
+        Case.objects.start(
+            workflow=Workflow.objects.get(pk="my-wf"),
+            form=Form.objects.get(pk="my-form")),
+            user=AnonymousUser()
+        )
+        ```
+        """
+        user = kwargs.pop("user", None)
+
+        assert isinstance(
+            user, BaseUser
+        ), "`user` argument is required and must be instance of OIDCUser or AnonymousUser"
+
+        validated_data = self._pre_create(self._validate(kwargs), user)
+
+        case = self.create(**kwargs)
+
+        return self._post_create(case, user, validated_data.get("parent_work_item"))

--- a/caluma/caluma_workflow/models.py
+++ b/caluma/caluma_workflow/models.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from localized_fields.fields import LocalizedField
 
 from ..caluma_core.models import ChoicesCharField, SlugModel, UUIDModel
+from . import managers
 
 
 class Task(SlugModel):
@@ -107,6 +108,8 @@ class TaskFlow(UUIDModel):
 
 
 class Case(UUIDModel):
+    objects = managers.CaseManager()
+
     STATUS_RUNNING = "running"
     STATUS_COMPLETED = "completed"
     STATUS_CANCELED = "canceled"

--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -8,66 +8,8 @@ from caluma.caluma_core.events import SendEventSerializerMixin
 
 from ..caluma_core import serializers
 from ..caluma_form.models import Document, Form
-from . import events, models, validators
+from . import events, models, utils, validators
 from .jexl import FlowJexl, GroupJexl
-
-
-def get_group_jexl_structure(work_item_created_by_group, case, prev_work_item=None):
-    return {
-        "case": {"created_by_group": case.created_by_group},
-        "work_item": {"created_by_group": work_item_created_by_group},
-        "prev_work_item": {
-            "controlling_groups": prev_work_item.controlling_groups
-            if prev_work_item
-            else None
-        },
-    }
-
-
-def get_jexl_groups(jexl, case, work_item_created_by_group, prev_work_item=None):
-    context = get_group_jexl_structure(work_item_created_by_group, case, prev_work_item)
-    if jexl:
-        return GroupJexl(validation_context=context).evaluate(jexl)
-    return []
-
-
-def bulk_create_work_items(tasks, case, user, prev_work_item=None):
-    work_items = []
-    for task in tasks:
-        controlling_groups = get_jexl_groups(
-            task.control_groups,
-            case,
-            user.group,
-            prev_work_item if prev_work_item else None,
-        )
-        addressed_groups = [
-            get_jexl_groups(
-                task.address_groups,
-                case,
-                user.group,
-                prev_work_item if prev_work_item else None,
-            )
-        ]
-        if task.is_multiple_instance:
-            addressed_groups = [[x] for x in addressed_groups[0]]
-
-        for groups in addressed_groups:
-            work_items.append(
-                models.WorkItem(
-                    addressed_groups=groups,
-                    controlling_groups=controlling_groups,
-                    task_id=task.pk,
-                    deadline=task.calculate_deadline(),
-                    document=Document.objects.create_document_for_task(task, user),
-                    case=case,
-                    status=models.WorkItem.STATUS_READY,
-                    created_by_user=user.username,
-                    created_by_group=user.group,
-                )
-            )
-
-    bulk_create_with_history(work_items, models.WorkItem)
-    return work_items
 
 
 class FlowJexlField(serializers.JexlField):
@@ -229,56 +171,24 @@ class CaseSerializer(SendEventSerializerMixin, serializers.ModelSerializer):
     )
 
     def validate(self, data):
-        form = data.get("form")
-        workflow = data["workflow"]
-
-        if form:
-            if (
-                not workflow.allow_all_forms
-                and not workflow.allow_forms.filter(pk=form.pk).exists()
-            ):
-                raise exceptions.ValidationError(
-                    f"Workflow {workflow.pk} does not allow to start case with form {form.pk}"
-                )
+        try:
+            data = models.Case.objects._validate(data)
+        except Exception as e:
+            raise exceptions.ValidationError(str(e))
 
         return super().validate(data)
 
     @transaction.atomic
     def create(self, validated_data):
         user = self.context["request"].user
-        parent_work_item = validated_data.get("parent_work_item")
-        validated_data["status"] = models.Case.STATUS_RUNNING
 
-        form = validated_data.pop("form", None)
-        if form:
-            validated_data["document"] = Document.objects.create(
-                form=form, created_by_user=user.username, created_by_group=user.group
-            )
+        validated_data = models.Case.objects._pre_create(validated_data, user)
 
-        if parent_work_item:
-            case = parent_work_item.case
-            while hasattr(case, "parent_work_item"):
-                case = case.parent_work_item.case
-            validated_data["family"] = case
+        case = super().create(validated_data)
 
-        instance = super().create(validated_data)
-
-        # Django doesn't save reverse one-to-one relationships automatically:
-        # https://code.djangoproject.com/ticket/18638
-        if parent_work_item:
-            parent_work_item.child_case = instance
-            parent_work_item.save()
-
-        workflow = instance.workflow
-        tasks = workflow.start_tasks.all()
-
-        work_items = bulk_create_work_items(tasks, instance, user)
-
-        self.send_event(events.created_case, case=instance)
-        for work_item in work_items:  # pragma: no cover
-            self.send_event(events.created_work_item, work_item=work_item)
-
-        return instance
+        return models.Case.objects._post_create(
+            case, user, validated_data.get("parent_work_item")
+        )
 
     class Meta:
         model = models.Case
@@ -403,7 +313,7 @@ class CompleteWorkItemSerializer(SendEventSerializerMixin, serializers.ModelSeri
 
             tasks = models.Task.objects.filter(pk__in=result)
 
-            work_items = bulk_create_work_items(tasks, case, user, instance)
+            work_items = utils.bulk_create_work_items(tasks, case, user, instance)
 
             for work_item in work_items:  # pragma: no cover
                 self.send_event(events.created_work_item, work_item=work_item)
@@ -519,12 +429,16 @@ class CreateWorkItemSerializer(SendEventSerializerMixin, serializers.ModelSerial
         data["status"] = models.WorkItem.STATUS_READY
 
         if "controlling_groups" not in data:
-            controlling_groups = get_jexl_groups(task.control_groups, case, user.group)
+            controlling_groups = utils.get_jexl_groups(
+                task.control_groups, case, user.group
+            )
             if controlling_groups is not None:
                 data["controlling_groups"] = controlling_groups
 
         if "addressed_groups" not in data:
-            addressed_groups = get_jexl_groups(task.address_groups, case, user.group)
+            addressed_groups = utils.get_jexl_groups(
+                task.address_groups, case, user.group
+            )
             if addressed_groups is not None:
                 data["addressed_groups"] = addressed_groups
 

--- a/caluma/caluma_workflow/tests/test_case.py
+++ b/caluma/caluma_workflow/tests/test_case.py
@@ -567,3 +567,24 @@ def test_work_item_document(
     assert not result.errors
 
     assert len(result.data["allCases"]["edges"]) == result_count
+
+
+@pytest.mark.parametrize("task__lead_time", [100, None])
+@pytest.mark.parametrize("task__address_groups", ['["group-name"]|groups', None])
+def test_start_case_manager(
+    db,
+    workflow,
+    workflow_allow_forms,
+    workflow_start_tasks,
+    work_item,
+    task,
+    form,
+    case,
+    admin_user,
+):
+    case = models.Case.objects.start(workflow=workflow, form=form, user=admin_user)
+    work_item = case.work_items.get(task_id=task.pk)
+
+    assert case.document.form == form
+    assert work_item.document.form == form
+    assert work_item.status == models.WorkItem.STATUS_READY

--- a/caluma/caluma_workflow/utils.py
+++ b/caluma/caluma_workflow/utils.py
@@ -1,0 +1,63 @@
+from simple_history.utils import bulk_create_with_history
+
+from ..caluma_form.models import Document
+from . import models
+from .jexl import GroupJexl
+
+
+def get_group_jexl_structure(work_item_created_by_group, case, prev_work_item=None):
+    return {
+        "case": {"created_by_group": case.created_by_group},
+        "work_item": {"created_by_group": work_item_created_by_group},
+        "prev_work_item": {
+            "controlling_groups": prev_work_item.controlling_groups
+            if prev_work_item
+            else None
+        },
+    }
+
+
+def get_jexl_groups(jexl, case, work_item_created_by_group, prev_work_item=None):
+    context = get_group_jexl_structure(work_item_created_by_group, case, prev_work_item)
+    if jexl:
+        return GroupJexl(validation_context=context).evaluate(jexl)
+    return []
+
+
+def bulk_create_work_items(tasks, case, user, prev_work_item=None):
+    work_items = []
+    for task in tasks:
+        controlling_groups = get_jexl_groups(
+            task.control_groups,
+            case,
+            user.group,
+            prev_work_item if prev_work_item else None,
+        )
+        addressed_groups = [
+            get_jexl_groups(
+                task.address_groups,
+                case,
+                user.group,
+                prev_work_item if prev_work_item else None,
+            )
+        ]
+        if task.is_multiple_instance:
+            addressed_groups = [[x] for x in addressed_groups[0]]
+
+        for groups in addressed_groups:
+            work_items.append(
+                models.WorkItem(
+                    addressed_groups=groups,
+                    controlling_groups=controlling_groups,
+                    task_id=task.pk,
+                    deadline=task.calculate_deadline(),
+                    document=Document.objects.create_document_for_task(task, user),
+                    case=case,
+                    status=models.WorkItem.STATUS_READY,
+                    created_by_user=user.username,
+                    created_by_group=user.group,
+                )
+            )
+
+    bulk_create_with_history(work_items, models.WorkItem)
+    return work_items


### PR DESCRIPTION
When caluma is used as a django app, it is often desireable to trigger specific mutations by calling python APIs directly (instead of the GraphQL API). This shows how we could go about offering a Python API for starting cases that mirrors what the GraphQL API offers via `saveCase`: We extract the business logic out of the serializer into a custom manager.