### PR TITLE
docs(pipenv): switch to 'id -u' when creating a pipenv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ pipenv install -d -r requirements-dev.txt
 You can also run tests without the caluma-container:
 
 ```bash
-echo UID=$(id --user) > .env
+echo UID=$(id -u) > .env
 echo ENV=dev >> .env
 docker-compose up -d db
 pipenv install --python 3.7 -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 
 pipenv_setup = """
-echo UID=$(id --user) > .env
+echo UID=$(id -u) > .env
 echo ENV=dev >> .env
 docker-compose up -d db
 rm -f Pipfile*


### PR DESCRIPTION
'id --user' is not POSIX and missing on some systems