### PR TITLE
fix(dynamic question)!: pass user instead of info object to data source

### DIFF
--- a/caluma/caluma_data_source/data_source_handlers.py
+++ b/caluma/caluma_data_source/data_source_handlers.py
@@ -53,12 +53,12 @@ def get_data_sources(dic=False):
     ]
 
 
-def get_data_source_data(info, name):
+def get_data_source_data(user, name):
     data_sources = get_data_sources(dic=True)
     if name not in data_sources:
         raise DataSourceException(f"No data_source found for name: {name}")
 
-    raw_data = data_sources[name]().try_get_data_with_fallback(info)
+    raw_data = data_sources[name]().try_get_data_with_fallback(user)
     if not is_iterable_and_no_string(raw_data):
         raise DataSourceException(f"Failed to parse data from source: {name}")
 

--- a/caluma/caluma_data_source/data_sources.py
+++ b/caluma/caluma_data_source/data_sources.py
@@ -14,7 +14,7 @@ class BaseDataSource:
     two items. The first will be used for the option name, the second one for it's
     value. If only one value is provided, this value will also be used as choice name.
 
-    The `validate_answer_value`-method checks if each value in `self.get_data(info)` equals the value
+    The `validate_answer_value`-method checks if each value in `self.get_data(user)` equals the value
     of the parameter `value`. If this is correct the method returns the label as a String
     and otherwise the method returns `False`.
 
@@ -40,10 +40,8 @@ class BaseDataSource:
     ...     info = 'User choices from "someapi"'
     ...
     ...     @data_source_cache(timeout=3600)
-    ...     def get_data(self, info):
-    ...         response = requests.get(
-    ...             f"https://someapi/?user={info.context.request.user.username}"
-    ...         )
+    ...     def get_data(self, user):
+    ...         response = requests.get(f"https://someapi/?user={user.username}")
     ...         return [result["value"] for result in response.json()["results"]]
     ```
 
@@ -55,11 +53,11 @@ class BaseDataSource:
     def __init__(self):
         pass
 
-    def get_data(self, info):  # pragma: no cover
+    def get_data(self, user):  # pragma: no cover
         raise NotImplementedError()
 
-    def validate_answer_value(self, value, document, question, info):
-        for data in self.get_data(info):
+    def validate_answer_value(self, value, document, question, user):
+        for data in self.get_data(user):
             label = data
             if is_iterable_and_no_string(data):
                 label = data[-1]
@@ -75,9 +73,9 @@ class BaseDataSource:
             return dynamic_option.label
         return False
 
-    def try_get_data_with_fallback(self, info):
+    def try_get_data_with_fallback(self, user):
         try:
-            new_data = self.get_data(info)
+            new_data = self.get_data(user)
         except Exception as e:
             logger.exception(
                 f"Executing {type(self).__name__}.get_data() failed:"

--- a/caluma/caluma_data_source/schema.py
+++ b/caluma/caluma_data_source/schema.py
@@ -33,4 +33,4 @@ class Query(object):
         return get_data_sources()
 
     def resolve_data_source(self, info, name):
-        return get_data_source_data(info, name)
+        return get_data_source_data(info.context.user, name)

--- a/caluma/caluma_data_source/tests/data_sources.py
+++ b/caluma/caluma_data_source/tests/data_sources.py
@@ -9,7 +9,7 @@ class MyDataSource(BaseDataSource):
     default = [1, 2, 3]
 
     @data_source_cache(timeout=3600)
-    def get_data(self, info):
+    def get_data(self, user):
         return [
             1,
             (5.5,),
@@ -45,7 +45,7 @@ class MyFaultyDataSource(BaseDataSource):
     default = None
 
     @data_source_cache(timeout=3600)
-    def get_data(self, info):
+    def get_data(self, user):
         return "just a string"
 
 
@@ -54,7 +54,7 @@ class MyOtherFaultyDataSource(BaseDataSource):
     default = None
 
     @data_source_cache(timeout=3600)
-    def get_data(self, info):
+    def get_data(self, user):
         return [["just", "some", "strings"]]
 
 
@@ -63,7 +63,7 @@ class MyBrokenDataSource(BaseDataSource):
     default = [1, 2, 3]
 
     @data_source_cache(timeout=3600)
-    def get_data(self, info):
+    def get_data(self, user):
         raise Exception()
 
 
@@ -72,5 +72,5 @@ class MyOtherBrokenDataSource(BaseDataSource):
     default = None
 
     @data_source_cache(timeout=3600)
-    def get_data(self, info):
+    def get_data(self, user):
         raise Exception()

--- a/caluma/caluma_form/schema.py
+++ b/caluma/caluma_form/schema.py
@@ -285,7 +285,7 @@ class DynamicChoiceQuestion(QuestionQuerysetMixin, FormDjangoObjectType):
     data_source = graphene.String(required=True)
 
     def resolve_options(self, info, *args):
-        return get_data_source_data(info, self.data_source)
+        return get_data_source_data(info.context.user, self.data_source)
 
     class Meta:
         model = models.Question
@@ -310,7 +310,7 @@ class DynamicMultipleChoiceQuestion(QuestionQuerysetMixin, FormDjangoObjectType)
     data_source = graphene.String(required=True)
 
     def resolve_options(self, info, *args):
-        return get_data_source_data(info, self.data_source)
+        return get_data_source_data(info.context.user, self.data_source)
 
     class Meta:
         model = models.Question

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -214,10 +214,8 @@ class CustomDataSource(BaseDataSource):
    info = 'User choices from "someapi"'
 
    @data_source_cache(timeout=3600)
-   def get_data(self, info):
-       response = requests.get(
-           f"https://someapi/?user={info.context.user.username}"
-       )
+   def get_data(self, user):
+       response = requests.get(f"https://someapi/?user={user.username}")
        return [result["value"] for result in response.json()["results"]]
 ```
 


### PR DESCRIPTION
BREAKING CHANGE: Pass the `user` to the `get_data` method of a data source instead of the whole `info` object since we don't have an info object when calling the python API.

Before:

```python
class CustomDataSource(BaseDataSource):
   info = 'User choices from "someapi"'

   @data_source_cache(timeout=3600)
   def get_data(self, info):
       response = requests.get(
           f"https://someapi/?user={info.context.user.username}"
       )
       return [result["value"] for result in response.json()["results"]]
```

After:

```python
class CustomDataSource(BaseDataSource):
   info = 'User choices from "someapi"'

   @data_source_cache(timeout=3600)
   def get_data(self, user):
       response = requests.get(f"https://someapi/?user={user.username}")
       return [result["value"] for result in response.json()["results"]]
```

This fixes the `validate_answer_value` method that currently only passes the `user` instead of the `info` object.