### PR TITLE
Initial python api for caluma_form

### DIFF
--- a/caluma/caluma_core/models.py
+++ b/caluma/caluma_core/models.py
@@ -60,6 +60,9 @@ class SlugModel(BaseModel, HistoricalModel):
     def __str__(self):
         return self.slug
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(slug={self.slug})"
+
     class Meta:
         abstract = True
 
@@ -72,6 +75,12 @@ class UUIDModel(BaseModel, HistoricalModel):
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    def __str__(self):
+        return self.id
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(id={self.id})"
 
     class Meta:
         abstract = True
@@ -88,6 +97,12 @@ class NaturalKeyModel(BaseModel, HistoricalModel):
     def save(self, *args, **kwargs):
         self.id = self.natural_key()
         return super().save(*args, **kwargs)
+
+    def __str__(self):
+        return self.id
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(id={self.id})"
 
     class Meta:
         abstract = True

--- a/caluma/caluma_form/api.py
+++ b/caluma/caluma_form/api.py
@@ -1,0 +1,40 @@
+from typing import Any, Optional
+
+from caluma.caluma_form import domain_logic, models
+from caluma.caluma_user.models import BaseUser
+
+
+def save_answer(
+    question: models.Question,
+    document: models.Document,
+    user: Optional[BaseUser] = None,
+    value: Optional[Any] = None,
+    context: Optional[dict] = None,
+    **kwargs
+) -> models.Answer:
+    """
+    Save an answer for given question, document.
+
+    Similar to saveDocumentStringAnswer and the likes, it performes upsert.
+    :param value: Must match the question type
+    """
+
+    data = {"question": question, "document": document, "value": value}
+    data.update(kwargs)
+
+    answer = models.Answer.objects.filter(question=question, document=document).first()
+
+    validated_data = domain_logic.SaveAnswerLogic.pre_save(
+        domain_logic.SaveAnswerLogic.validate_for_save(
+            data, user, answer=answer, origin=True
+        )
+    )
+
+    if answer is None:
+        answer = domain_logic.SaveAnswerLogic.create(validated_data, user)
+    else:
+        answer = domain_logic.SaveAnswerLogic.update(validated_data, answer)
+
+    domain_logic.SaveAnswerLogic.post_save(answer)
+
+    return answer

--- a/caluma/caluma_form/api.py
+++ b/caluma/caluma_form/api.py
@@ -38,3 +38,21 @@ def save_answer(
     domain_logic.SaveAnswerLogic.post_save(answer)
 
     return answer
+
+
+def save_document(
+    form: models.Form,
+    meta: Optional[dict] = None,
+    document: Optional[models.Document] = None,
+    user: Optional[BaseUser] = None,
+) -> models.Document:
+    """Save a document for a given form."""
+
+    if meta is None:
+        meta = {}
+
+    if not document:
+        return domain_logic.SaveDocumentLogic.create(form=form, meta=meta, user=user)
+
+    domain_logic.SaveDocumentLogic.update(document, form=form, meta=meta)
+    return document

--- a/caluma/caluma_form/domain_logic.py
+++ b/caluma/caluma_form/domain_logic.py
@@ -1,0 +1,85 @@
+from django.db import transaction
+
+from caluma.caluma_form import models, validators
+from caluma.caluma_user.models import BaseUser
+from caluma.utils import update_model
+
+
+class SaveAnswerLogic:
+    @staticmethod
+    def validate_for_save(
+        data: dict, user: BaseUser, answer: models.Answer = None, origin: bool = False
+    ) -> dict:
+        question = data["question"]
+
+        if question.type == models.Question.TYPE_TABLE:
+            data["documents"] = models.Document.objects.filter(pk__in=data["value"])
+            del data["value"]
+        elif question.type == models.Question.TYPE_FILE:
+            data["file"] = data["value"]
+            del data["value"]
+        elif question.type == models.Question.TYPE_DATE:
+            data["date"] = data["value"]
+            del data["value"]
+
+        validators.AnswerValidator().validate(
+            **data, user=user, instance=answer, origin=origin
+        )
+
+        return data
+
+    @staticmethod
+    def pre_save(validated_data: dict) -> dict:
+        # TODO emit events
+        return validated_data
+
+    @staticmethod
+    def post_save(answer: models.Answer) -> models.Answer:
+        # TODO emit events
+        return answer
+
+    @staticmethod
+    @transaction.atomic
+    def create(validated_data, user):
+        if validated_data["question"].type == models.Question.TYPE_FILE:
+            validated_data = __class__.set_file(validated_data)
+
+        if validated_data["question"].type == models.Question.TYPE_TABLE:
+            documents = validated_data.pop("documents")
+
+        if user:
+            validated_data["created_by_user"] = user
+            validated_data["created_by_group"] = user.group
+
+        answer = models.Answer.objects.create(**validated_data)
+
+        if answer.question.type == models.Question.TYPE_TABLE:
+            answer.create_answer_documents(documents)
+
+        return answer
+
+    @staticmethod
+    @transaction.atomic
+    def update(validated_data, answer):
+        if answer.question.type == models.Question.TYPE_TABLE:
+            documents = validated_data.pop("documents")
+            answer.unlink_unused_rows(docs_to_keep=documents)
+
+        if (
+            answer.question.type == models.Question.TYPE_FILE
+            and answer.file.name is not validated_data["file"]
+        ):
+            answer.file.delete()
+            validated_data = __class__.set_file(validated_data)
+
+        update_model(answer, validated_data)
+
+        if answer.question.type == models.Question.TYPE_TABLE:
+            answer.create_answer_documents(documents)
+
+    @staticmethod
+    def set_file(validated_data):
+        file_name = validated_data.get("file")
+        file = models.File.objects.create(name=file_name)
+        validated_data["file"] = file
+        return validated_data

--- a/caluma/caluma_form/models.py
+++ b/caluma/caluma_form/models.py
@@ -164,6 +164,10 @@ class Question(core_models.SlugModel):
         }
         return empties.get(self.type, None)
 
+    def __repr__(self):
+        base = super().__repr__()
+        return base[:-1] + f", type={self.type})"
+
     class Meta:
         indexes = [GinIndex(fields=["meta"])]
 
@@ -290,6 +294,9 @@ class Document(core_models.UUIDModel):
 
         return new_document
 
+    def __repr__(self):
+        return f"Document(form={self.form!r})"
+
     class Meta:
         indexes = [GinIndex(fields=["meta"])]
 
@@ -366,6 +373,9 @@ class Answer(core_models.BaseModel):
             # TODO: Can/should we delete the detached documents?
             ans_doc.document.set_family(ans_doc.document)
             ans_doc.delete()
+
+    def __repr__(self):
+        return f"Answer(document={self.document!r}, question={self.question!r}, value={self.value!r})"
 
     class Meta:
         # a question may only be answerd once per document

--- a/caluma/caluma_form/tests/__snapshots__/test_document.ambr
+++ b/caluma/caluma_form/tests/__snapshots__/test_document.ambr
@@ -349,7 +349,7 @@
     },
   }
 ---
-# name: test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-False]
+# name: test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -360,7 +360,10 @@
     },
   }
 ---
-# name: test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-True]
+# name: test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -371,7 +374,10 @@
     },
   }
 ---
-# name: test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-False]
+# name: test_save_document_answer[choice-question__configuration17-None-question__format_validators17-option-slug-None-SaveDocumentStringAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=choice), value='option-slug')
+---
+# name: test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentDateAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -382,7 +388,10 @@
     },
   }
 ---
-# name: test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-True]
+# name: test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentDateAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -393,7 +402,10 @@
     },
   }
 ---
-# name: test_save_document_answer[dynamic_choice-question__configuration21-MyDataSource-question__format_validators21-5.5-None-SaveDocumentStringAnswer-True-option-slug-False]
+# name: test_save_document_answer[date-question__configuration7-None-question__format_validators7-None-2019-02-22-SaveDocumentDateAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=date), value=None)
+---
+# name: test_save_document_answer[dynamic_choice-question__configuration21-MyDataSource-question__format_validators21-5.5-None-SaveDocumentStringAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -404,7 +416,10 @@
     },
   }
 ---
-# name: test_save_document_answer[dynamic_choice-question__configuration21-MyDataSource-question__format_validators21-5.5-None-SaveDocumentStringAnswer-True-option-slug-True]
+# name: test_save_document_answer[dynamic_choice-question__configuration21-MyDataSource-question__format_validators21-5.5-None-SaveDocumentStringAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[dynamic_choice-question__configuration21-MyDataSource-question__format_validators21-5.5-None-SaveDocumentStringAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -415,7 +430,10 @@
     },
   }
 ---
-# name: test_save_document_answer[dynamic_multiple_choice-question__configuration19-MyDataSource-question__format_validators19-answer__value19-None-SaveDocumentListAnswer-True-option-slug-False]
+# name: test_save_document_answer[dynamic_choice-question__configuration21-MyDataSource-question__format_validators21-5.5-None-SaveDocumentStringAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=dynamic_choice), value='5.5')
+---
+# name: test_save_document_answer[dynamic_multiple_choice-question__configuration19-MyDataSource-question__format_validators19-answer__value19-None-SaveDocumentListAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentListAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -429,7 +447,10 @@
     },
   }
 ---
-# name: test_save_document_answer[dynamic_multiple_choice-question__configuration19-MyDataSource-question__format_validators19-answer__value19-None-SaveDocumentListAnswer-True-option-slug-True]
+# name: test_save_document_answer[dynamic_multiple_choice-question__configuration19-MyDataSource-question__format_validators19-answer__value19-None-SaveDocumentListAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[dynamic_multiple_choice-question__configuration19-MyDataSource-question__format_validators19-answer__value19-None-SaveDocumentListAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentListAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -443,7 +464,10 @@
     },
   }
 ---
-# name: test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-False]
+# name: test_save_document_answer[dynamic_multiple_choice-question__configuration19-MyDataSource-question__format_validators19-answer__value19-None-SaveDocumentListAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=dynamic_multiple_choice), value=['5.5', '1'])
+---
+# name: test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentFileAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -457,7 +481,10 @@
     },
   }
 ---
-# name: test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-True]
+# name: test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentFileAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -471,7 +498,10 @@
     },
   }
 ---
-# name: test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-False]
+# name: test_save_document_answer[file-question__configuration10-None-question__format_validators10-not-exist.pdf-None-SaveDocumentFileAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=file), value=None)
+---
+# name: test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentFileAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -485,7 +515,10 @@
     },
   }
 ---
-# name: test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-True]
+# name: test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentFileAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -499,7 +532,10 @@
     },
   }
 ---
-# name: test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-False]
+# name: test_save_document_answer[file-question__configuration9-None-question__format_validators9-some-file.pdf-None-SaveDocumentFileAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=file), value=None)
+---
+# name: test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentFloatAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -510,7 +546,10 @@
     },
   }
 ---
-# name: test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-True]
+# name: test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentFloatAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -521,7 +560,10 @@
     },
   }
 ---
-# name: test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-False]
+# name: test_save_document_answer[float-question__configuration2-None-question__format_validators2-2.1-None-SaveDocumentFloatAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=float), value=2.1)
+---
+# name: test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentIntegerAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -532,7 +574,10 @@
     },
   }
 ---
-# name: test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-True]
+# name: test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentIntegerAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -543,7 +588,10 @@
     },
   }
 ---
-# name: test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-False]
+# name: test_save_document_answer[integer-question__configuration0-None-question__format_validators0-1-None-SaveDocumentIntegerAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=integer), value=1)
+---
+# name: test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentListAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -556,7 +604,10 @@
     },
   }
 ---
-# name: test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-True]
+# name: test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentListAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -569,7 +620,10 @@
     },
   }
 ---
-# name: test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-False]
+# name: test_save_document_answer[multiple_choice-question__configuration15-None-question__format_validators15-answer__value15-None-SaveDocumentListAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=multiple_choice), value=['option-slug'])
+---
+# name: test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentTableAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -591,7 +645,10 @@
     },
   }
 ---
-# name: test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-True]
+# name: test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentTableAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -613,7 +670,10 @@
     },
   }
 ---
-# name: test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False]
+# name: test_save_document_answer[table-question__configuration12-None-question__format_validators12-None-None-SaveDocumentTableAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=treatment-radio)), question=Question(slug=effort-meet, type=table), value=None)
+---
+# name: test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -624,7 +684,10 @@
     },
   }
 ---
-# name: test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True]
+# name: test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -635,7 +698,10 @@
     },
   }
 ---
-# name: test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-False]
+# name: test_save_document_answer[text-question__configuration24-None-question__format_validators24-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=text), value='test@example.com')
+---
+# name: test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -646,7 +712,10 @@
     },
   }
 ---
-# name: test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-True]
+# name: test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -657,7 +726,10 @@
     },
   }
 ---
-# name: test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-False]
+# name: test_save_document_answer[text-question__configuration4-None-question__format_validators4-Test-None-SaveDocumentStringAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=text), value='Test')
+---
+# name: test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -668,7 +740,10 @@
     },
   }
 ---
-# name: test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-True]
+# name: test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -679,7 +754,10 @@
     },
   }
 ---
-# name: test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False]
+# name: test_save_document_answer[textarea-question__configuration13-None-question__format_validators13-Test-None-SaveDocumentStringAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=textarea), value='Test')
+---
+# name: test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -690,7 +768,10 @@
     },
   }
 ---
-# name: test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True]
+# name: test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-False-True]
+  None
+---
+# name: test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True-False]
   <class 'OrderedDict'> {
     'saveDocumentStringAnswer': <class 'dict'> {
       'answer': <class 'dict'> {
@@ -700,6 +781,9 @@
       'clientMutationId': 'testid',
     },
   }
+---
+# name: test_save_document_answer[textarea-question__configuration26-None-question__format_validators26-test@example.com-None-SaveDocumentStringAnswer-True-option-slug-True-True]
+  Answer(document=Document(form=Form(slug=suggest-traditional)), question=Question(slug=effort-meet, type=textarea), value='test@example.com')
 ---
 # name: test_save_document_answer_empty[text-false-None-False]
   <class 'OrderedDict'> {

--- a/caluma/caluma_form/tests/test_document.py
+++ b/caluma/caluma_form/tests/test_document.py
@@ -386,7 +386,7 @@ def test_save_document(db, document, schema_executor, update):
     assert same_id == update
 
 
-@pytest.mark.parametrize("use_api", [True, False])  # noqa:C901
+@pytest.mark.parametrize("use_python_api", [True, False])  # noqa:C901
 @pytest.mark.parametrize("delete_answer", [True, False])
 @pytest.mark.parametrize("option__slug", ["option-slug"])
 @pytest.mark.parametrize(
@@ -663,7 +663,7 @@ def test_save_document_answer(
     delete_answer,
     minio_mock,
     data_source_settings,
-    use_api,
+    use_python_api,
     admin_user,
 ):
     mutation_func = mutation[0].lower() + mutation[1:]
@@ -747,7 +747,7 @@ def test_save_document_answer(
         # delete answer to force create test instead of update
         Answer.objects.filter(pk=answer.pk).delete()
 
-    if not use_api:
+    if not use_python_api:
         result = schema_executor(query, variable_values=inp)
 
         assert not bool(result.errors) == success

--- a/caluma/caluma_form/tests/test_document.py
+++ b/caluma/caluma_form/tests/test_document.py
@@ -1,4 +1,5 @@
 import pytest
+from django.utils.dateparse import parse_date
 from graphql_relay import to_global_id
 
 from ...caluma_core.relay import extract_global_id
@@ -6,7 +7,7 @@ from ...caluma_core.tests import extract_serializer_input_fields
 from ...caluma_core.visibilities import BaseVisibility, filter_queryset_for
 from ...caluma_form.models import Answer, Document, Question
 from ...caluma_form.schema import Document as DocumentNodeType
-from .. import serializers
+from .. import api, serializers
 
 
 @pytest.mark.parametrize(
@@ -385,6 +386,7 @@ def test_save_document(db, document, schema_executor, update):
     assert same_id == update
 
 
+@pytest.mark.parametrize("use_api", [True, False])  # noqa:C901
 @pytest.mark.parametrize("delete_answer", [True, False])
 @pytest.mark.parametrize("option__slug", ["option-slug"])
 @pytest.mark.parametrize(
@@ -661,6 +663,8 @@ def test_save_document_answer(
     delete_answer,
     minio_mock,
     data_source_settings,
+    use_api,
+    admin_user,
 ):
     mutation_func = mutation[0].lower() + mutation[1:]
     query = f"""
@@ -736,15 +740,34 @@ def test_save_document_answer(
         if answer.date == "1900-01-01":
             inp["input"]["value"] = "not a date"
 
+        if use_python_api and success:
+            inp["input"]["value"] = parse_date(inp["input"]["value"])
+
     if delete_answer:
         # delete answer to force create test instead of update
         Answer.objects.filter(pk=answer.pk).delete()
 
-    result = schema_executor(query, variable_values=inp)
+    if not use_api:
+        result = schema_executor(query, variable_values=inp)
 
-    assert not bool(result.errors) == success
-    if success:
-        snapshot.assert_match(result.data)
+        assert not bool(result.errors) == success
+
+        if success:
+            snapshot.assert_match(result.data)
+    else:
+        if success:
+            answer = api.save_answer(
+                question, answer.document, user=admin_user, value=inp["input"]["value"]
+            )
+            snapshot.assert_match(answer)
+        else:
+            with pytest.raises(Exception):
+                api.save_answer(
+                    question,
+                    answer.document,
+                    user=admin_user,
+                    value=inp["input"]["value"],
+                )
 
 
 @pytest.mark.parametrize("delete_answer", [True, False])
@@ -839,9 +862,8 @@ def test_save_document_table_answer_invalid_row_form(
             serializers.SaveAnswerSerializer, answer
         )
     }
-    inp["input"]["value"] = [
-        str(document.pk) for document in document_factory.create_batch(1)
-    ]
+    inp["input"]["value"] = [str(document_factory().pk)]
+
     result = schema_executor(query, variable_values=inp)
     assert result.errors
 

--- a/caluma/caluma_workflow/api.py
+++ b/caluma/caluma_workflow/api.py
@@ -1,18 +1,10 @@
 from typing import Optional
 
-from django.db.models import Model
-
 from caluma.caluma_form.models import Form
 from caluma.caluma_user.models import BaseUser
+from caluma.utils import update_model
 
 from . import domain_logic, models
-
-
-def update_model(model: Model, data: dict) -> Model:
-    for key, value in data.items():
-        setattr(model, key, value)
-
-    model.save()
 
 
 def start_case(

--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -496,14 +496,14 @@ class CreateWorkItemSerializer(SendEventSerializerMixin, ContextModelSerializer)
                 task.control_groups, task, case, user, None, data.get("context", None)
             )
             if controlling_groups is not None:
-                data["controlling_groups"] = controlling_groups
+                data["controlling_groups"] = sorted(controlling_groups)
 
         if "addressed_groups" not in data:
             addressed_groups = utils.get_jexl_groups(
                 task.address_groups, task, case, user, None, data.get("context", None)
             )
             if addressed_groups is not None:
-                data["addressed_groups"] = addressed_groups
+                data["addressed_groups"] = sorted(addressed_groups)
 
         return super().validate(data)
 

--- a/caluma/caluma_workflow/tests/__snapshots__/test_work_item.ambr
+++ b/caluma/caluma_workflow/tests/__snapshots__/test_work_item.ambr
@@ -95,23 +95,23 @@
               <class 'dict'> {
                 'node': <class 'dict'> {
                   'addressedGroups': <class 'list'> [
-                    'some-group',
-                  ],
-                  'controllingGroups': <class 'list'> [
-                    'some-group',
-                  ],
-                  'status': 'READY',
-                },
-              },
-              <class 'dict'> {
-                'node': <class 'dict'> {
-                  'addressedGroups': <class 'list'> [
                   ],
                   'controllingGroups': <class 'list'> [
                     'controlling-group1',
                     'controlling-group2',
                   ],
                   'status': 'COMPLETED',
+                },
+              },
+              <class 'dict'> {
+                'node': <class 'dict'> {
+                  'addressedGroups': <class 'list'> [
+                    'some-group',
+                  ],
+                  'controllingGroups': <class 'list'> [
+                    'some-group',
+                  ],
+                  'status': 'READY',
                 },
               },
             ],
@@ -137,8 +137,10 @@
                   'addressedGroups': <class 'list'> [
                   ],
                   'controllingGroups': <class 'list'> [
+                    'controlling-group1',
+                    'controlling-group2',
                   ],
-                  'status': 'READY',
+                  'status': 'COMPLETED',
                 },
               },
               <class 'dict'> {
@@ -146,10 +148,8 @@
                   'addressedGroups': <class 'list'> [
                   ],
                   'controllingGroups': <class 'list'> [
-                    'controlling-group1',
-                    'controlling-group2',
                   ],
-                  'status': 'COMPLETED',
+                  'status': 'READY',
                 },
               },
             ],
@@ -175,8 +175,10 @@
                   'addressedGroups': <class 'list'> [
                   ],
                   'controllingGroups': <class 'list'> [
+                    'controlling-group1',
+                    'controlling-group2',
                   ],
-                  'status': 'READY',
+                  'status': 'COMPLETED',
                 },
               },
               <class 'dict'> {
@@ -184,10 +186,8 @@
                   'addressedGroups': <class 'list'> [
                   ],
                   'controllingGroups': <class 'list'> [
-                    'controlling-group1',
-                    'controlling-group2',
                   ],
-                  'status': 'COMPLETED',
+                  'status': 'READY',
                 },
               },
             ],
@@ -211,6 +211,17 @@
               <class 'dict'> {
                 'node': <class 'dict'> {
                   'addressedGroups': <class 'list'> [
+                  ],
+                  'controllingGroups': <class 'list'> [
+                    'controlling-group1',
+                    'controlling-group2',
+                  ],
+                  'status': 'COMPLETED',
+                },
+              },
+              <class 'dict'> {
+                'node': <class 'dict'> {
+                  'addressedGroups': <class 'list'> [
                     'case-creating-group',
                     'fake-user-group',
                   ],
@@ -219,17 +230,6 @@
                     'fake-user-group',
                   ],
                   'status': 'READY',
-                },
-              },
-              <class 'dict'> {
-                'node': <class 'dict'> {
-                  'addressedGroups': <class 'list'> [
-                  ],
-                  'controllingGroups': <class 'list'> [
-                    'controlling-group1',
-                    'controlling-group2',
-                  ],
-                  'status': 'COMPLETED',
                 },
               },
             ],
@@ -253,36 +253,36 @@
               <class 'dict'> {
                 'node': <class 'dict'> {
                   'addressedGroups': <class 'list'> [
-                    'fake-user-group',
-                  ],
-                  'controllingGroups': <class 'list'> [
-                    'case-creating-group',
-                    'fake-user-group',
-                  ],
-                  'status': 'READY',
-                },
-              },
-              <class 'dict'> {
-                'node': <class 'dict'> {
-                  'addressedGroups': <class 'list'> [
-                    'case-creating-group',
-                  ],
-                  'controllingGroups': <class 'list'> [
-                    'case-creating-group',
-                    'fake-user-group',
-                  ],
-                  'status': 'READY',
-                },
-              },
-              <class 'dict'> {
-                'node': <class 'dict'> {
-                  'addressedGroups': <class 'list'> [
                   ],
                   'controllingGroups': <class 'list'> [
                     'controlling-group1',
                     'controlling-group2',
                   ],
                   'status': 'COMPLETED',
+                },
+              },
+              <class 'dict'> {
+                'node': <class 'dict'> {
+                  'addressedGroups': <class 'list'> [
+                    'case-creating-group',
+                  ],
+                  'controllingGroups': <class 'list'> [
+                    'case-creating-group',
+                    'fake-user-group',
+                  ],
+                  'status': 'READY',
+                },
+              },
+              <class 'dict'> {
+                'node': <class 'dict'> {
+                  'addressedGroups': <class 'list'> [
+                    'fake-user-group',
+                  ],
+                  'controllingGroups': <class 'list'> [
+                    'case-creating-group',
+                    'fake-user-group',
+                  ],
+                  'status': 'READY',
                 },
               },
             ],
@@ -306,6 +306,17 @@
               <class 'dict'> {
                 'node': <class 'dict'> {
                   'addressedGroups': <class 'list'> [
+                  ],
+                  'controllingGroups': <class 'list'> [
+                    'controlling-group1',
+                    'controlling-group2',
+                  ],
+                  'status': 'COMPLETED',
+                },
+              },
+              <class 'dict'> {
+                'node': <class 'dict'> {
+                  'addressedGroups': <class 'list'> [
                     'case-creating-group',
                     'fake-user-group',
                   ],
@@ -314,17 +325,6 @@
                     'fake-user-group',
                   ],
                   'status': 'READY',
-                },
-              },
-              <class 'dict'> {
-                'node': <class 'dict'> {
-                  'addressedGroups': <class 'list'> [
-                  ],
-                  'controllingGroups': <class 'list'> [
-                    'controlling-group1',
-                    'controlling-group2',
-                  ],
-                  'status': 'COMPLETED',
                 },
               },
             ],
@@ -348,23 +348,23 @@
               <class 'dict'> {
                 'node': <class 'dict'> {
                   'addressedGroups': <class 'list'> [
-                    'case-creating-group',
-                  ],
-                  'controllingGroups': <class 'list'> [
-                    'case-creating-group',
-                  ],
-                  'status': 'READY',
-                },
-              },
-              <class 'dict'> {
-                'node': <class 'dict'> {
-                  'addressedGroups': <class 'list'> [
                   ],
                   'controllingGroups': <class 'list'> [
                     'controlling-group1',
                     'controlling-group2',
                   ],
                   'status': 'COMPLETED',
+                },
+              },
+              <class 'dict'> {
+                'node': <class 'dict'> {
+                  'addressedGroups': <class 'list'> [
+                    'case-creating-group',
+                  ],
+                  'controllingGroups': <class 'list'> [
+                    'case-creating-group',
+                  ],
+                  'status': 'READY',
                 },
               },
             ],
@@ -388,6 +388,17 @@
               <class 'dict'> {
                 'node': <class 'dict'> {
                   'addressedGroups': <class 'list'> [
+                  ],
+                  'controllingGroups': <class 'list'> [
+                    'controlling-group1',
+                    'controlling-group2',
+                  ],
+                  'status': 'COMPLETED',
+                },
+              },
+              <class 'dict'> {
+                'node': <class 'dict'> {
+                  'addressedGroups': <class 'list'> [
                     'controlling-group1',
                     'controlling-group2',
                   ],
@@ -396,17 +407,6 @@
                     'controlling-group2',
                   ],
                   'status': 'READY',
-                },
-              },
-              <class 'dict'> {
-                'node': <class 'dict'> {
-                  'addressedGroups': <class 'list'> [
-                  ],
-                  'controllingGroups': <class 'list'> [
-                    'controlling-group1',
-                    'controlling-group2',
-                  ],
-                  'status': 'COMPLETED',
                 },
               },
             ],
@@ -430,23 +430,23 @@
               <class 'dict'> {
                 'node': <class 'dict'> {
                   'addressedGroups': <class 'list'> [
-                    'fake-user-group',
-                  ],
-                  'controllingGroups': <class 'list'> [
-                    'fake-user-group',
-                  ],
-                  'status': 'READY',
-                },
-              },
-              <class 'dict'> {
-                'node': <class 'dict'> {
-                  'addressedGroups': <class 'list'> [
                   ],
                   'controllingGroups': <class 'list'> [
                     'controlling-group1',
                     'controlling-group2',
                   ],
                   'status': 'COMPLETED',
+                },
+              },
+              <class 'dict'> {
+                'node': <class 'dict'> {
+                  'addressedGroups': <class 'list'> [
+                    'fake-user-group',
+                  ],
+                  'controllingGroups': <class 'list'> [
+                    'fake-user-group',
+                  ],
+                  'status': 'READY',
                 },
               },
             ],

--- a/caluma/caluma_workflow/tests/test_case.py
+++ b/caluma/caluma_workflow/tests/test_case.py
@@ -600,7 +600,7 @@ def test_api_start_case(
 
 
 @pytest.mark.parametrize("work_item__child_case", [None])
-@pytest.mark.parametrize("use_api", [True, False])
+@pytest.mark.parametrize("use_python_api", [True, False])
 @pytest.mark.parametrize(
     "action,case__status,work_item__status,expected_case_status,expected_work_item_status,error",
     [
@@ -666,7 +666,7 @@ def test_cancel_suspend_resume_case(
     db,
     admin_user,
     schema_executor,
-    use_api,
+    use_python_api,
     action,
     case,
     work_item,
@@ -674,7 +674,7 @@ def test_cancel_suspend_resume_case(
     expected_work_item_status,
     error,
 ):
-    if not use_api:
+    if not use_python_api:
         query = f"""
             mutation ($id: ID!) {{
                 {action}Case(input: {{ id: $id }}) {{

--- a/caluma/caluma_workflow/tests/test_case.py
+++ b/caluma/caluma_workflow/tests/test_case.py
@@ -674,7 +674,7 @@ def test_cancel_suspend_resume_case(
     expected_work_item_status,
     error,
 ):
-    if use_api:
+    if not use_api:
         query = f"""
             mutation ($id: ID!) {{
                 {action}Case(input: {{ id: $id }}) {{

--- a/caluma/caluma_workflow/tests/test_work_item.py
+++ b/caluma/caluma_workflow/tests/test_work_item.py
@@ -406,7 +406,7 @@ def test_complete_work_item_with_next(
     db,
     group_jexl,
     is_multiple_instance,
-    snapshot,
+    sorted_snapshot,
     work_item,
     task,
     task_factory,
@@ -466,7 +466,7 @@ def test_complete_work_item_with_next(
     result = schema_executor(query, variable_values=inp, info=info)
 
     assert not result.errors
-    snapshot.assert_match(result.data)
+    assert result.data == sorted_snapshot("addressedGroups")
 
 
 @pytest.mark.parametrize(

--- a/caluma/caluma_workflow/tests/test_work_item.py
+++ b/caluma/caluma_workflow/tests/test_work_item.py
@@ -466,7 +466,7 @@ def test_complete_work_item_with_next(
     result = schema_executor(query, variable_values=inp, info=info)
 
     assert not result.errors
-    assert result.data == sorted_snapshot("addressedGroups")
+    assert result.data == sorted_snapshot("edges", lambda x: json.dumps(x))
 
 
 @pytest.mark.parametrize(

--- a/caluma/conftest.py
+++ b/caluma/conftest.py
@@ -294,7 +294,7 @@ def sorted_snapshot(snapshot):
     The second arg (key) is passed to the builtin `sorted` function.
     """
 
-    def _sorted(name, key):
+    def _sorted(name, key=None):
         def _(data, path):
             if isinstance(data, list) and path[-1][0] == name:
                 return sorted(data, key=key)

--- a/caluma/utils.py
+++ b/caluma/utils.py
@@ -1,5 +1,7 @@
 from logging import getLogger
 
+from django.db.models import Model
+
 log = getLogger(__name__)
 
 
@@ -79,3 +81,10 @@ def fix_foreign_key_types(apps, connection):
                     cursor.execute(
                         fix_sql % (model._meta.db_table, _field_name(field), new_type)
                     )
+
+
+def update_model(model: Model, data: dict) -> Model:
+    for key, value in data.items():
+        setattr(model, key, value)
+
+    model.save()

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -317,6 +317,8 @@ For completeness, they are listed here:
 You can also use the full business logic that is provided by the GraphQL API
 in your application that installs Caluma as a django app:
 
+- `caluma_form.api.save_answer` To save an answer for give question, document
+- `caluma_form.api.save_document` To save an document
 - `caluma_workflow.api.start_case` To start a new case of a given workflow
 - `caluma_workflow.api.cancel_case` To cancel a case
 - `caluma_workflow.api.suspend_case` To suspend a case


### PR DESCRIPTION
* [x] `saveDocument___Answer` -> `save_answer` handles all question types
* [x] `saveDocument`

Future considerations:
* [ ] `removeAnswer`
* [ ] `copyDocument`
* [ ] `save___Question`
* [ ] `saveForm`
* [ ] `copyForm`
* [ ] `addFormQuestion`
* [ ] `removeFormQuestion`
* [ ] `reorderFormQuestions`
