### PR TITLE
chore: bump versions of several dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,8 +24,8 @@ pytest-env==0.6.2
 pytest-factoryboy==2.0.3
 pytest-mock==3.2.0
 pytest-randomly==3.4.1
-pytest-xdist==1.33.0
-python-semantic-release==7.2.1
+pytest-xdist==1.34.0
+python-semantic-release==7.2.2
 requests-mock==1.8.0
-reuse==0.11.0
+reuse==0.11.1
 syrupy==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 dateparser==0.7.6
-django==2.2.14
+django==2.2.15
 django-cors-headers==3.4.0
 django-environ==0.4.5
-django-extensions==2.2.9
+django-extensions==3.0.5
 django-filter==2.3.0
 django-localized-fields==5.4.2
 django-postgres-extra==1.22
-djangorestframework==3.11.0
+djangorestframework==3.11.1
 django_simple_history==2.11.0
 graphene-django==2.8.2
 idna==2.10


### PR DESCRIPTION
This fixes #1055, #1102, #1120, #1122, #1136, and #1144