### PR TITLE
fix(jexl): separate extractor for mapby arguments

### DIFF
--- a/caluma/caluma_core/tests/test_jexl.py
+++ b/caluma/caluma_core/tests/test_jexl.py
@@ -3,7 +3,7 @@ import functools
 import pyjexl
 import pytest
 
-from ..jexl import JEXL, Cache, ExtractTransformReferenceAnalyzer
+from ..jexl import JEXL, Cache, ExtractTransformSubjectAnalyzer
 
 
 @pytest.mark.parametrize(
@@ -24,7 +24,7 @@ def test_extract_transforms(expression, expected_transforms):
         jexl.analyze(
             expression,
             functools.partial(
-                ExtractTransformReferenceAnalyzer, transforms=["transform1"]
+                ExtractTransformSubjectAnalyzer, transforms=["transform1"]
             ),
         )
     ) == set(expected_transforms)

--- a/caluma/caluma_form/jexl.py
+++ b/caluma/caluma_form/jexl.py
@@ -62,14 +62,8 @@ class QuestionJexl(JEXL):
         )
 
     def answer_transform(self, question_slug):
-        fields = self._structure.get_fields(question_slug)
+        field = self._structure.get_field(question_slug)
 
-        if len(fields) == 0 or len(fields) > 1:  # pragma: no cover
-            raise RuntimeError(
-                "Answer transform cannot reference row_form questions from outside row context"
-            )
-
-        field = fields[0]
         if self.is_hidden(field):
             return field.question.empty_value()
 
@@ -109,11 +103,9 @@ class QuestionJexl(JEXL):
 
     def _get_referenced_fields(self, field: Field, expr: str):
         deps = list(self.extract_referenced_questions(expr))
-        referenced_fields = [
-            ref_field for slug in deps for ref_field in self._structure.get_fields(slug)
-        ]
+        referenced_fields = [self._structure.get_field(slug) for slug in deps]
 
-        referenced_slugs = [ref.question.slug for ref in referenced_fields]
+        referenced_slugs = [ref.question.slug for ref in referenced_fields if ref]
 
         for slug in deps:
             if slug not in referenced_slugs:

--- a/caluma/caluma_form/jexl.py
+++ b/caluma/caluma_form/jexl.py
@@ -5,7 +5,11 @@ from functools import partial
 from pyjexl.analysis import ValidatingAnalyzer
 from pyjexl.evaluator import Context
 
-from ..caluma_core.jexl import JEXL, ExtractTransformReferenceAnalyzer
+from ..caluma_core.jexl import (
+    JEXL,
+    ExtractTransformArgumentAnalyzer,
+    ExtractTransformSubjectAnalyzer,
+)
 from .structure import Field
 
 
@@ -77,7 +81,13 @@ class QuestionJexl(JEXL):
     def extract_referenced_questions(self, expr):
         transforms = ["answer", "mapby"]
         yield from self.analyze(
-            expr, partial(ExtractTransformReferenceAnalyzer, transforms=transforms)
+            expr, partial(ExtractTransformSubjectAnalyzer, transforms=transforms)
+        )
+
+    def extract_referenced_mapby_questions(self, expr):
+        transforms = ["answer", "mapby"]
+        yield from self.analyze(
+            expr, partial(ExtractTransformArgumentAnalyzer, transforms=transforms)
         )
 
     @contextmanager

--- a/caluma/caluma_form/signals.py
+++ b/caluma/caluma_form/signals.py
@@ -58,8 +58,14 @@ def set_document_family(sender, instance, **kwargs):
 
 def _update_calc_dependents(slug, old_expr, new_expr):
     jexl = QuestionJexl()
-    old_q = set(jexl.extract_referenced_questions(old_expr))
-    new_q = set(jexl.extract_referenced_questions(new_expr))
+    old_q = set(
+        list(jexl.extract_referenced_questions(old_expr))
+        + list(jexl.extract_referenced_mapby_questions(old_expr))
+    )
+    new_q = set(
+        list(jexl.extract_referenced_questions(new_expr))
+        + list(jexl.extract_referenced_mapby_questions(new_expr))
+    )
 
     to_add = new_q - old_q
     to_remove = old_q - new_q

--- a/caluma/caluma_form/signals.py
+++ b/caluma/caluma_form/signals.py
@@ -11,7 +11,7 @@ from django.db.models.signals import (
 from django.dispatch import receiver
 from simple_history.signals import pre_create_historical_record
 
-from caluma.utils import disable_raw, update_model
+from caluma.utils import disable_raw
 
 from . import models, structure
 from .jexl import QuestionJexl
@@ -97,13 +97,9 @@ def _update_or_create_calc_answer(question, document):
     # be invalid, in which case we return None
     value = jexl.evaluate(field.question.calc_expression, raise_on_error=False)
 
-    try:
-        ans = models.Answer.objects.get(question=question, document=field.document)
-        update_model(ans, {"value": value})
-    except models.Answer.DoesNotExist:
-        models.Answer.objects.create(
-            question=question, document=field.document, value=value
-        )
+    models.Answer.objects.update_or_create(
+        question=question, document=field.document, defaults={"value": value}
+    )
 
 
 # Update calc dependents on pre_save

--- a/caluma/caluma_form/tests/test_answer.py
+++ b/caluma/caluma_form/tests/test_answer.py
@@ -316,8 +316,6 @@ def test_validation_class_save_document_answer(db, mocker, answer, schema_execut
 
 
 @pytest.mark.parametrize("question__type", [Question.TYPE_CALCULATED_FLOAT])
-def test_validate_save_calculated_float_answer(
-    db, mocker, document, question, schema_executor
-):
+def test_validate_save_calculated_float_answer(db, document, question):
     with pytest.raises(validators.CustomValidationError):
         api.save_answer(document=document, question=question, value=1.0)

--- a/caluma/caluma_form/tests/test_validators.py
+++ b/caluma/caluma_form/tests/test_validators.py
@@ -3,7 +3,7 @@ from rest_framework.exceptions import ValidationError
 
 from ...caluma_core.tests import extract_serializer_input_fields
 from ...caluma_form.models import DynamicOption, Question
-from .. import serializers, structure
+from .. import api, serializers, structure
 from ..jexl import QuestionMissing
 from ..validators import DocumentValidator, QuestionValidator
 
@@ -747,3 +747,29 @@ def test_validate_form_in_table(
         # Should not raise, as the "form" referenced by the
         # question's jexl is the rowform, which is wrong
         DocumentValidator().validate(document, admin_user)
+
+
+@pytest.mark.parametrize("question__type", [Question.TYPE_CALCULATED_FLOAT])
+def test_validate_save_calculated_float_answer(db, document, question):
+    with pytest.raises(ValidationError):
+        api.save_answer(document=document, question=question, value=1.0)
+
+
+@pytest.mark.parametrize("question__type", [Question.TYPE_CALCULATED_FLOAT])
+def test_validate_save_calculated_float_question(db, document, question):
+
+    with pytest.raises(ValidationError):
+        QuestionValidator().validate(
+            data={
+                "type": Question.TYPE_CALCULATED_FLOAT,
+                "calc_expression": f"'{question.slug}'|answer",
+            }
+        )
+
+    with pytest.raises(ValidationError):
+        QuestionValidator().validate(
+            data={
+                "type": Question.TYPE_CALCULATED_FLOAT,
+                "calc_expression": "'foo'|answer",
+            }
+        )

--- a/caluma/caluma_form/tests/test_validators.py
+++ b/caluma/caluma_form/tests/test_validators.py
@@ -295,7 +295,7 @@ def test_validate_empty_answers(
 ):
 
     struct = structure.FieldSet(document, document.form)
-    field = struct.get_fields(question.slug)[0]
+    field = struct.get_field(question.slug)
     answer_value = field.value() if field else field
     assert answer_value == expected_value
 

--- a/caluma/caluma_workflow/jexl.py
+++ b/caluma/caluma_workflow/jexl.py
@@ -6,7 +6,7 @@ from pyjexl.analysis import ValidatingAnalyzer
 from pyjexl.evaluator import Context
 from pyjexl.parser import Literal
 
-from ..caluma_core.jexl import JEXL, ExtractTransformReferenceAnalyzer
+from ..caluma_core.jexl import JEXL, ExtractTransformSubjectAnalyzer
 from .models import Task
 
 
@@ -155,7 +155,7 @@ class FlowJexl(JEXL):
 
     def extract_tasks(self, expr):
         yield from self.analyze(
-            expr, partial(ExtractTransformReferenceAnalyzer, transforms=["task"])
+            expr, partial(ExtractTransformSubjectAnalyzer, transforms=["task"])
         )
 
         # tasks transforms return a list of literals
@@ -163,8 +163,7 @@ class FlowJexl(JEXL):
             literal.value
             for literal in chain(
                 *self.analyze(
-                    expr,
-                    partial(ExtractTransformReferenceAnalyzer, transforms=["tasks"]),
+                    expr, partial(ExtractTransformSubjectAnalyzer, transforms=["tasks"])
                 )
             )
         )

--- a/docs/calculated-questions.md
+++ b/docs/calculated-questions.md
@@ -48,3 +48,8 @@ The answer is modified when:
 ### Limitations
 
 Currently the calculated questions cannot reference other calculated questions. This is an intentional limitation to avoid implementation complexity (dependency calculation "propagation", circular dependency checks).
+
+Additionally only existing questions can be referenced at the time of saving.
+This is because of optimizations in the way caluma tracks references of calculated questions.
+Specifically, caluma writes the reverse-dependencies to the database at the moment a calculated question is saved.
+If a referenced question would be missing at this point, it couldn't memoise the calculated question and thus not update if an answer is created or updated.


### PR DESCRIPTION
This fixes a regression, when table questions are referenced that haven't been answered, so no row document is available. In this case the jexl failed because no field exists for such a question.
Thus we separate the extractors and extract the mapby arguments only where need, that is to determine the calc dependents.

Theoretically it would still be correct to treat the arguments as fields too (if the subject is an answer transform), but then we would need a way to distinguish between actually missing questions (don't exist in the form but are referenced in the jexl) and missing table answers (that are "optional" because a table doesn't necessarily need to have rows).
With the separate extractor we could do that, but there is currently no need for it during regular validation steps.

