### PR TITLE
feat(architecture): expose start case logic in public python api module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ A collaborative form editing service.
 
 Caluma Service is the core part of the Caluma project providing a
 [GraphQL API](https://graphql.org/). For a big picture and to learn what Caluma
- does for you, have a look at [caluma.io](https://caluma.io)
-
-
+does for you, have a look at [caluma.io](https://caluma.io)
 
 ## Getting started
 
@@ -24,11 +22,11 @@ NOTE: We recommend using Caluma as a dedicated service. However, it is possible 
 Caluma into a django project. You can read about this [here](docs/django-apps.md).
 
 **Requirements**
-* docker
-* docker-compose
+
+- docker
+- docker-compose
 
 After installing and configuring those, download [docker-compose.yml](https://github.com/projectcaluma/caluma/blob/master/docker-compose.yml) and run the following command:
-
 
 ```bash
 docker-compose up -d
@@ -56,7 +54,6 @@ This enables [Django Debug Middleware](https://docs.graphene-python.org/projects
 For profiling you can use `./manage.py runprofileserver`. See [docker-compose.override.yml](docker-compose.override.yml) for
 an example.
 
-
 ## License
 
 Code released under the [GPL-3.0-or-later license](LICENSE).
@@ -65,20 +62,21 @@ For further information on our license choice, you can read up on the [correspon
 
 ## Further reading
 
-* [Installation & Configuration](docs/configuration.md) - Get started installing
+- [Installation & Configuration](docs/configuration.md) - Get started installing
   Caluma in a production context
-* [Contributing](CONTRIBUTING.md) - If you want to help us, here's
+- [Contributing](CONTRIBUTING.md) - If you want to help us, here's
   how to start with your first contribution.
-* [Caluma Guide](docs/guide.md) - How to get up and running with Caluma
-* [Workflow Concepts](docs/workflow-concepts.md) - How to use caluma workflows
-* [Historical Records](docs/historical-records.md) - Undo and audit trail
+- [Caluma Guide](docs/guide.md) - How to get up and running with Caluma
+- [Workflow Concepts](docs/workflow-concepts.md) - How to use caluma workflows
+- [Historical Records](docs/historical-records.md) - Undo and audit trail
   functionality
-* [GraphQL](docs/graphql.md) - Further information on how to use the GraphQL
+- [GraphQL](docs/graphql.md) - Further information on how to use the GraphQL
   interface
-* [Validation](docs/validation.md) - Validation of user input
-* [Extending Caluma](docs/extending.md) - Extensions: Data visibility and
+- [Validation](docs/validation.md) - Validation of user input
+- [Extending Caluma](docs/extending.md) - Extensions: Data visibility and
   permissions
-* [Caluma Events](docs/events.md) - Reacting upon Caluma Events
-* [Using Caluma as django apps](docs/django-apps.md)
-* [Maintainer's Handbook](docs/maintainers.md) - HOWTO for various maintainer's
+- [Caluma Events](docs/events.md) - Reacting upon Caluma Events
+- [Using Caluma as django apps](docs/django-apps.md)
+- [Interfaces](docs/interfaces.md)
+- [Maintainer's Handbook](docs/maintainers.md) - HOWTO for various maintainer's
   tasks

--- a/caluma/caluma_workflow/api.py
+++ b/caluma/caluma_workflow/api.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+from caluma.caluma_form.models import Form
+from caluma.caluma_user.models import BaseUser
+
+from . import domain_logic, models
+
+
+def start_case(
+    workflow: models.Workflow,
+    user: BaseUser,
+    form: Optional[Form] = None,
+    parent_work_item: Optional[models.WorkItem] = None,
+    **kwargs
+) -> models.Case:
+    """
+    Start a case of a given workflow (just like `saveCase`).
+
+    Similar to Case.objects.create(), but with the same business logic as
+    used in the `saveCase` mutation.
+
+    Usage example:
+    ```py
+    start_case(
+        workflow=Workflow.objects.get(pk="my-wf"),
+        form=Form.objects.get(pk="my-form")),
+        user=AnonymousUser()
+    )
+    ```
+    """
+    data = {"workflow": workflow, "form": form, "parent_work_item": parent_work_item}
+
+    data.update(kwargs)
+
+    validated_data = domain_logic.StartCaseLogic.pre_start(
+        domain_logic.StartCaseLogic.validate_for_start(data), user
+    )
+
+    case = models.Case.objects.create(**validated_data)
+
+    return domain_logic.StartCaseLogic.post_start(case, user, parent_work_item)

--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -1,0 +1,74 @@
+from django.core.exceptions import ValidationError
+
+from caluma.caluma_core.events import send_event
+
+from ..caluma_form.models import Document
+from . import events, models, utils
+
+
+class StartCaseLogic:
+    """
+    Shared domain logic for starting cases.
+
+    Used in the `saveCase` mutation and in the `start_case` API. The logic
+    for case creation is split in three parts (`validate_for_start`,
+    `pre_start` and `post_start`) so that in between the appropriate create
+    method can be called (`super().create(...)` for the serializer and
+    `Case.objects.create(...) for the python API`).
+    """
+
+    @staticmethod
+    def validate_for_start(data):
+        form = data.get("form")
+        workflow = data.get("workflow")
+
+        if form:
+            if (
+                not workflow.allow_all_forms
+                and not workflow.allow_forms.filter(pk=form.pk).exists()
+            ):
+                raise ValidationError(
+                    f"Workflow {workflow.pk} does not allow to start case with form {form.pk}"
+                )
+
+        return data
+
+    @staticmethod
+    def pre_start(validated_data, user):
+        parent_work_item = validated_data.get("parent_work_item")
+        validated_data["status"] = models.Case.STATUS_RUNNING
+
+        form = validated_data.pop("form", None)
+        if form:
+            validated_data["document"] = Document.objects.create(
+                form=form, created_by_user=user.username, created_by_group=user.group
+            )
+
+        if parent_work_item:
+            case = parent_work_item.case
+            while hasattr(case, "parent_work_item"):
+                case = case.parent_work_item.case
+            validated_data["family"] = case
+
+        return validated_data
+
+    @staticmethod
+    def post_start(case, user, parent_work_item):
+        # Django doesn't save reverse one-to-one relationships automatically:
+        # https://code.djangoproject.com/ticket/18638
+        if parent_work_item:
+            parent_work_item.child_case = case
+            parent_work_item.save()
+
+        workflow = case.workflow
+        tasks = workflow.start_tasks.all()
+
+        work_items = utils.bulk_create_work_items(tasks, case, user)
+
+        send_event(events.created_case, sender="case_post_create", case=case)
+        for work_item in work_items:  # pragma: no cover
+            send_event(
+                events.created_work_item, sender="case_post_create", work_item=work_item
+            )
+
+        return case

--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils import timezone
 from rest_framework import exceptions
@@ -8,66 +9,8 @@ from caluma.caluma_core.events import SendEventSerializerMixin
 
 from ..caluma_core import serializers
 from ..caluma_form.models import Document, Form
-from . import events, models, validators
+from . import domain_logic, events, models, utils, validators
 from .jexl import FlowJexl, GroupJexl
-
-
-def get_group_jexl_structure(work_item_created_by_group, case, prev_work_item=None):
-    return {
-        "case": {"created_by_group": case.created_by_group},
-        "work_item": {"created_by_group": work_item_created_by_group},
-        "prev_work_item": {
-            "controlling_groups": prev_work_item.controlling_groups
-            if prev_work_item
-            else None
-        },
-    }
-
-
-def get_jexl_groups(jexl, case, work_item_created_by_group, prev_work_item=None):
-    context = get_group_jexl_structure(work_item_created_by_group, case, prev_work_item)
-    if jexl:
-        return GroupJexl(validation_context=context).evaluate(jexl)
-    return []
-
-
-def bulk_create_work_items(tasks, case, user, prev_work_item=None):
-    work_items = []
-    for task in tasks:
-        controlling_groups = get_jexl_groups(
-            task.control_groups,
-            case,
-            user.group,
-            prev_work_item if prev_work_item else None,
-        )
-        addressed_groups = [
-            get_jexl_groups(
-                task.address_groups,
-                case,
-                user.group,
-                prev_work_item if prev_work_item else None,
-            )
-        ]
-        if task.is_multiple_instance:
-            addressed_groups = [[x] for x in addressed_groups[0]]
-
-        for groups in addressed_groups:
-            work_items.append(
-                models.WorkItem(
-                    addressed_groups=groups,
-                    controlling_groups=controlling_groups,
-                    task_id=task.pk,
-                    deadline=task.calculate_deadline(),
-                    document=Document.objects.create_document_for_task(task, user),
-                    case=case,
-                    status=models.WorkItem.STATUS_READY,
-                    created_by_user=user.username,
-                    created_by_group=user.group,
-                )
-            )
-
-    bulk_create_with_history(work_items, models.WorkItem)
-    return work_items
 
 
 class FlowJexlField(serializers.JexlField):
@@ -229,56 +172,24 @@ class CaseSerializer(SendEventSerializerMixin, serializers.ModelSerializer):
     )
 
     def validate(self, data):
-        form = data.get("form")
-        workflow = data["workflow"]
-
-        if form:
-            if (
-                not workflow.allow_all_forms
-                and not workflow.allow_forms.filter(pk=form.pk).exists()
-            ):
-                raise exceptions.ValidationError(
-                    f"Workflow {workflow.pk} does not allow to start case with form {form.pk}"
-                )
+        try:
+            data = domain_logic.StartCaseLogic.validate_for_start(data)
+        except ValidationError as e:
+            raise exceptions.ValidationError(str(e))
 
         return super().validate(data)
 
     @transaction.atomic
     def create(self, validated_data):
         user = self.context["request"].user
-        parent_work_item = validated_data.get("parent_work_item")
-        validated_data["status"] = models.Case.STATUS_RUNNING
 
-        form = validated_data.pop("form", None)
-        if form:
-            validated_data["document"] = Document.objects.create(
-                form=form, created_by_user=user.username, created_by_group=user.group
-            )
+        validated_data = domain_logic.StartCaseLogic.pre_start(validated_data, user)
 
-        if parent_work_item:
-            case = parent_work_item.case
-            while hasattr(case, "parent_work_item"):
-                case = case.parent_work_item.case
-            validated_data["family"] = case
+        case = super().create(validated_data)
 
-        instance = super().create(validated_data)
-
-        # Django doesn't save reverse one-to-one relationships automatically:
-        # https://code.djangoproject.com/ticket/18638
-        if parent_work_item:
-            parent_work_item.child_case = instance
-            parent_work_item.save()
-
-        workflow = instance.workflow
-        tasks = workflow.start_tasks.all()
-
-        work_items = bulk_create_work_items(tasks, instance, user)
-
-        self.send_event(events.created_case, case=instance)
-        for work_item in work_items:  # pragma: no cover
-            self.send_event(events.created_work_item, work_item=work_item)
-
-        return instance
+        return domain_logic.StartCaseLogic.post_start(
+            case, user, validated_data.get("parent_work_item")
+        )
 
     class Meta:
         model = models.Case
@@ -403,7 +314,7 @@ class CompleteWorkItemSerializer(SendEventSerializerMixin, serializers.ModelSeri
 
             tasks = models.Task.objects.filter(pk__in=result)
 
-            work_items = bulk_create_work_items(tasks, case, user, instance)
+            work_items = utils.bulk_create_work_items(tasks, case, user, instance)
 
             for work_item in work_items:  # pragma: no cover
                 self.send_event(events.created_work_item, work_item=work_item)
@@ -519,12 +430,16 @@ class CreateWorkItemSerializer(SendEventSerializerMixin, serializers.ModelSerial
         data["status"] = models.WorkItem.STATUS_READY
 
         if "controlling_groups" not in data:
-            controlling_groups = get_jexl_groups(task.control_groups, case, user.group)
+            controlling_groups = utils.get_jexl_groups(
+                task.control_groups, case, user.group
+            )
             if controlling_groups is not None:
                 data["controlling_groups"] = controlling_groups
 
         if "addressed_groups" not in data:
-            addressed_groups = get_jexl_groups(task.address_groups, case, user.group)
+            addressed_groups = utils.get_jexl_groups(
+                task.address_groups, case, user.group
+            )
             if addressed_groups is not None:
                 data["addressed_groups"] = addressed_groups
 

--- a/caluma/caluma_workflow/tests/test_case.py
+++ b/caluma/caluma_workflow/tests/test_case.py
@@ -3,7 +3,7 @@ from graphql_relay import to_global_id
 
 from ...caluma_core.relay import extract_global_id
 from ...caluma_form.models import Question
-from .. import models
+from .. import api, models
 
 
 @pytest.mark.parametrize(
@@ -567,3 +567,24 @@ def test_work_item_document(
     assert not result.errors
 
     assert len(result.data["allCases"]["edges"]) == result_count
+
+
+@pytest.mark.parametrize("task__lead_time", [100, None])
+@pytest.mark.parametrize("task__address_groups", ['["group-name"]|groups', None])
+def test_api_start_case(
+    db,
+    workflow,
+    workflow_allow_forms,
+    workflow_start_tasks,
+    work_item,
+    task,
+    form,
+    case,
+    admin_user,
+):
+    case = api.start_case(workflow=workflow, form=form, user=admin_user)
+    work_item = case.work_items.get(task_id=task.pk)
+
+    assert case.document.form == form
+    assert work_item.document.form == form
+    assert work_item.status == models.WorkItem.STATUS_READY

--- a/caluma/caluma_workflow/utils.py
+++ b/caluma/caluma_workflow/utils.py
@@ -1,0 +1,63 @@
+from simple_history.utils import bulk_create_with_history
+
+from ..caluma_form.models import Document
+from . import models
+from .jexl import GroupJexl
+
+
+def get_group_jexl_structure(work_item_created_by_group, case, prev_work_item=None):
+    return {
+        "case": {"created_by_group": case.created_by_group},
+        "work_item": {"created_by_group": work_item_created_by_group},
+        "prev_work_item": {
+            "controlling_groups": prev_work_item.controlling_groups
+            if prev_work_item
+            else None
+        },
+    }
+
+
+def get_jexl_groups(jexl, case, work_item_created_by_group, prev_work_item=None):
+    context = get_group_jexl_structure(work_item_created_by_group, case, prev_work_item)
+    if jexl:
+        return GroupJexl(validation_context=context).evaluate(jexl)
+    return []
+
+
+def bulk_create_work_items(tasks, case, user, prev_work_item=None):
+    work_items = []
+    for task in tasks:
+        controlling_groups = get_jexl_groups(
+            task.control_groups,
+            case,
+            user.group,
+            prev_work_item if prev_work_item else None,
+        )
+        addressed_groups = [
+            get_jexl_groups(
+                task.address_groups,
+                case,
+                user.group,
+                prev_work_item if prev_work_item else None,
+            )
+        ]
+        if task.is_multiple_instance:
+            addressed_groups = [[x] for x in addressed_groups[0]]
+
+        for groups in addressed_groups:
+            work_items.append(
+                models.WorkItem(
+                    addressed_groups=groups,
+                    controlling_groups=controlling_groups,
+                    task_id=task.pk,
+                    deadline=task.calculate_deadline(),
+                    document=Document.objects.create_document_for_task(task, user),
+                    case=case,
+                    status=models.WorkItem.STATUS_READY,
+                    created_by_user=user.username,
+                    created_by_group=user.group,
+                )
+            )
+
+    bulk_create_with_history(work_items, models.WorkItem)
+    return work_items

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -6,8 +6,8 @@ Here you find a list of interfaces we support and won't change without further n
 
 The `info` object holds the resolver info.
 
-* `info.context` holds the [http request](https://docs.djangoproject.com/en/1.11/ref/request-response/#httprequest-objects)
-* `info.context.user` holds the `User`
+- `info.context` holds the [http request](https://docs.djangoproject.com/en/1.11/ref/request-response/#httprequest-objects)
+- `info.context.user` holds the `User`
 
 ## Models
 
@@ -21,243 +21,242 @@ For more information about a model and it's fields, please consult the source co
 
 All models share a common set of fields:
 
-* `created_at`
-* `modified_at`
-* `created_by_user`
-* `created_by_group`
-* `history` --> manager for accessing historical records
-
+- `created_at`
+- `modified_at`
+- `created_by_user`
+- `created_by_group`
+- `history` --> manager for accessing historical records
 
 ### caluma_form.models.Form
+
 This model contains the forms.
 
 #### Fields
 
-* `slug` / `pk`
-* `name`
-* `description`
-* `meta`
-* `is_published`
-* `is_archived`
-* `questions`
-* `source`
-
+- `slug` / `pk`
+- `name`
+- `description`
+- `meta`
+- `is_published`
+- `is_archived`
+- `questions`
+- `source`
 
 ### caluma_form.models.Question
+
 This model contains the questions.
 
 #### Fields
 
-* `slug` / `pk`
-* `label`
-* `type`
-* `is_required`
-* `is_hidden`
-* `is_archived`
-* `placeholder`
-* `info_text`
-* `static_content`
-* `configuration`
-* `meta`
-* `data_source`
-* `options`
-* `row_form`
-* `sub_form`
-* `source`
-* `format_validators`
+- `slug` / `pk`
+- `label`
+- `type`
+- `is_required`
+- `is_hidden`
+- `is_archived`
+- `placeholder`
+- `info_text`
+- `static_content`
+- `configuration`
+- `meta`
+- `data_source`
+- `options`
+- `row_form`
+- `sub_form`
+- `source`
+- `format_validators`
 
 #### Properties
 
-* `min_length`
-* `max_length`
-* `max_value`
-* `min_value`
-
+- `min_length`
+- `max_length`
+- `max_value`
+- `min_value`
 
 ### caluma_form.models.FormQuestion
+
 Intermediary table for the `Form` <--> `Question` m2m.
 
 #### Fields
 
-* `id` / `pk`
-* `form`
-* `question`
-* `sort`
-
+- `id` / `pk`
+- `form`
+- `question`
+- `sort`
 
 ### caluma_form.models.Option
+
 This model contains the options used in choice and mutliple choice questions.
 
 #### Fields
 
-* `slug` / `pk`
-* `label`
-* `is_archived`
-* `meta`
-* `source`
-
+- `slug` / `pk`
+- `label`
+- `is_archived`
+- `meta`
+- `source`
 
 ### caluma_form.models.QuestionOption
+
 Intermediary table for the `Question` <--> `Option` m2m.
 
 #### Fields
 
-* `id` / `pk`
-* `question`
-* `option`
-* `sort`
-
+- `id` / `pk`
+- `question`
+- `option`
+- `sort`
 
 ### caluma_form.models.Document
+
 This model contains the documents.
 
 #### Fields
 
-* `id` / `pk`
-* `family`
-* `form`
-* `meta`
-
+- `id` / `pk`
+- `family`
+- `form`
+- `meta`
 
 ### caluma_form.models.Answer
+
 This model contains the answers.
 
 #### Fields
 
-* `id` / `pk`
-* `question`
-* `value`
-* `meta`
-* `document`
-* `documents`
-* `date`
-* `file`
-
+- `id` / `pk`
+- `question`
+- `value`
+- `meta`
+- `document`
+- `documents`
+- `date`
+- `file`
 
 ### caluma_form.models.AnswerDocument
+
 Intermediary table for the `Answer` <--> `Document` m2m used in table answers.
 
 #### Fields
 
-* `id` / `pk`
-* `answer`
-* `document`
-* `sort`
-
+- `id` / `pk`
+- `answer`
+- `document`
+- `sort`
 
 ### caluma_form.models.File
+
 This model contains the file records used in file answers.
 
 #### Fields
 
-* `id` / `pk`
-* `name`
+- `id` / `pk`
+- `name`
 
 #### Properties
 
-* `object_name`
-* `upload_url`
-* `download_url`
-* `metadata`
-
+- `object_name`
+- `upload_url`
+- `download_url`
+- `metadata`
 
 ### caluma_workflow.models.Task
+
 This model contains tasks.
 
 #### Fields
 
-* `slug` / `pk`
-* `name`
-* `description`
-* `type`
-* `meta`
-* `address_groups`
-* `control_groups`
-* `is_archived`
-* `form`
-* `lead_time`
-* `is_multiple_instance`
+- `slug` / `pk`
+- `name`
+- `description`
+- `type`
+- `meta`
+- `address_groups`
+- `control_groups`
+- `is_archived`
+- `form`
+- `lead_time`
+- `is_multiple_instance`
 
 #### Methods
 
-* `calculate_deadline()`
-
+- `calculate_deadline()`
 
 ### caluma_workflow.models.Workflow
+
 This model contains workflows.
 
 #### Fields
 
-* `slug` / `pk`
-* `name`
-* `description`
-* `meta`
-* `is_published`
-* `is_archived`
-* `start_tasks`
-* `allow_all_forms`
-* `allow_forms`
+- `slug` / `pk`
+- `name`
+- `description`
+- `meta`
+- `is_published`
+- `is_archived`
+- `start_tasks`
+- `allow_all_forms`
+- `allow_forms`
 
 #### Properties
 
-* `flows`
-
+- `flows`
 
 ### caluma_workflow.models.Flow
+
 This model contains flows.
 
 #### Fields
 
-* `id` / `pk`
-* `next`
-
+- `id` / `pk`
+- `next`
 
 ### caluma_workflow.models.TaskFlow
+
 This model contains task flows.
 
 #### Fields
 
-* `id` / `pk`
-* `workflow`
-* `task`
-* `flow`
-
+- `id` / `pk`
+- `workflow`
+- `task`
+- `flow`
 
 ### caluma_workflow.models.Case
+
 This model contains cases.
 
 #### Fields
 
-* `id` / `pk`
-* `closed_at`
-* `closed_by_user`
-* `closed_by_group`
-* `workflow`
-* `status`
-* `meta`
-* `document`
-
+- `id` / `pk`
+- `closed_at`
+- `closed_by_user`
+- `closed_by_group`
+- `workflow`
+- `status`
+- `meta`
+- `document`
 
 ### caluma_workflow.models.WorkItem
+
 This model contains work items.
 
 #### Fields
 
-* `id` / `pk`
-* `closed_at`
-* `closed_by_user`
-* `closed_by_group`
-* `deadline`
-* `task`
-* `status`
-* `meta`
-* `addressed_groups`
-* `controlling_groups`
-* `assigned_users`
-* `case`
-* `child_case`
-* `document`
-
+- `id` / `pk`
+- `closed_at`
+- `closed_by_user`
+- `closed_by_group`
+- `deadline`
+- `task`
+- `status`
+- `meta`
+- `addressed_groups`
+- `controlling_groups`
+- `assigned_users`
+- `case`
+- `child_case`
+- `document`
 
 ### caluma_user.models.OIDCUser / caluma_user.models.AnonymousUser
 
@@ -266,29 +265,27 @@ available during the lifetime of a request.
 
 #### Fields
 
-* `claims`
-* `username`
-* `groups`
-* `token`
-* `is_authenticated`
+- `claims`
+- `username`
+- `groups`
+- `token`
+- `is_authenticated`
 
 #### Properties
 
-* `group`
-
+- `group`
 
 ## Schema
 
 All the schemas:
 
-* `caluma_data_source.schema`
-* `caluma_form.schema`
-* `caluma_workflow.schema`
+- `caluma_data_source.schema`
+- `caluma_form.schema`
+- `caluma_workflow.schema`
 
 ## urls.py
 
 You can include the `graphql` endpoint into your `urls.py` from `caluma.caluma_core.urls`.
-
 
 ## Extensions base classes and decorators
 
@@ -296,21 +293,28 @@ Further information about extensions and their utilities can be found [here](ext
 
 For completeness, they are listed here:
 
-* `caluma_core.mutation.Mutation`
-* `caluma_core.permissions.AllowAny`
-* `caluma_core.permissions.BasePermission`
-* `caluma_core.permissions.object_permission_for`
-* `caluma_core.permissions.permission_for`
-* `caluma_core.validations.BaseValidation`
-* `caluma_core.validations.validation_for`
-* `caluma_core.visibilities.Any`
-* `caluma_core.visibilities.BaseVisibility`
-* `caluma_core.visibilities.filter_queryset_for`
-* `caluma_core.visibilities.Union`
-* `caluma_data_source.data_source.BaseDataSource`
-* `caluma_data_source.utils.data_source_cache`
-* `caluma_user.permissions.CreatedByGroup`
-* `caluma_user.permissions.IsAuthenticated`
-* `caluma_user.visibilities.Authenticated`
-* `caluma_user.visibilities.CreatedByGroup`
-* `caluma_workflow.visibilities.AddressedGroups`
+- `caluma_core.mutation.Mutation`
+- `caluma_core.permissions.AllowAny`
+- `caluma_core.permissions.BasePermission`
+- `caluma_core.permissions.object_permission_for`
+- `caluma_core.permissions.permission_for`
+- `caluma_core.validations.BaseValidation`
+- `caluma_core.validations.validation_for`
+- `caluma_core.visibilities.Any`
+- `caluma_core.visibilities.BaseVisibility`
+- `caluma_core.visibilities.filter_queryset_for`
+- `caluma_core.visibilities.Union`
+- `caluma_data_source.data_source.BaseDataSource`
+- `caluma_data_source.utils.data_source_cache`
+- `caluma_user.permissions.CreatedByGroup`
+- `caluma_user.permissions.IsAuthenticated`
+- `caluma_user.visibilities.Authenticated`
+- `caluma_user.visibilities.CreatedByGroup`
+- `caluma_workflow.visibilities.AddressedGroups`
+
+## Public Python API
+
+You can also use the full business logic that is provided by the GraphQL API
+in your application that installs Caluma as a django app:
+
+- `caluma_workflow.api.start_case` To start a new case of a given workflow


### PR DESCRIPTION
When caluma is used as a django app, it is often desireable to trigger
specific mutations by calling python APIs directly (instead of the
GraphQL API). This shows how we could go about offering a Python API for
starting cases that mirrors what the GraphQL API offers via saveCase: We
extract the business logic out of the serializer into a domain logic
class which is then used in a public method exposed in an api module.

Closes #1046 