### PR TITLE
fix(form): make HistoricalDocument inherit from Document

### DIFF
--- a/caluma/caluma_form/historical_schema.py
+++ b/caluma/caluma_form/historical_schema.py
@@ -9,9 +9,9 @@ from . import models
 from .schema import (
     Answer,
     DateAnswer,
+    Document,
     FileAnswer,
     FloatAnswer,
-    FormDjangoObjectType,
     IntegerAnswer,
     ListAnswer,
     StringAnswer,
@@ -142,7 +142,7 @@ class HistoricalFileAnswer(FileAnswer):
         interfaces = (HistoricalAnswer, graphene.Node)
 
 
-class HistoricalDocument(FormDjangoObjectType):
+class HistoricalDocument(Document):
     historical_answers = ConnectionField(
         HistoricalAnswerConnection,
         as_of=graphene.types.datetime.DateTime(required=True),

--- a/caluma/tests/snapshots/snap_test_schema.py
+++ b/caluma/tests/snapshots/snap_test_schema.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots[
@@ -847,6 +846,7 @@ type HistoricalDocument implements Node {
   source: Document
   historyDate: DateTime!
   historyType: String
+  answers(before: String, after: String, first: Int, last: Int, metaValue: [JSONValueFilterType], orderBy: [AnswerOrdering], filter: [AnswerFilterSetType], order: [AnswerOrderSetType], question: ID, search: String, createdByUser: String, createdByGroup: String, createdBefore: DateTime, createdAfter: DateTime, metaHasKey: String, questions: [ID], visibleInContext: Boolean): AnswerConnection
   historicalAnswers(asOf: DateTime!, before: String, after: String, first: Int, last: Int): HistoricalAnswerConnection
   documentId: UUID
 }


### PR DESCRIPTION
HistoricalDocument is of type Document.
This way, we can reuse the Document type for visibilities and such,
applying the same rules to HistoricalDocument if we have a rule for
Document.

fixes #1070

Caution: This is probably a breaking change, if an extension (eg. visibility) expects that a `@filter_queryset_for` rule for Document doesn't apply for HistoricalDocument (which would use the rule of a fallback, probably Node or no filter).