### PR TITLE
fix: always send post_complete_work_item event

### DIFF
--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -125,6 +125,14 @@ class CompleteWorkItemLogic:
     def post_complete(work_item, user, context=None):
         case = work_item.case
 
+        send_event(
+            events.completed_work_item,
+            sender="post_complete_work_item",
+            work_item=work_item,
+            user=user,
+            context=context,
+        )
+
         if not CompleteWorkItemLogic._can_continue(work_item, work_item.task):
             return work_item
 
@@ -160,14 +168,6 @@ class CompleteWorkItemLogic:
                         user=user,
                         context=context,
                     )
-
-        send_event(
-            events.completed_work_item,
-            sender="post_complete_work_item",
-            work_item=work_item,
-            user=user,
-            context=context,
-        )
 
         if (
             not next_tasks.exists()

--- a/docs/events.md
+++ b/docs/events.md
@@ -68,6 +68,13 @@ in case the event sends additional arguments in the future.
 | `suspended_case`      | `SuspendCase`                                                     | `case`, `user`, `context`      |
 | `resumed_case`        | `ResumeCase`                                                      | `case`, `user`, `context`      |
 
+In some cases when one mutation emits multiple events, it is important to know their respective order:
+
+- `CompleteWorkItem`:
+  1. `completed_work_item`
+  2. `created_work_item`
+  3. `completed_case`
+
 ## Event receivers are blocking
 
 For the time being, event receivers are blocking. Keep in mind that a request that leads to Caluma


### PR DESCRIPTION
This event should always be sent when a work item has been completed,
even if the workflow doesn't continue (e.g. for multiple instance tasks
that remain open).