### PR TITLE
fix(workflow): enable context for skipping work items

### DIFF
--- a/caluma/caluma_workflow/api.py
+++ b/caluma/caluma_workflow/api.py
@@ -72,7 +72,9 @@ def complete_work_item(
     return work_item
 
 
-def skip_work_item(work_item: models.WorkItem, user: BaseUser) -> models.WorkItem:
+def skip_work_item(
+    work_item: models.WorkItem, user: BaseUser, context: Optional[dict] = None
+) -> models.WorkItem:
     """
     Skip a work item (just like `SkipWorkItem`).
 
@@ -88,7 +90,7 @@ def skip_work_item(work_item: models.WorkItem, user: BaseUser) -> models.WorkIte
 
     update_model(models.WorkItem.objects.get(pk=work_item.pk), validated_data)
 
-    domain_logic.SkipWorkItemLogic.post_skip(work_item, user)
+    domain_logic.SkipWorkItemLogic.post_skip(work_item, user, context)
 
     return work_item
 

--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -196,8 +196,8 @@ class SkipWorkItemLogic:
         return validated_data
 
     @staticmethod
-    def post_skip(work_item, user):
-        work_item = CompleteWorkItemLogic.post_complete(work_item, user)
+    def post_skip(work_item, user, context):
+        work_item = CompleteWorkItemLogic.post_complete(work_item, user, context)
 
         send_event(
             events.skipped_work_item,

--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -246,7 +246,7 @@ class CompleteWorkItemSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
         write_only=True,
-        help_text="Provide extra context for DynamicGroups",
+        help_text="Provide extra context for dynamic jexl transforms",
     )
 
     def validate(self, data):
@@ -282,6 +282,13 @@ class CompleteWorkItemSerializer(serializers.ModelSerializer):
 
 class SkipWorkItemSerializer(serializers.ModelSerializer):
     id = serializers.GlobalIDField()
+    context = JSONField(
+        encoder=None,
+        required=False,
+        allow_null=True,
+        write_only=True,
+        help_text="Provide extra context for dynamic jexl transforms",
+    )
 
     def validate(self, data):
         try:
@@ -294,16 +301,17 @@ class SkipWorkItemSerializer(serializers.ModelSerializer):
     def update(self, work_item, validated_data):
         user = self.context["request"].user
 
+        context = validated_data.pop("context", {})
         validated_data = domain_logic.SkipWorkItemLogic.pre_skip(validated_data, user)
 
         work_item = super().update(work_item, validated_data)
-        work_item = domain_logic.SkipWorkItemLogic.post_skip(work_item, user)
+        work_item = domain_logic.SkipWorkItemLogic.post_skip(work_item, user, context)
 
         return work_item
 
     class Meta:
         model = models.WorkItem
-        fields = ("id",)
+        fields = ("id", "context")
 
 
 class CancelWorkItemSerializer(serializers.ModelSerializer):

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -1787,6 +1787,7 @@
   
   input SkipWorkItemInput {
     id: ID!
+    context: JSONString
     clientMutationId: String
   }
   


### PR DESCRIPTION
Skipping a work item causes the same side effects for the workflow as
completing it. Therefore it also needs the new context to function
properly.