### PR TITLE
feat(workflow): add context for all case and workitem mutations

### DIFF
--- a/caluma/caluma_core/events.py
+++ b/caluma/caluma_core/events.py
@@ -29,5 +29,6 @@ class SendEventSerializerMixin:
             event,
             sender=self.context["mutation"],
             user=self.context["request"].user,
+            context=getattr(self, "context_data", None),
             **kwargs,
         )  # noqa

--- a/caluma/caluma_workflow/api.py
+++ b/caluma/caluma_workflow/api.py
@@ -95,7 +95,9 @@ def skip_work_item(
     return work_item
 
 
-def cancel_case(case: models.Case, user: BaseUser) -> models.Case:
+def cancel_case(
+    case: models.Case, user: BaseUser, context: Optional[dict] = None
+) -> models.Case:
     """
     Cancel a case and its pending work items (just like `CancelCase`).
 
@@ -111,12 +113,14 @@ def cancel_case(case: models.Case, user: BaseUser) -> models.Case:
 
     update_model(models.Case.objects.get(pk=case.pk), validated_data)
 
-    domain_logic.CancelCaseLogic.post_cancel(case, user)
+    domain_logic.CancelCaseLogic.post_cancel(case, user, context)
 
     return case
 
 
-def cancel_work_item(work_item: models.WorkItem, user: BaseUser) -> models.WorkItem:
+def cancel_work_item(
+    work_item: models.WorkItem, user: BaseUser, context: Optional[dict] = None
+) -> models.WorkItem:
     """
     Cancel a work item (just like `CancelWorkItem`).
 
@@ -132,6 +136,6 @@ def cancel_work_item(work_item: models.WorkItem, user: BaseUser) -> models.WorkI
 
     update_model(models.WorkItem.objects.get(pk=work_item.pk), validated_data)
 
-    domain_logic.CancelWorkItemLogic.post_cancel(work_item, user)
+    domain_logic.CancelWorkItemLogic.post_cancel(work_item, user, context)
 
     return work_item

--- a/caluma/caluma_workflow/events.py
+++ b/caluma/caluma_workflow/events.py
@@ -1,9 +1,9 @@
 from django.dispatch import Signal
 
-created_work_item = Signal(providing_args=["work_item"])
-cancelled_work_item = Signal(providing_args=["work_item"])
-completed_work_item = Signal(providing_args=["work_item"])
-skipped_work_item = Signal(providing_args=["work_item"])
-completed_case = Signal(providing_args=["case"])
-created_case = Signal(providing_args=["case"])
-cancelled_case = Signal(providing_args=["case"])
+created_work_item = Signal(providing_args=["work_item", "user", "context"])
+cancelled_work_item = Signal(providing_args=["work_item", "user", "context"])
+completed_work_item = Signal(providing_args=["work_item", "user", "context"])
+skipped_work_item = Signal(providing_args=["work_item", "user", "context"])
+completed_case = Signal(providing_args=["case", "user", "context"])
+created_case = Signal(providing_args=["case", "user", "context"])
+cancelled_case = Signal(providing_args=["case", "user", "context"])

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -110,6 +110,7 @@
   
   input CancelCaseInput {
     id: ID!
+    context: JSONString
     clientMutationId: String
   }
   
@@ -120,6 +121,7 @@
   
   input CancelWorkItemInput {
     id: ID!
+    context: JSONString
     clientMutationId: String
   }
   
@@ -337,6 +339,7 @@
     controllingGroups: [String]
     deadline: DateTime
     meta: JSONString
+    context: JSONString
     clientMutationId: String
   }
   
@@ -1729,6 +1732,7 @@
     assignedUsers: [String]
     deadline: DateTime
     meta: JSONString
+    context: JSONString
     clientMutationId: String
   }
   
@@ -1901,6 +1905,7 @@
     meta: JSONString
     parentWorkItem: ID
     form: ID
+    context: JSONString
     clientMutationId: String
   }
   

--- a/docs/events.md
+++ b/docs/events.md
@@ -20,7 +20,7 @@ from caluma.caluma_workflow.schema import CompleteWorkItem
 
 
 @on(completed_work_item)
-def send_mail_on_complete_work_item(sender, work_item, user, **kwargs):
+def send_mail_on_complete_work_item(sender, work_item, user, context, **kwargs):
     if work_item.task.slug == "slug-we-are-interested-in":
         # send notification
         pass
@@ -29,7 +29,7 @@ def send_mail_on_complete_work_item(sender, work_item, user, **kwargs):
 # It's also possible to specify a sender, which refers to a mutation class,
 # analog to the `permission_for` decorators
 @on(completed_work_item, sender=CompleteWorkItem)
-def send_mail_on_complete_work_item_2(sender, work_item, user, **kwargs):
+def send_mail_on_complete_work_item_2(sender, work_item, user, context, **kwargs):
     if work_item.task.slug == "slug-we-are-interested-in":
         # send notification
         pass
@@ -56,15 +56,15 @@ in case the event sends additional arguments in the future.
 
 ## List of emitted events
 
-| Event                 | Mutations that can emit this event                                | Arguments           |
-| --------------------- | ----------------------------------------------------------------- | ------------------- |
-| `created_work_item`   | `CreateWorkItem`, `SaveWorkItem`, `StartCase`, `CompleteWorkItem` | `work_item`, `user` |
-| `completed_work_item` | `CompleteWorkItem`                                                | `work_item`, `user` |
-| `cancelled_work_item` | `CancelCase`, `CancelWorkItem`                                    | `work_item`, `user` |
-| `skipped_work_item`   | `SkipWorkItem`                                                    | `work_item`, `user` |
-| `created_case`        | `SaveCase`, `StartCase`                                           | `case`, `user`      |
-| `completed_case`      | `CompleteWorkItem`                                                | `case`, `user`      |
-| `cancelled_case`      | `CancelCase`                                                      | `case`, `user`      |
+| Event                 | Mutations that can emit this event                                | Arguments                      |
+| --------------------- | ----------------------------------------------------------------- | ------------------------------ |
+| `created_work_item`   | `CreateWorkItem`, `SaveWorkItem`, `StartCase`, `CompleteWorkItem` | `work_item`, `user`, `context` |
+| `completed_work_item` | `CompleteWorkItem`                                                | `work_item`, `user`, `context` |
+| `cancelled_work_item` | `CancelCase`, `CancelWorkItem`                                    | `work_item`, `user`, `context` |
+| `skipped_work_item`   | `SkipWorkItem`                                                    | `work_item`, `user`, `context` |
+| `created_case`        | `SaveCase`, `StartCase`                                           | `case`, `user`, `context`      |
+| `completed_case`      | `CompleteWorkItem`                                                | `case`, `user`, `context`      |
+| `cancelled_case`      | `CancelCase`                                                      | `case`, `user`, `context`      |
 
 ## Event receivers are blocking
 


### PR DESCRIPTION
This commit adds the `context` property for all workitem and case
mutations. It also passes that context to all events emitted in those
mutations (and API functions) since the context is very helpful
sometimes in event handlers.