### PR TITLE
fix(workflow): make tasks reusable in workflow flows

### DIFF
--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -71,7 +71,9 @@ class AddWorkflowFlowSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         user = self.context["request"].user
         tasks = validated_data["tasks"]
-        models.Flow.objects.filter(task_flows__task__in=tasks).delete()
+        models.Flow.objects.filter(
+            task_flows__workflow=instance, task_flows__task__in=tasks
+        ).delete()
         flow = models.Flow.objects.create(
             next=validated_data["next"],
             created_by_user=user.username,


### PR DESCRIPTION
Remove only flows of the same workflow when creating WorkflowFlows.
Previously, all flows connecting from the same task were deleted upon
using the AddWorkflowFlow migration. Now we filter using the given
workflow instance, allowing reuse of the same task in multiple worklows.

Fixes #1065