### PR TITLE
chore: separate version pinning for install_requires

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -21,6 +21,7 @@ Files:
     manage.py
     MANIFEST.in
     renovate.json
+    requirements-all.txt
     requirements-dev.txt
     requirements.txt
     setup.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ env:
     - DOCKER_COMPOSE_VERSION=1.24.0
 
 before_install:
-  # install newer compose version
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-
   # Workaround for https://github.com/travis-ci/travis-ci/issues/4842
   # Let's stop postgresql
   - sudo service postgresql stop
@@ -45,3 +39,16 @@ jobs:
         PIPENV_IGNORE_VIRTUALENVS=1
       install: python3 setup.py pipenv
       script: pipenv run pytest
+    - env:
+        BUILD_TYPE=package
+      install:
+        - echo UID=$(id -u) > .env
+        - echo ENV=dev >> .env
+        - docker-compose up -d db
+        - rm -rf dist/
+        - python -m pip install --upgrade pip
+        - pip install setuptools wheel
+        - python setup.py bdist_wheel
+        - pip install dist/caluma-*.whl
+        - pip install -r requirements-dev.txt
+      script: pytest --no-cov-on-fail --cov --create-db -vv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ First create a virtualenv with the tool of your choice before running below comm
 
 ```bash
 pip install pre-commit
-pip install -r requirements-dev.txt -U
+pip install -r requirements-all.txt -U
 pre-commit install --hook=pre-commit
 pre-commit install --hook=commit-msg
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV DJANGO_SETTINGS_MODULE caluma.settings.django
 ENV UWSGI_INI /app/uwsgi.ini
 
 ARG REQUIREMENTS=requirements.txt
-COPY requirements.txt requirements-dev.txt $APP_HOME/
+COPY requirements.txt requirements-dev.txt requirements-all.txt $APP_HOME/
 RUN pip install --no-cache-dir --upgrade -r $REQUIREMENTS --disable-pip-version-check
 
 USER caluma

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: .
       args:
-        REQUIREMENTS: requirements-dev.txt
+        REQUIREMENTS: requirements-all.txt
     user: "${UID:?Set UID env variable to your user id}"
     volumes:
       - ./:/app

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+-r requirements-dev.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 # When adding new dependencies here, also add them to the renovate.json to
 # enable auto-merge
 
--r requirements.txt
 black==19.3b0
 factory-boy==3.0.1
 faker==4.16.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,27 @@
+[options]
+package = find:
+python_requires = >=3.6, <4
+install_requires =
+    dateparser <2
+    django ~= 2.2
+    django-cors-headers <4
+    django-environ <0.5
+    django-extensions <4
+    django-filter <3
+    django-localized-fields <6
+    django-postgres-extra <2
+    djangorestframework <4
+    django_simple_history <3
+    graphene-django <=2.8.2
+    idna <3
+    minio <6
+    psycopg2-binary <3
+    pyjexl <0.3
+    python-memcached <2
+    requests <3
+    urllib3 <2
+    uwsgi <2.1
+
 [flake8]
 ignore =
     # whitespace before ':'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import distutils.cmd
 import os
 from os import path
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 version = {}
 with open("caluma/caluma_metadata.py") as fp:
@@ -60,28 +60,5 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Programming Language :: Python :: 3.7",
-    ],
-    packages=find_packages(),
-    python_requires=">=3.6, <4",
-    install_requires=[
-        "dateparser<2",
-        "django>=2.2, <3",
-        "django-cors-headers<4",
-        "django-environ<0.5",
-        "django-extensions<4",
-        "django-filter<3",
-        "django-localized-fields<6",
-        "django-postgres-extra<2",
-        "djangorestframework<4",
-        "django_simple_history<3",
-        "graphene-django<=2.8.2",
-        "idna<3",
-        "minio<6",
-        "psycopg2-binary<3",
-        "pyjexl<0.3",
-        "python-memcached<2",
-        "requests<3",
-        "urllib3<2",
-        "uwsgi<2.1",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,16 +26,6 @@ pipenv install -d -r requirements-dev.txt
 """.strip().splitlines()
 
 
-def deps_from_file(filename):
-    lines = [line.strip().split("#")[0] for line in open(filename).readlines()]
-    # filter out comment lines
-    return [line for line in lines if line]
-
-
-dependencies = deps_from_file("requirements.txt")
-dev_dependencies = deps_from_file("requirements-dev.txt")
-
-
 class PipenvCommand(distutils.cmd.Command):
     description = "setup local development with pipenv"
     user_options = []
@@ -66,11 +56,32 @@ setup(
     download_url="https://github.com/projectcaluma/caluma",
     license="License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Programming Language :: Python :: 3.7",
     ],
     packages=find_packages(),
-    install_requires=dependencies,
+    python_requires=">=3.6, <4",
+    install_requires=[
+        "dateparser<2",
+        "django>=2.2, <3",
+        "django-cors-headers<4",
+        "django-environ<0.5",
+        "django-extensions<4",
+        "django-filter<3",
+        "django-localized-fields<6",
+        "django-postgres-extra<2",
+        "djangorestframework<4",
+        "django_simple_history<3",
+        "graphene-django<=2.8.2",
+        "idna<3",
+        "minio<6",
+        "psycopg2-binary<3",
+        "pyjexl<0.3",
+        "python-memcached<2",
+        "requests<3",
+        "urllib3<2",
+        "uwsgi<2.1",
+    ],
 )


### PR DESCRIPTION
Explicitly declare install_requires instead of copying requirements.txt.
The setup.py needs looser requirements to ease package installation.
This has been an issue before, when caluma installed as a package, but
with the upcoming pip resolver downstream projects will break.

Add a separate travis build for the package.

Resolves #1271 