### PR TITLE
chore: remove version pinning for subdependencies

### DIFF
--- a/caluma/caluma_core/tests/test_inversible_filters.py
+++ b/caluma/caluma_core/tests/test_inversible_filters.py
@@ -27,7 +27,7 @@ def test_inversible_with_vars(db, schema_executor, document_factory):
         }
     """
 
-    result = schema_executor(query, variables=variables)
+    result = schema_executor(query, variable_values=variables)
     assert not result.errors
 
     result_ids = [

--- a/caluma/caluma_core/tests/test_meta_filters.py
+++ b/caluma/caluma_core/tests/test_meta_filters.py
@@ -46,7 +46,7 @@ def test_meta_value_filter(
     if lookup:
         variables["filter"][0]["lookup"] = lookup
 
-    result = schema_executor(query, variables=variables)
+    result = schema_executor(query, variable_values=variables)
 
     assert not result.errors
 

--- a/caluma/caluma_core/tests/test_mutation_params.py
+++ b/caluma/caluma_core/tests/test_mutation_params.py
@@ -97,7 +97,7 @@ def test_get_mutation_params_with_vars(db, schema_executor, permission_classes, 
 
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "quest": {
                 "slug": "email_addr",
                 "label": "hello",

--- a/caluma/caluma_core/tests/test_ordersets.py
+++ b/caluma/caluma_core/tests/test_ordersets.py
@@ -41,7 +41,7 @@ def test_inversible_with_vars(db, schema_executor, document_factory, question):
         ]
 
     def get_ordered(ordering):
-        result = schema_executor(query, variables={"order": ordering})
+        result = schema_executor(query, variable_values={"order": ordering})
         assert not result.errors
         return result_ids(result)
 

--- a/caluma/caluma_core/tests/test_pagination.py
+++ b/caluma/caluma_core/tests/test_pagination.py
@@ -42,7 +42,7 @@ def test_has_next_previous(
 
     inp = {"first": first, "last": last, "before": before, "after": after}
 
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
     assert result.data["allDocuments"]["pageInfo"]["hasNextPage"] == has_next

--- a/caluma/caluma_data_source/tests/test_data_source.py
+++ b/caluma/caluma_data_source/tests/test_data_source.py
@@ -117,7 +117,7 @@ def test_data_source_failure(data_source, schema_executor, settings):
 
     inp = {"name": data_source}
 
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert result.errors
 
 
@@ -144,7 +144,7 @@ def test_data_source_defaults(snapshot, schema_executor, settings):
             }
         """
 
-    result = schema_executor(query, variables={})
+    result = schema_executor(query, variable_values={})
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -171,7 +171,7 @@ def test_data_source_exception(schema_executor, settings):
             }
         """
 
-    result = schema_executor(query, variables={})
+    result = schema_executor(query, variable_values={})
     assert result.errors
 
 
@@ -243,7 +243,7 @@ def test_data_sources_stores_user(
         }
     }
     assert not DynamicOption.objects.exists()
-    result = schema_executor(query, variables=variables, info=info)
+    result = schema_executor(query, variable_values=variables, info=info)
     assert not result.errors
     assert DynamicOption.objects.filter(
         document=document,

--- a/caluma/caluma_form/tests/test_answer.py
+++ b/caluma/caluma_form/tests/test_answer.py
@@ -20,7 +20,9 @@ def test_remove_answer(db, snapshot, question, answer, schema_executor):
         }
     """
 
-    result = schema_executor(query, variables={"input": {"answer": str(answer.pk)}})
+    result = schema_executor(
+        query, variable_values={"input": {"answer": str(answer.pk)}}
+    )
 
     assert not result.errors
     with pytest.raises(models.Answer.DoesNotExist):

--- a/caluma/caluma_form/tests/test_filter_by_answer.py
+++ b/caluma/caluma_form/tests/test_filter_by_answer.py
@@ -96,7 +96,7 @@ def test_query_all_questions(
                 }
             }
         """,
-        variables={"form_id": top_form.pk},
+        variable_values={"form_id": top_form.pk},
     )
 
     document_id = extract_global_id(result.data["saveDocument"]["document"]["id"])
@@ -138,7 +138,7 @@ def test_query_all_questions(
     if hierarchy_lookup is not None:
         variables["hasAnswer"][0]["hierarchy"] = hierarchy_lookup
 
-    result = schema_executor(query, variables=variables)
+    result = schema_executor(query, variable_values=variables)
     # note: result.errors may contain stuff that pytest-snapshottest cannot
     # serialize properly, thus we stringify it
     snapshot.assert_match(
@@ -192,7 +192,7 @@ def test_has_answer_intersect(
         ]
     }
 
-    result = schema_executor(query, variables=variables)
+    result = schema_executor(query, variable_values=variables)
     assert not result.errors
 
     expect_count = 1 if expect_find else 0
@@ -223,7 +223,7 @@ def test_visible_in_context(
     """
     variables = {"visible": True}
 
-    result = schema_executor(query, variables=variables)
+    result = schema_executor(query, variable_values=variables)
     assert not result.errors
     assert (
         len(result.data["allDocuments"]["edges"][0]["node"]["answers"]["edges"])

--- a/caluma/caluma_form/tests/test_form.py
+++ b/caluma/caluma_form/tests/test_form.py
@@ -52,7 +52,7 @@ def test_query_all_forms(
 
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "question": question.label,
             "orderBy": ["NAME_ASC", "CREATED_AT_ASC"],
         },
@@ -81,7 +81,7 @@ def test_save_form(db, snapshot, form, settings, schema_executor, language_code)
 
     inp = {"input": extract_serializer_input_fields(SaveFormSerializer, form)}
     with translation.override(language_code):
-        result = schema_executor(query, variables=inp)
+        result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
     snapshot.assert_match(result.data)
@@ -100,7 +100,7 @@ def test_save_form_created_as_admin_user(db, form, admin_schema_executor, admin_
 
     inp = {"input": extract_serializer_input_fields(SaveFormSerializer, form)}
     form.delete()  # test creation of form
-    result = admin_schema_executor(query, variables=inp)
+    result = admin_schema_executor(query, variable_values=inp)
 
     assert not result.errors
     assert result.data["saveForm"]["form"]["createdByUser"] == admin_user.username
@@ -121,7 +121,7 @@ def test_copy_form(db, form, form_question_factory, schema_executor):
     """
 
     inp = {"input": {"source": form.pk, "slug": "new-form", "name": "Test Form"}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
 
@@ -163,7 +163,7 @@ def test_add_form_question(db, form, question, form_question_factory, schema_exe
 
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "input": {
                 "form": to_global_id(type(form).__name__, form.pk),
                 "question": to_global_id(type(question).__name__, question.pk),
@@ -199,7 +199,7 @@ def test_remove_form_question(
 
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "input": {
                 "form": to_global_id(type(form).__name__, form.pk),
                 "question": to_global_id(type(question).__name__, question.pk),
@@ -236,7 +236,7 @@ def test_reorder_form_questions(db, form, form_question_factory, schema_executor
     )
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "input": {
                 "form": to_global_id(type(form).__name__, form.pk),
                 "questions": [
@@ -283,7 +283,7 @@ def test_reorder_form_questions_invalid_question(
 
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "input": {
                 "form": to_global_id(type(form).__name__, form.pk),
                 "questions": [
@@ -319,7 +319,7 @@ def test_reorder_form_questions_duplicated_question(
 
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "input": {
                 "form": to_global_id(type(form).__name__, form.pk),
                 "questions": [question.slug, question.slug],

--- a/caluma/caluma_form/tests/test_format_validators.py
+++ b/caluma/caluma_form/tests/test_format_validators.py
@@ -88,7 +88,7 @@ def test_base_format_validators(
 
     inp = {"input": extract_serializer_input_fields(SaveAnswerSerializer, answer)}
 
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors) == success
     if success:

--- a/caluma/caluma_form/tests/test_option.py
+++ b/caluma/caluma_form/tests/test_option.py
@@ -22,7 +22,7 @@ def test_save_option(db, option, snapshot, schema_executor):
         )
     }
 
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -40,7 +40,7 @@ def test_copy_option(db, option, schema_executor):
     """
 
     inp = {"input": {"source": option.pk, "slug": "new-option", "label": "Test Option"}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
 
@@ -68,7 +68,7 @@ def test_dynamic_option(db, schema_executor, dynamic_option_factory):
 
     dynamic_option = dynamic_option_factory()
     inp = {"filter": [{"document": dynamic_option.id}]}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
     assert dynamic_option.slug == "service-bank-arm"

--- a/caluma/caluma_form/tests/test_question.py
+++ b/caluma/caluma_form/tests/test_question.py
@@ -145,7 +145,7 @@ def test_query_all_questions(
 
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "search": question.label,
             "forms": [extract_global_id_input_fields(form)["id"]],
         },
@@ -178,7 +178,7 @@ def test_copy_question(
             "label": "Test Question",
         }
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
 
@@ -234,7 +234,7 @@ def test_save_question(db, snapshot, question, mutation, schema_executor, succes
             serializers.SaveQuestionSerializer, question
         )
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors) == success
     if success:
@@ -283,7 +283,7 @@ def test_save_text_question(db, question, schema_executor, success):
             serializers.SaveTextQuestionSerializer, question
         )
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not bool(result.errors) == success
     if success:
         assert result.data["saveTextQuestion"]["question"]["maxLength"] == 10
@@ -324,7 +324,7 @@ def test_save_textarea_question(db, question, schema_executor):
             serializers.SaveTextareaQuestionSerializer, question
         )
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     assert result.data["saveTextareaQuestion"]["question"]["maxLength"] == 10
 
@@ -361,7 +361,7 @@ def test_save_float_question(db, snapshot, question, schema_executor, success):
             serializers.SaveFloatQuestionSerializer, question
         )
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not bool(result.errors) == success
     if success:
         snapshot.assert_match(result.data)
@@ -399,7 +399,7 @@ def test_save_integer_question(db, snapshot, question, success, schema_executor)
             serializers.SaveIntegerQuestionSerializer, question
         )
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not bool(result.errors) == success
     if success:
         snapshot.assert_match(result.data)
@@ -444,7 +444,7 @@ def test_save_multiple_choice_question(
         )
     }
     inp["input"]["options"] = option_ids
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -482,7 +482,7 @@ def test_save_choice_question(db, snapshot, question, question_option, schema_ex
         )
     }
     question.delete()  # test creation
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -527,7 +527,7 @@ def test_save_dynamic_choice_question(
     }
     if delete:
         question.delete()  # test creation
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -577,7 +577,7 @@ def test_save_dynamic_multiple_choice_question(
     }
     if delete:
         question.delete()  # test creation
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -610,7 +610,7 @@ def test_save_table_question(db, snapshot, question, question_option, schema_exe
         )
     }
     question.delete()  # test creation
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -643,7 +643,7 @@ def test_save_form_question(db, snapshot, question, question_option, schema_exec
         )
     }
     question.delete()  # test creation
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -673,7 +673,7 @@ def test_save_static_question(db, snapshot, question, schema_executor):
             serializers.SaveStaticQuestionSerializer, question
         )
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not bool(result.errors)
     snapshot.assert_match(result.data)
 

--- a/caluma/caluma_form/tests/test_root_document_filter.py
+++ b/caluma/caluma_form/tests/test_root_document_filter.py
@@ -61,7 +61,7 @@ def test_root_document_filter(
     """
     variables = {"root": str(document1.id)}
 
-    result = schema_executor(query, variables=variables)
+    result = schema_executor(query, variable_values=variables)
     assert not result.errors
     result_ids = [
         extract_global_id(doc["node"]["id"])

--- a/caluma/caluma_form/tests/test_search_answers.py
+++ b/caluma/caluma_form/tests/test_search_answers.py
@@ -39,7 +39,7 @@ def test_search(
 
     def _search(slugs, word, expect_count):
         variables = {"search": [{"questions": slugs, "value": word}]}
-        result = schema_executor(query, variables=variables)
+        result = schema_executor(query, variable_values=variables)
 
         assert not result.errors
         edges = result.data["allDocuments"]["edges"]
@@ -99,7 +99,7 @@ def test_search_multiple(
     # Here, we send two searches, which we expect to be joined by AND.
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "search": [
                 # "hello" is in doc_a and doc_b
                 {"questions": [question_a.slug], "value": "hello"},
@@ -133,7 +133,7 @@ def test_search_invalid_question_type(schema_executor, db, question_factory):
               }
             }
         """,
-        variables={"search": [{"questions": [question.slug], "value": "blah"}]},
+        variable_values={"search": [{"questions": [question.slug], "value": "blah"}]},
     )
 
     assert [str(err) for err in result.errors] == [

--- a/caluma/caluma_form/tests/test_type.py
+++ b/caluma/caluma_form/tests/test_type.py
@@ -36,7 +36,7 @@ def test_answer_types(
         }
     """
 
-    result = schema_executor(query, variables={"id": global_id})
+    result = schema_executor(query, variable_values={"id": global_id})
     assert not result.errors == success
     if success:
         assert result.data["node"]["__typename"] == expected_typename
@@ -74,6 +74,6 @@ def test_question_types(
         }
     """
 
-    result = schema_executor(query, variables={"id": global_id})
+    result = schema_executor(query, variable_values={"id": global_id})
     assert not result.errors
     assert result.data["node"]["__typename"] == expected_typename

--- a/caluma/caluma_workflow/tests/test_base_filters.py
+++ b/caluma/caluma_workflow/tests/test_base_filters.py
@@ -15,7 +15,7 @@ def test_base_model_created_by_user_filter(db, work_item_factory, schema_executo
             }
         """
 
-    result = schema_executor(query, variables={"createdByUser": "Winston Smith"})
+    result = schema_executor(query, variable_values={"createdByUser": "Winston Smith"})
 
     assert not result.errors
     assert len(result.data["allWorkItems"]["edges"]) == 1
@@ -42,7 +42,7 @@ def test_base_model_created_by_group_filter(db, work_item_factory, schema_execut
                 }
             """
 
-    result = schema_executor(query, variables={"createdByGroup": "Oceania"})
+    result = schema_executor(query, variable_values={"createdByGroup": "Oceania"})
 
     assert not result.errors
     assert len(result.data["allWorkItems"]["edges"]) == 1

--- a/caluma/caluma_workflow/tests/test_case.py
+++ b/caluma/caluma_workflow/tests/test_case.py
@@ -91,7 +91,7 @@ def test_start_case(
     if mutation == "saveCase":
         inp["input"]["id"] = str(case.id)
 
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
 
@@ -129,7 +129,7 @@ def test_start_sub_sub_case(
     inp = {
         "input": {"workflow": workflow.slug, "parentWorkItem": str(sub_work_item.pk)}
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
 
@@ -152,7 +152,7 @@ def test_start_case_invalid_form(db, workflow, form, schema_executor):
     """
 
     inp = {"input": {"workflow": workflow.slug, "form": str(form.pk)}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert result.errors
 
@@ -190,7 +190,7 @@ def test_cancel_case(db, snapshot, case, work_item, schema_executor, success):
     """
 
     inp = {"input": {"id": case.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors) == success
     if success:
@@ -213,7 +213,7 @@ def test_multiple_instance_task_address_groups(
     """
 
     inp = {"input": {"workflow": workflow.slug}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not bool(result.errors)
     assert models.WorkItem.objects.count() == count
 
@@ -265,7 +265,7 @@ def test_root_case_filter(schema_executor, db, workflow_factory, case_factory):
         }
     """
     variables = {"case": case.pk}
-    result = schema_executor(query, variables=variables)
+    result = schema_executor(query, variable_values=variables)
 
     assert not result.errors
 
@@ -302,7 +302,7 @@ def test_family_workitems(schema_executor, db, case_factory, work_item_factory):
     """
 
     variables = {"case": to_global_id("Case", case.pk)}
-    result = schema_executor(query, variables=variables)
+    result = schema_executor(query, variable_values=variables)
 
     assert not result.errors
 
@@ -476,7 +476,7 @@ def test_order_by_question_answer_value(
 
     inp = {"orderByQuestionAnswerValue": value}
 
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors) == success
     if success:
@@ -511,7 +511,7 @@ def test_document_form(
         }
     """
     # search for form A's slug
-    result = schema_executor(query, variables={"form": form_a.slug})
+    result = schema_executor(query, variable_values={"form": form_a.slug})
 
     assert len(result.data["allCases"]["edges"]) == 1
 
@@ -559,7 +559,7 @@ def test_work_item_document(
     """
     result = schema_executor(
         query,
-        variables={
+        variable_values={
             "filter": {"question": question.slug, "value": "hello", "lookup": "EXACT"}
         },
     )

--- a/caluma/caluma_workflow/tests/test_date_filters.py
+++ b/caluma/caluma_workflow/tests/test_date_filters.py
@@ -50,7 +50,7 @@ def test_before_after_filters(
             }
         """
 
-    result = schema_executor(query, variables={"filter": filter})
+    result = schema_executor(query, variable_values={"filter": filter})
 
     assert not result.errors
     result_info = set(

--- a/caluma/caluma_workflow/tests/test_events.py
+++ b/caluma/caluma_workflow/tests/test_events.py
@@ -27,7 +27,7 @@ def test_events(db, work_item_factory, schema_executor):
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
     work_item.refresh_from_db()

--- a/caluma/caluma_workflow/tests/test_task.py
+++ b/caluma/caluma_workflow/tests/test_task.py
@@ -23,7 +23,7 @@ def test_query_all_tasks(db, snapshot, task, schema_executor):
         }
     """
 
-    result = schema_executor(query, variables={"name": task.name})
+    result = schema_executor(query, variable_values={"name": task.name})
 
     assert not result.errors
     snapshot.assert_match(result.data)
@@ -49,7 +49,7 @@ def test_save_task(db, snapshot, task, mutation, schema_executor):
     inp = {
         "input": extract_serializer_input_fields(serializers.SaveTaskSerializer, task)
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)
 
@@ -74,6 +74,6 @@ def test_save_comlete_task_form_task(db, snapshot, task, schema_executor):
             serializers.SaveCompleteTaskFormTaskSerializer, task
         )
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
     snapshot.assert_match(result.data)

--- a/caluma/caluma_workflow/tests/test_work_item.py
+++ b/caluma/caluma_workflow/tests/test_work_item.py
@@ -27,7 +27,7 @@ def test_query_all_work_items_filter_status(db, work_item_factory, schema_execut
     """
 
     result = schema_executor(
-        query, variables={"status": to_const(models.WorkItem.STATUS_READY)}
+        query, variable_values={"status": to_const(models.WorkItem.STATUS_READY)}
     )
 
     assert not result.errors
@@ -69,7 +69,7 @@ def test_query_all_work_items_filter_groups(
             }
         """
 
-    result = schema_executor(query, variables={"groups": ["B", "C"]})
+    result = schema_executor(query, variable_values={"groups": ["B", "C"]})
 
     assert not result.errors
     assert len(result.data["allWorkItems"]["edges"]) == 1
@@ -78,7 +78,7 @@ def test_query_all_work_items_filter_groups(
         "B",
     ]
 
-    result = schema_executor(query, variables={"groups": ["C", "D"]})
+    result = schema_executor(query, variable_values={"groups": ["C", "D"]})
 
     assert not result.errors
     assert len(result.data["allWorkItems"]["edges"]) == 0
@@ -114,7 +114,7 @@ def test_complete_work_item_last(
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = admin_schema_executor(query, variables=inp)
+    result = admin_schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors) == success
     if success:
@@ -177,7 +177,7 @@ def test_complete_workflow_form_work_item(
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors) == success
     if success:
@@ -223,7 +223,7 @@ def test_complete_task_form_work_item(
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors) == success
     if success:
@@ -257,7 +257,7 @@ def test_complete_multiple_instance_task_form_work_item(
     """
 
     inp = {"input": {"id": work_item_1.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors)
     assert result.data["completeWorkItem"]["workItem"]["status"] == to_const(
@@ -268,7 +268,7 @@ def test_complete_multiple_instance_task_form_work_item(
     )
 
     inp = {"input": {"id": work_item_2.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors)
     assert result.data["completeWorkItem"]["workItem"]["status"] == to_const(
@@ -330,7 +330,7 @@ def test_complete_multiple_instance_task_form_work_item_next(
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not bool(result.errors)
     snapshot.assert_match(result.data)
@@ -419,7 +419,7 @@ def test_complete_work_item_with_next(
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = schema_executor(query, variables=inp, info=info)
+    result = schema_executor(query, variable_values=inp, info=info)
 
     assert not result.errors
     snapshot.assert_match(result.data)
@@ -469,7 +469,7 @@ def test_complete_work_item_with_next_multiple_tasks(
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
     assert case.work_items.count() == 3
@@ -524,7 +524,7 @@ def test_complete_work_item_with_next_multiple_instance_task(
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
     assert case.work_items.filter(status=models.WorkItem.STATUS_READY).count() == 3
@@ -577,7 +577,7 @@ def test_complete_work_item_with_merge(
         }
     """
     inp = {"input": {"id": work_item_1.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
 
     # one parallel work item is left, no new one created as both preceding
@@ -587,7 +587,7 @@ def test_complete_work_item_with_merge(
 
     # complete second work item
     inp = {"input": {"id": work_item_2.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
     assert not result.errors
 
     # new work item is created of merge task
@@ -644,7 +644,7 @@ def test_save_work_item(
             "description": work_item_description,
         }
     }
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
     work_item.refresh_from_db()
@@ -755,7 +755,7 @@ def test_create_work_item(
         inp["input"]["controllingGroups"] = []
         inp["input"]["addressedGroups"] = []
 
-    result = schema_executor(query, variables=inp, info=info)
+    result = schema_executor(query, variable_values=inp, info=info)
 
     assert not bool(result.errors) == success
     if success:
@@ -810,7 +810,7 @@ def test_filter_document_has_answer(
 
         result = schema_executor(
             query,
-            variables={
+            variable_values={
                 "has_answer": [{"question": answer.question_id, "value": "foo"}]
             },
         )
@@ -873,7 +873,7 @@ def test_query_all_work_items_filter_case_meta_value(
     if lookup_expr:
         variables["lookup"] = lookup_expr
 
-    result = schema_executor(query, variables={"case_meta_value": [variables]})
+    result = schema_executor(query, variable_values={"case_meta_value": [variables]})
 
     assert not result.errors
     assert len(result.data["allWorkItems"]["edges"]) == len_results
@@ -913,7 +913,7 @@ def test_skip_task_form_work_item(
     """
 
     inp = {"input": {"id": work_item.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     # when skipping, both valid and invalid forms don't matter (contrary
     # to completion, where it DOES matter)
@@ -964,7 +964,7 @@ def test_skip_multiple_instance_task_form_work_item(
     """
 
     inp = {"input": {"id": work_item_1.pk}}
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert bool(result.errors) != success
 
@@ -981,7 +981,7 @@ def test_skip_multiple_instance_task_form_work_item(
         )
 
         inp = {"input": {"id": work_item_2.pk}}
-        result = schema_executor(query, variables=inp)
+        result = schema_executor(query, variable_values=inp)
 
         assert not bool(result.errors)
         assert result.data["skipWorkItem"]["workItem"]["status"] == to_const(

--- a/caluma/caluma_workflow/tests/test_workflow.py
+++ b/caluma/caluma_workflow/tests/test_workflow.py
@@ -56,7 +56,7 @@ def test_query_all_workflows(
         }
     """
 
-    result = schema_executor(query, variables={"name": workflow.name})
+    result = schema_executor(query, variable_values={"name": workflow.name})
 
     assert not result.errors
     snapshot.assert_match(result.data)
@@ -93,7 +93,7 @@ def test_save_workflow(
         )
     }
     workflow.delete()  # test creation
-    result = schema_executor(query, variables=inp)
+    result = schema_executor(query, variable_values=inp)
 
     assert not result.errors
     snapshot.assert_match(result.data)
@@ -147,7 +147,7 @@ def test_add_workflow_flow(
 
     result = admin_schema_executor(
         query,
-        variables={
+        variable_values={
             "input": {
                 "workflow": to_global_id(type(workflow).__name__, workflow.pk),
                 "tasks": [to_global_id(type(task).__name__, task.pk)],
@@ -172,7 +172,7 @@ def test_remove_flow(db, workflow, task_flow, flow, schema_executor):
         }
     """
 
-    result = schema_executor(query, variables={"input": {"flow": str(flow.pk)}})
+    result = schema_executor(query, variable_values={"input": {"flow": str(flow.pk)}})
     assert not result.errors
     assert workflow.task_flows.count() == 0
 
@@ -200,7 +200,7 @@ def test_add_workflow_flow_reuse_task(
 
     result = admin_schema_executor(
         query,
-        variables={
+        variable_values={
             "input": {
                 "workflow": workflow_a.slug,
                 "tasks": [task_a.slug],
@@ -212,7 +212,7 @@ def test_add_workflow_flow_reuse_task(
 
     result = admin_schema_executor(
         query,
-        variables={
+        variable_values={
             "input": {
                 "workflow": workflow_b.slug,
                 "tasks": [task_a.slug],

--- a/caluma/conftest.py
+++ b/caluma/conftest.py
@@ -107,7 +107,7 @@ def simple_history_middleware(next, root, info, **args):
 def schema_executor(anonymous_request):
     return functools.partial(
         schema.execute,
-        context=anonymous_request,
+        context_value=anonymous_request,
         middleware=[simple_history_middleware],
     )
 
@@ -115,7 +115,9 @@ def schema_executor(anonymous_request):
 @pytest.fixture
 def admin_schema_executor(admin_request):
     return functools.partial(
-        schema.execute, context=admin_request, middleware=[simple_history_middleware]
+        schema.execute,
+        context_value=admin_request,
+        middleware=[simple_history_middleware],
     )
 
 

--- a/caluma/tests/test_schema.py
+++ b/caluma/tests/test_schema.py
@@ -30,7 +30,7 @@ def test_schema_node(db, snapshot, request, node_type):
         "name": node_instance.__class__.__name__
     }
 
-    result = schema.execute(node_query, variables={"id": global_id})
+    result = schema.execute(node_query, variable_values={"id": global_id})
     assert not result.errors
     assert result.data["node"]["id"] == global_id
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,7 @@ django-localized-fields==5.4.2
 django-postgres-extra==1.22
 djangorestframework==3.11.0
 django_simple_history==2.10.0
-graphene==2.1.8
 graphene-django==2.8.2
-graphql-core==2.2.1
-graphql-relay==2.0.1
 idna==2.9
 minio==5.0.10
 psycopg2-binary==2.8.5


### PR DESCRIPTION
graphene-django does a good job pinning the version for graphql-core,
graphene and graphql-relay.
So we remove them from our requirements and let graphene-django handle
these.