### PR TITLE
feat(validation): validate jexl expressions

### DIFF
--- a/caluma/caluma_core/jexl.py
+++ b/caluma/caluma_core/jexl.py
@@ -75,7 +75,7 @@ class JEXL(pyjexl.JEXL):
 
 class ExtractTransformSubjectAnalyzer(ValidatingAnalyzer):
     """
-    Extract all subject values of given transforms.
+    Extract all subjects of given transforms.
 
     If no transforms are given all subjects of all transforms will be extracted.
     """
@@ -86,7 +86,16 @@ class ExtractTransformSubjectAnalyzer(ValidatingAnalyzer):
 
     def visit_Transform(self, transform):
         if not self.transforms or transform.name in self.transforms:
-            # can only extract subject's value if subject is not a transform itself
-            if not isinstance(transform.subject, type(transform)):
-                yield transform.subject.value
+            yield transform.subject
         yield from self.generic_visit(transform)
+
+
+class ExtractTransformSubjectValueAnalyzer(ExtractTransformSubjectAnalyzer):
+    """
+    Extract all subject values of given transforms.
+
+    If no transforms are given all subjects of all transforms will be extracted.
+    """
+
+    def visit_Transform(self, transform):
+        return (literal.value for literal in super().visit_Transform(transform))

--- a/caluma/caluma_core/tests/test_jexl.py
+++ b/caluma/caluma_core/tests/test_jexl.py
@@ -21,7 +21,8 @@ def test_extract_transforms(expression, expected_transforms):
     jexl.add_transform("transform2", lambda x: x)
 
     assert set(
-        jexl.analyze(
+        expr.value
+        for expr in jexl.analyze(
             expression,
             functools.partial(
                 ExtractTransformSubjectAnalyzer, transforms=["transform1"]

--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -366,11 +366,22 @@ class QuestionValidator:
         if data_source not in data_sources:
             raise exceptions.ValidationError(f'Invalid data_source: "{data_source}"')
 
+    def _validate_jexl(self, expr):
+        q_jexl = jexl.QuestionJexl({})
+        # Extraction of referenced questions triggers validation.
+        # It implies that the expression is parseable and the `mapby` and
+        # `answer` transforms are only applied to string literals
+        list(q_jexl.extract_referenced_questions(expr))
+
     def validate(self, data):
         if data["type"] in ["text", "textarea"]:
             self._validate_format_validators(data)
         if "dataSource" in data:
             self._validate_data_source(data["dataSource"])
+        if "isRequired" in data:
+            self._validate_jexl(data["isRequired"])
+        if "isHidden" in data:
+            self._validate_jexl(data["isHidden"])
 
 
 def get_document_validity(document, user):

--- a/caluma/caluma_workflow/jexl.py
+++ b/caluma/caluma_workflow/jexl.py
@@ -6,7 +6,7 @@ from pyjexl.analysis import ValidatingAnalyzer
 from pyjexl.evaluator import Context
 from pyjexl.parser import Literal
 
-from ..caluma_core.jexl import JEXL, ExtractTransformSubjectAnalyzer
+from ..caluma_core.jexl import JEXL, ExtractTransformSubjectValueAnalyzer
 from .models import Task
 
 
@@ -155,7 +155,7 @@ class FlowJexl(JEXL):
 
     def extract_tasks(self, expr):
         yield from self.analyze(
-            expr, partial(ExtractTransformSubjectAnalyzer, transforms=["task"])
+            expr, partial(ExtractTransformSubjectValueAnalyzer, transforms=["task"])
         )
 
         # tasks transforms return a list of literals
@@ -163,7 +163,8 @@ class FlowJexl(JEXL):
             literal.value
             for literal in chain(
                 *self.analyze(
-                    expr, partial(ExtractTransformSubjectAnalyzer, transforms=["tasks"])
+                    expr,
+                    partial(ExtractTransformSubjectValueAnalyzer, transforms=["tasks"]),
                 )
             )
         )

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -47,6 +47,10 @@ Here are the available transforms:
   `'ravioli' in 'fridge-contents'|answer|mapby('food-name')` will tell you whether
   there are ravioli.
 
+Note: The `answer` transform only works on string literals. It is not
+possible to calculate a question slug, for example, and then fetch the
+answer of that.
+
 ### Operators
 
 Other operators that aren't transforms are also available:


### PR DESCRIPTION
Question JEXL expressions should be validated, and some checks applied.
Parse the expressions, and verify that the `answer` and `mapby` transforms
are only applied to string literals.