### PR TITLE
fix(form): fix validation of table questions

### DIFF
--- a/caluma/caluma_form/migrations/0038_remove_table_answer_value.py
+++ b/caluma/caluma_form/migrations/0038_remove_table_answer_value.py
@@ -1,0 +1,13 @@
+from django.db import migrations
+from caluma.caluma_form.models import Question
+
+
+def remove_value(apps, schema_editor):
+    apps.get_model("caluma_form", "Answer").objects.filter(
+        question__type=Question.TYPE_TABLE, value__isnull=False
+    ).update(value=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [("caluma_form", "0037_default_answer_one2one")]
+    operations = [migrations.RunPython(remove_value, migrations.RunPython.noop)]

--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -189,7 +189,7 @@ class AnswerValidator:
     ):
         # Check all possible fields for value
         value = None
-        for i in ["value", "file", "date", "documents"]:
+        for i in ["documents", "file", "date", "value"]:
             value = kwargs.get(i, value)
             if value:
                 break


### PR DESCRIPTION
This is another regression of 445741333fd77494bd323078c70d3717ad54135a. Before that commit, the value was saved on table answers. This caused problems when validating table answers that were created before that change since they had a string value which caluma tried to validate as documents.