### PR TITLE
feat: add --dangling option for cleanup_history command, drop --keep option

### DIFF
--- a/caluma/caluma_core/management/commands/cleanup_history.py
+++ b/caluma/caluma_core/management/commands/cleanup_history.py
@@ -1,7 +1,16 @@
 from dateparser import parse
 from django.core.management.base import BaseCommand
+from django.db.models import Q
 from django.utils import timezone
 from simple_history.models import registered_models
+
+# Instances which are created at run-time, referencing config-time models
+# eg. Answers are created at run-time by users and referencing Question
+RELATED_HISTORICAL_MODELS = {
+    "Answer": {"question__type__isnull": True},
+    "Document": {"form__name__isnull": True},
+    "DynamicOption": {"question__type__isnull": True},
+}
 
 
 class Command(BaseCommand):
@@ -21,18 +30,37 @@ class Command(BaseCommand):
                 "E.g. '6 months', '1 year'. Uses dateparser."
             ),
         )
+        parser.add_argument(
+            "-d",
+            "--dangling",
+            dest="dangling",
+            default=False,
+            action="store_true",
+            help=(
+                "Remove records missing a related instance, e.g. HistoricalAnswer missing the Question it relates to."
+                "Caution: This does not respect the --keep option but removes ALL such instances."
+            ),
+        )
 
     def handle(self, *args, **options):
         force = options["force"]
+        dangling = options["dangling"]
+        keep = options["keep"]
 
-        lt = parse(options["keep"])
-        if lt is not None:
-            lt = timezone.make_aware(lt)
+        if keep:
+            keep = timezone.make_aware(parse(keep))
 
-        for _, model in registered_models.items():
+        for model in registered_models.values():
             qs = model.history.all()
-            if lt is not None:
-                qs = model.history.filter(history_date__lt=lt)
+            _filter = Q()
+
+            if keep is not None:
+                _filter = Q(history_date__lt=keep)
+
+            if dangling and model.__name__ in RELATED_HISTORICAL_MODELS:
+                _filter |= Q(**RELATED_HISTORICAL_MODELS[model.__name__])
+
+            qs = qs.filter(_filter)
 
             action_str = "Deleting" if force else "Would delete"
             self.stdout.write(

--- a/caluma/caluma_core/management/commands/cleanup_history.py
+++ b/caluma/caluma_core/management/commands/cleanup_history.py
@@ -1,7 +1,4 @@
-from dateparser import parse
 from django.core.management.base import BaseCommand
-from django.db.models import Q
-from django.utils import timezone
 from simple_history.models import registered_models
 
 # Instances which are created at run-time, referencing config-time models
@@ -21,46 +18,26 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--force", dest="force", default=False, action="store_true")
         parser.add_argument(
-            "-k",
-            "--keep",
-            dest="keep",
-            default="1 year",
-            help=(
-                "Duration we want to keep the records. "
-                "E.g. '6 months', '1 year'. Uses dateparser."
-            ),
-        )
-        parser.add_argument(
             "-d",
             "--dangling",
             dest="dangling",
             default=False,
             action="store_true",
             help=(
-                "Remove records missing a related instance, e.g. HistoricalAnswer missing the Question it relates to."
-                "Caution: This does not respect the --keep option but removes ALL such instances."
+                "Remove records missing a related instance, e.g."
+                "HistoricalAnswer missing the Question it relates to."
             ),
         )
 
     def handle(self, *args, **options):
         force = options["force"]
         dangling = options["dangling"]
-        keep = options["keep"]
-
-        if keep:
-            keep = timezone.make_aware(parse(keep))
 
         for model in registered_models.values():
-            qs = model.history.all()
-            _filter = Q()
-
-            if keep is not None:
-                _filter = Q(history_date__lt=keep)
-
             if dangling and model.__name__ in RELATED_HISTORICAL_MODELS:
-                _filter |= Q(**RELATED_HISTORICAL_MODELS[model.__name__])
-
-            qs = qs.filter(_filter)
+                qs = model.history.filter(**RELATED_HISTORICAL_MODELS[model.__name__])
+            else:
+                qs = model.history.none()
 
             action_str = "Deleting" if force else "Would delete"
             self.stdout.write(

--- a/docs/historical-records.md
+++ b/docs/historical-records.md
@@ -13,7 +13,8 @@ exposed in the GraphQL API. To enable it, set `ENABLE_HISTORICAL_API` to `true`
 ## Cleanup
 
 You may want to periodically cleanup the historical records. There are
-two commands available for this:
+three commands available for this:
 
  - `clean_duplicate_history`: Historical records are always created when `save()` has been called on a model. This command removes all duplicates.
- - `cleanup_history`: Remove all historical records, or the ones that are older than specified.
+ - `clean_old_history`: Remove all historical records, or the ones that are older than specified.
+ - `cleanup_history`: Remove historical records that have a foreign key to a deleted related model. Supported are caluma_form models: `Answer`, `Document` and `DynamicOption`.


### PR DESCRIPTION
Add option -d, --dangling, cleaning up instances with missing relation.
For example, if a question was deleted, the historical answers
referencing this question might have a broken reference.
Passing -d will include theses instances for deletion.

We drop --keep, this functionality is now provided by upstream simple_history's `clean_old_history`