### PR TITLE
fix(migrations): do not hang in migrations on broken data

### DIFF
--- a/caluma/caluma_workflow/migrations/0020_case_families.py
+++ b/caluma/caluma_workflow/migrations/0020_case_families.py
@@ -16,8 +16,13 @@ def set_family(apps, schema_editor):
 
     for case in orphan_cases:
         family = case
-        while hasattr(family, "parent_work_item"):
-            family = case.parent_work_item.case
+        # Navigate up the hierarchy, but avoid hanging
+        # if we have a loop in the data structure
+        while (
+            hasattr(family, "parent_work_item")
+            and family.parent_work_item.case != family
+        ):
+            family = family.parent_work_item.case
         case.family = family
 
     Case.objects.using(db_alias).bulk_update(orphan_cases, ["family"])


### PR DESCRIPTION
When a case's parent work item points to itself, the migration will
loop forever. Catch this situation and abort in that case.