### PR TITLE
refactor: fields list should be list, not tuple

### DIFF
--- a/caluma/caluma_form/serializers.py
+++ b/caluma/caluma_form/serializers.py
@@ -22,7 +22,7 @@ class QuestionJexlField(serializers.JexlField):
 class SaveFormSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Form
-        fields = ("slug", "name", "description", "meta", "is_archived", "is_published")
+        fields = ["slug", "name", "description", "meta", "is_archived", "is_published"]
 
 
 class CopyFormSerializer(serializers.ModelSerializer):
@@ -38,7 +38,7 @@ class CopyFormSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Form
-        fields = ("slug", "name", "description", "source", "is_published")
+        fields = ["slug", "name", "description", "source", "is_published"]
 
 
 class AddFormQuestionSerializer(serializers.ModelSerializer):
@@ -67,7 +67,7 @@ class AddFormQuestionSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        fields = ("form", "question")
+        fields = ["form", "question"]
         model = models.Form
 
 
@@ -84,7 +84,7 @@ class RemoveFormQuestionSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        fields = ("form", "question")
+        fields = ["form", "question"]
         model = models.Form
 
 
@@ -117,7 +117,7 @@ class ReorderFormQuestionsSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        fields = ("form", "questions")
+        fields = ["form", "questions"]
         model = models.Form
 
 
@@ -158,7 +158,7 @@ class CopyQuestionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Question
-        fields = ("slug", "label", "source")
+        fields = ["slug", "label", "source"]
 
 
 class SaveQuestionSerializer(serializers.ModelSerializer):
@@ -172,7 +172,7 @@ class SaveQuestionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Question
-        fields = (
+        fields = [
             "slug",
             "label",
             "info_text",
@@ -181,7 +181,7 @@ class SaveQuestionSerializer(serializers.ModelSerializer):
             "meta",
             "is_archived",
             "default_answer",
-        )
+        ]
 
 
 class SaveTextQuestionSerializer(SaveQuestionSerializer):
@@ -194,12 +194,12 @@ class SaveTextQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + (
+        fields = SaveQuestionSerializer.Meta.fields + [
             "min_length",
             "max_length",
             "placeholder",
             "format_validators",
-        )
+        ]
 
 
 class SaveTextareaQuestionSerializer(SaveQuestionSerializer):
@@ -212,12 +212,12 @@ class SaveTextareaQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + (
+        fields = SaveQuestionSerializer.Meta.fields + [
             "min_length",
             "max_length",
             "placeholder",
             "format_validators",
-        )
+        ]
 
 
 class SaveDateQuestionSerializer(SaveQuestionSerializer):
@@ -273,7 +273,7 @@ class SaveMultipleChoiceQuestionSerializer(
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + ("options",)
+        fields = SaveQuestionSerializer.Meta.fields + ["options"]
 
 
 class SaveChoiceQuestionSerializer(SaveQuestionOptionsMixin, SaveQuestionSerializer):
@@ -286,7 +286,7 @@ class SaveChoiceQuestionSerializer(SaveQuestionOptionsMixin, SaveQuestionSeriali
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + ("options",)
+        fields = SaveQuestionSerializer.Meta.fields + ["options"]
 
 
 class SaveDynamicChoiceQuestionSerializer(SaveQuestionSerializer):
@@ -297,7 +297,7 @@ class SaveDynamicChoiceQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + ("data_source",)
+        fields = SaveQuestionSerializer.Meta.fields + ["data_source"]
 
 
 class SaveDynamicMultipleChoiceQuestionSerializer(SaveQuestionSerializer):
@@ -308,7 +308,7 @@ class SaveDynamicMultipleChoiceQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + ("data_source",)
+        fields = SaveQuestionSerializer.Meta.fields + ["data_source"]
 
 
 class SaveFloatQuestionSerializer(SaveQuestionSerializer):
@@ -334,11 +334,11 @@ class SaveFloatQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + (
+        fields = SaveQuestionSerializer.Meta.fields + [
             "min_value",
             "max_value",
             "placeholder",
-        )
+        ]
 
 
 class SaveIntegerQuestionSerializer(SaveQuestionSerializer):
@@ -364,11 +364,11 @@ class SaveIntegerQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + (
+        fields = SaveQuestionSerializer.Meta.fields + [
             "min_value",
             "max_value",
             "placeholder",
-        )
+        ]
 
 
 class SaveTableQuestionSerializer(SaveQuestionSerializer):
@@ -383,7 +383,7 @@ class SaveTableQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + ("row_form",)
+        fields = SaveQuestionSerializer.Meta.fields + ["row_form"]
 
 
 class SaveFormQuestionSerializer(SaveQuestionSerializer):
@@ -396,7 +396,7 @@ class SaveFormQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + ("sub_form",)
+        fields = SaveQuestionSerializer.Meta.fields + ["sub_form"]
 
 
 class SaveFileQuestionSerializer(SaveQuestionSerializer):
@@ -416,7 +416,7 @@ class SaveStaticQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = (
+        fields = [
             "label",
             "slug",
             "info_text",
@@ -424,7 +424,7 @@ class SaveStaticQuestionSerializer(SaveQuestionSerializer):
             "meta",
             "is_archived",
             "static_content",
-        )
+        ]
 
 
 class SaveCalculatedFloatQuestionSerializer(SaveQuestionSerializer):
@@ -435,12 +435,14 @@ class SaveCalculatedFloatQuestionSerializer(SaveQuestionSerializer):
         return super().validate(data)
 
     class Meta(SaveQuestionSerializer.Meta):
-        fields = SaveQuestionSerializer.Meta.fields + ("calc_expression",)
+        fields = SaveQuestionSerializer.Meta.fields + [
+            "calc_expression",
+        ]
 
 
 class SaveOptionSerializer(serializers.ModelSerializer):
     class Meta:
-        fields = ("slug", "label", "is_archived", "meta")
+        fields = ["slug", "label", "is_archived", "meta"]
         model = models.Option
 
 
@@ -455,7 +457,7 @@ class CopyOptionSerializer(serializers.ModelSerializer):
         return super().create(validated_data)
 
     class Meta:
-        fields = ("slug", "label", "source")
+        fields = ["slug", "label", "source"]
         model = models.Option
 
 
@@ -467,7 +469,7 @@ class DocumentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Document
-        fields = ("id", "form", "meta")
+        fields = ["id", "form", "meta"]
 
 
 class SaveAnswerSerializer(serializers.ModelSerializer):
@@ -489,7 +491,7 @@ class SaveAnswerSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Answer
-        fields = ("question", "document", "meta", "value")
+        fields = ["question", "document", "meta", "value"]
 
 
 class SaveDocumentStringAnswerSerializer(SaveAnswerSerializer):
@@ -545,7 +547,9 @@ class SaveDocumentFileAnswerSerializer(SaveAnswerSerializer):
     value_id = PrimaryKeyRelatedField(read_only=True, source="file", required=False)
 
     class Meta(SaveAnswerSerializer.Meta):
-        fields = SaveAnswerSerializer.Meta.fields + ("value_id",)
+        fields = SaveAnswerSerializer.Meta.fields + [
+            "value_id",
+        ]
 
 
 class RemoveAnswerSerializer(serializers.ModelSerializer):
@@ -559,7 +563,9 @@ class RemoveAnswerSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        fields = ("answer",)
+        fields = [
+            "answer",
+        ]
         model = models.Answer
 
 
@@ -579,7 +585,7 @@ class SaveDefaultAnswerSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Answer
-        fields = ("question", "meta", "value")
+        fields = ["question", "meta", "value"]
 
 
 class SaveDefaultStringAnswerSerializer(SaveDefaultAnswerSerializer):
@@ -639,7 +645,9 @@ class RemoveDefaultAnswerSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        fields = ("question",)
+        fields = [
+            "question",
+        ]
         model = models.Question
 
 
@@ -661,7 +669,7 @@ class RemoveDocumentSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        fields = ("document",)
+        fields = ["document"]
         model = models.Document
 
 
@@ -676,4 +684,4 @@ class CopyDocumentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Document
-        fields = ("source",)
+        fields = ["source"]

--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -40,7 +40,7 @@ class GroupJexlField(serializers.JexlField):
 class SaveWorkflowSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Workflow
-        fields = (
+        fields = [
             "slug",
             "name",
             "description",
@@ -50,7 +50,7 @@ class SaveWorkflowSerializer(serializers.ModelSerializer):
             "allow_forms",
             "is_archived",
             "is_published",
-        )
+        ]
 
 
 class AddWorkflowFlowSerializer(serializers.ModelSerializer):
@@ -90,7 +90,7 @@ class AddWorkflowFlowSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        fields = ("workflow", "tasks", "next")
+        fields = ["workflow", "tasks", "next"]
         model = models.Workflow
 
 
@@ -102,7 +102,7 @@ class RemoveFlowSerializer(serializers.ModelSerializer):
         return instance
 
     class Meta:
-        fields = ("flow",)
+        fields = ["flow"]
         model = models.Flow
 
 
@@ -121,7 +121,7 @@ class SaveTaskSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Task
-        fields = (
+        fields = [
             "slug",
             "name",
             "description",
@@ -131,7 +131,7 @@ class SaveTaskSerializer(serializers.ModelSerializer):
             "is_archived",
             "lead_time",
             "is_multiple_instance",
-        )
+        ]
 
 
 class SaveSimpleTaskSerializer(SaveTaskSerializer):
@@ -162,7 +162,7 @@ class SaveCompleteTaskFormTaskSerializer(SaveTaskSerializer):
         return super().validate(data)
 
     class Meta(SaveTaskSerializer.Meta):
-        fields = SaveTaskSerializer.Meta.fields + ("form",)
+        fields = SaveTaskSerializer.Meta.fields + ["form"]
 
 
 class CaseSerializer(SendEventSerializerMixin, ContextModelSerializer):
@@ -198,7 +198,7 @@ class CaseSerializer(SendEventSerializerMixin, ContextModelSerializer):
 
     class Meta:
         model = models.Case
-        fields = ("workflow", "meta", "parent_work_item", "form", "context")
+        fields = ["workflow", "meta", "parent_work_item", "form", "context"]
 
 
 class SaveCaseSerializer(CaseSerializer):
@@ -221,7 +221,7 @@ class SaveCaseSerializer(CaseSerializer):
         return instance
 
     class Meta(CaseSerializer.Meta):
-        fields = ("id", "workflow", "meta", "parent_work_item", "form", "context")
+        fields = ["id", "workflow", "meta", "parent_work_item", "form", "context"]
 
 
 class CancelCaseSerializer(SendEventSerializerMixin, ContextModelSerializer):
@@ -229,7 +229,7 @@ class CancelCaseSerializer(SendEventSerializerMixin, ContextModelSerializer):
 
     class Meta:
         model = models.Case
-        fields = ("id", "context")
+        fields = ["id", "context"]
 
     def validate(self, data):
         try:
@@ -260,7 +260,7 @@ class SuspendCaseSerializer(SendEventSerializerMixin, ContextModelSerializer):
 
     class Meta:
         model = models.Case
-        fields = ("id", "context")
+        fields = ["id", "context"]
 
     def validate(self, data):
         try:
@@ -291,7 +291,7 @@ class ResumeCaseSerializer(SendEventSerializerMixin, ContextModelSerializer):
 
     class Meta:
         model = models.Case
-        fields = ("id", "context")
+        fields = ["id", "context"]
 
     def validate(self, data):
         try:
@@ -347,7 +347,7 @@ class CompleteWorkItemSerializer(ContextModelSerializer):
 
     class Meta:
         model = models.WorkItem
-        fields = ("id", "context")
+        fields = ["id", "context"]
 
 
 class SkipWorkItemSerializer(ContextModelSerializer):
@@ -378,7 +378,7 @@ class SkipWorkItemSerializer(ContextModelSerializer):
 
     class Meta:
         model = models.WorkItem
-        fields = ("id", "context")
+        fields = ["id", "context"]
 
 
 class CancelWorkItemSerializer(ContextModelSerializer):
@@ -409,7 +409,7 @@ class CancelWorkItemSerializer(ContextModelSerializer):
 
     class Meta:
         model = models.WorkItem
-        fields = ("id", "context")
+        fields = ["id", "context"]
 
 
 class SaveWorkItemSerializer(SendEventSerializerMixin, ContextModelSerializer):
@@ -440,7 +440,7 @@ class SaveWorkItemSerializer(SendEventSerializerMixin, ContextModelSerializer):
 
     class Meta:
         model = models.WorkItem
-        fields = (
+        fields = [
             "work_item",
             "name",
             "description",
@@ -448,7 +448,7 @@ class SaveWorkItemSerializer(SendEventSerializerMixin, ContextModelSerializer):
             "deadline",
             "meta",
             "context",
-        )
+        ]
 
 
 class CreateWorkItemSerializer(SendEventSerializerMixin, ContextModelSerializer):
@@ -518,7 +518,7 @@ class CreateWorkItemSerializer(SendEventSerializerMixin, ContextModelSerializer)
 
     class Meta:
         model = models.WorkItem
-        fields = (
+        fields = [
             "case",
             "multiple_instance_task",
             "name",
@@ -529,7 +529,7 @@ class CreateWorkItemSerializer(SendEventSerializerMixin, ContextModelSerializer)
             "deadline",
             "meta",
             "context",
-        )
+        ]
 
 
 class SuspendWorkItemSerializer(ContextModelSerializer):
@@ -560,7 +560,7 @@ class SuspendWorkItemSerializer(ContextModelSerializer):
 
     class Meta:
         model = models.WorkItem
-        fields = ("id", "context")
+        fields = ["id", "context"]
 
 
 class ResumeWorkItemSerializer(ContextModelSerializer):
@@ -591,4 +591,4 @@ class ResumeWorkItemSerializer(ContextModelSerializer):
 
     class Meta:
         model = models.WorkItem
-        fields = ("id", "context")
+        fields = ["id", "context"]


### PR DESCRIPTION
The DRF documentation shows the fields list to be a list, not a
tuple. When analyzing the code using MyPy, it assumes that an N-tuple
is sort of a type, and changing the type to an N+X-tuple in a subclass
is therefore a type validation (which I sort of agree with).

Therefore, let's use lists instead.