### PR TITLE
feat: health endpoint

### DIFF
--- a/caluma/caluma_core/conftest.py
+++ b/caluma/caluma_core/conftest.py
@@ -1,0 +1,363 @@
+import logging
+import sys
+
+import pytest
+import requests
+from django.conf import settings
+from django.core import management
+from django.db import connection
+from minio import Minio
+from psycopg2 import OperationalError
+from requests.models import Response
+from watchman.decorators import check as watchman_check_decorator
+
+from caluma.caluma_form import storage_clients
+
+
+@pytest.fixture
+def disable_logs():
+    """Disable logs for health checks."""
+    urllib3_logger = logging.getLogger("urllib3")
+    watchman_logger = logging.getLogger("watchman")
+
+    urllib3_level = urllib3_logger.level
+    watchman_disabled = watchman_logger.disabled
+    urllib3_logger.setLevel(logging.ERROR)
+    watchman_logger.disabled = True
+
+    yield
+
+    urllib3_logger.setLevel(urllib3_level)
+    watchman_logger.disabled = watchman_disabled
+
+
+@pytest.fixture
+def track_errors(mocker):
+    """Write stacktrace to stderr to enable error checking in tests.
+
+    Patches django-watchman check decorator.
+    """
+
+    def track_error_check_decorator(func):
+        def wrapped(*args, **kwargs):
+            response = watchman_check_decorator(func)(*args, **kwargs)
+
+            if response.get("ok") is False:
+                sys.stderr.write(response["stacktrace"])
+            elif not response.get("ok"):
+                for value in response.values():
+                    if value.get("ok") is False:
+                        sys.stderr.write(value["stacktrace"])
+
+            return response
+
+        return wrapped
+
+    mocker.patch("watchman.decorators.check", new=track_error_check_decorator)
+
+    yield
+
+
+@pytest.fixture
+def db_broken_connection(transactional_db):
+    """DB fixture with broken connection.
+
+    Cap DB connection by trying to re-connect with faulty connection details.
+    Changes host settings and restores them after use.
+    """
+    # overwrite DB host setting and re-connect
+    try:
+        connection.close()
+        prev_settings = settings.DATABASES["default"]["HOST"]
+        settings.DATABASES["default"]["HOST"] = "not-db"
+        connection.connect()
+    except OperationalError:
+        # ignore connection error
+        pass
+
+    yield
+
+    # restore original DB settings
+    connection.close()
+    settings.DATABASES["default"]["HOST"] = prev_settings
+    connection.connect()
+
+
+def switch_user(test=False):
+    """Re-connect to database with either user 'tester' or 'caluma'."""
+    # set username and password
+    user = "tester" if test else "caluma"
+    password = "test" if test else "caluma"
+
+    # connect new user to database
+    connection.close()
+    settings.DATABASES["default"]["USER"] = user
+    settings.DATABASES["default"]["PASSWORD"] = password
+    connection.connect()
+
+
+@pytest.fixture
+def db_user_tester(transactional_db):
+    """Create new user 'tester' with privileges necessary for health checks.
+
+    User is removed after use.
+    """
+    # get db connection
+    cursor = connection.cursor()
+
+    # create test user (with all necessary privileges)
+    cursor.execute("CREATE USER tester WITH PASSWORD 'test';")
+    cursor.execute("GRANT ALL ON caluma_logging_accesslog TO tester;")
+    cursor.execute("GRANT ALL ON caluma_form_file TO tester;")
+    cursor.execute(
+        "GRANT USAGE, SELECT ON SEQUENCE caluma_logging_accesslog_id_seq TO tester;"
+    )
+    cursor.execute("GRANT ALL ON django_migrations TO tester;")
+
+    yield
+
+    # get db connection
+    cursor = connection.cursor()
+
+    # revoke privileges and remove user
+    cursor.execute("REVOKE ALL ON caluma_logging_accesslog FROM tester;")
+    cursor.execute("REVOKE ALL ON caluma_form_file FROM tester;")
+    cursor.execute(
+        "REVOKE USAGE, SELECT ON SEQUENCE caluma_logging_accesslog_id_seq FROM tester;"
+    )
+    cursor.execute("REVOKE ALL ON django_migrations FROM tester;")
+    cursor.execute("DROP USER tester;")
+
+
+@pytest.fixture
+def db_privileges_working(db_user_tester):
+    """DB fixture with all necessary privileges for health checks.
+
+    Create new test user with necessary privileges and connect to database.
+    Remove test user and reconnect with original database user after use.
+    """
+    # switch to new test user
+    switch_user(test=True)
+
+    yield
+
+    # switch back to caluma user
+    switch_user()
+
+
+@pytest.fixture
+def db_read_error(db_user_tester):
+    """DB fixture with revoked read privileges on caluma_logging_accesslog.
+
+    Create new test user without necessary read privileges for table used by
+    health check and connect to database.
+    Remove test user and reconnect with original database user after use.
+    """
+    # revoke select rights on accesslog table
+    cursor = connection.cursor()
+    cursor.execute("REVOKE SELECT ON caluma_logging_accesslog FROM tester;")
+
+    # switch to new test user
+    switch_user(test=True)
+
+    yield
+
+    # switch back to caluma user
+    switch_user()
+
+    # grant select rights on accesslog table such that user can be removed
+    cursor = connection.cursor()
+    cursor.execute("GRANT SELECT ON caluma_logging_accesslog TO tester;")
+
+
+@pytest.fixture
+def db_write_error(db_user_tester):
+    """DB fixture with revoked write privileges on caluma_logging_accesslog.
+
+    Create new test user without necessary write privileges for table used by
+    health check and connect to database.
+    Remove test user and reconnect with original database user after use.
+    """
+    # revoke insert, update and delete privileges on accesslog table
+    cursor = connection.cursor()
+    cursor.execute(
+        "REVOKE INSERT,UPDATE,DELETE ON caluma_logging_accesslog FROM tester;"
+    )
+
+    # switch to new test user
+    switch_user(test=True)
+
+    yield
+
+    # switch back to caluma user
+    switch_user()
+
+    # grant insert, update, delete rights on accesslog table
+    # such that user can be removed
+    cursor = connection.cursor()
+    cursor.execute("GRANT INSERT,UPDATE,DELETE ON caluma_logging_accesslog TO tester;")
+
+
+@pytest.fixture
+def minio_mock_working(minio_mock, mocker):
+    """Provide working minio mock for health checks.
+
+    Based on existing minio_mock.
+    Patches requests.get and requests.put to provide necessary responses for
+    health check.
+    """
+    # determine fixed UUID to be used during tests
+    uuid = "7c5ad424-e351-4db8-ba37-bbace45d0e0f"
+    mocker.patch("uuid.uuid4", return_value=uuid)
+
+    # mock upload response
+    upload_response = Response()
+    upload_response.status_code = 200
+    mocker.patch("requests.put", return_value=upload_response)
+
+    # mock download response
+    download_response = Response()
+    download_response.status_code = 200
+    download_response._content = (
+        b"--ffc537c8d0da305912d6440576ac0d75\r\n"
+        b'Content-Disposition: form-data; name="file"; '
+        b'filename="healthz_tmp-file.txt"\r\n\r\n'
+        b"Test\nTest\n\r\n"
+        b"--ffc537c8d0da305912d6440576ac0d75--\r\n"
+    )
+    mocker.patch("requests.get", return_value=download_response)
+
+    # change object name of existing stat response
+    stat_response = Minio.stat_object.return_value
+    stat_response._object_name = "healthz_tmp-object_" + uuid
+
+    # update responses compatible with media storage service health check
+    Minio.stat_object.side_effect = [stat_response, None]
+
+
+@pytest.fixture
+def minio_broken_connection():
+    """Provide new minio client with faulty connection details.
+
+    Change minio settings to generate new client unable to connect to minio
+    instance.
+    Restore original settings and client after use.
+    """
+    # store previous client
+    prev_client = storage_clients.client
+
+    # reconnect with new client (with invalid host settings)
+    prev_settings = settings.MINIO_STORAGE_ENDPOINT
+    settings.MINIO_STORAGE_ENDPOINT = "not-minio:9000"
+    storage_clients.client = storage_clients.Minio()
+
+    yield
+
+    # restore previous client
+    settings.MINIO_STORAGE_ENDPOINT = prev_settings
+    storage_clients.client = prev_client
+
+
+@pytest.fixture
+def minio_not_configured():
+    """Fixture with no connection to minio instance.
+
+    Remove minio client to ensure no connection is available.
+    """
+    # store previous client
+    prev_client = storage_clients.client
+
+    # reset client
+    storage_clients.client = None
+
+    yield
+
+    # restore previous client
+    storage_clients.client = prev_client
+
+
+@pytest.fixture
+def minio_mock_read_error(minio_mock, mocker):
+    """Produce exception when downloading file or stat-ing object.
+
+    This scenario might occur when there is a internal minio issue or if a
+    previous upload isn't successful (which doesn't issue exception).
+    """
+    # raise exception instead of handling request
+    def download_side_effect(*args, **kwargs):  # pragma: no cover
+        raise requests.exceptions.RequestException("GET request failed")
+
+    def stat_side_effect(*args, **kwargs):
+        raise Exception("stat_object failed")
+
+    # determine fixed UUID to be used during tests
+    uuid = "7c5ad424-e351-4db8-ba37-bbace45d0e0f"
+    mocker.patch("uuid.uuid4", return_value=uuid)
+
+    # mock upload response
+    upload_response = Response()
+    upload_response.status_code = 200
+    mocker.patch("requests.put", return_value=upload_response)
+
+    # mock erroneous download response
+    download_response = Response()
+    download_response.status_code = 500
+    mocker.patch(
+        "requests.get", return_value=download_response, side_effect=download_side_effect
+    )
+
+    # raise exception
+    Minio.stat_object.side_effect = stat_side_effect
+
+
+@pytest.fixture
+def minio_mock_write_error(minio_mock, mocker):
+    """Produce exception when uploading file.
+
+    This scenario might occur when there is a internal minio issue.
+    """
+    # raise exception instead of handling request
+    def upload_side_effect(*args, **kwargs):
+        raise requests.exceptions.RequestException("PUT request failed")
+
+    # determine fixed UUID to be used during tests
+    uuid = "7c5ad424-e351-4db8-ba37-bbace45d0e0f"
+    mocker.patch("uuid.uuid4", return_value=uuid)
+
+    # mock upload response
+    upload_response = Response()
+    upload_response.status_code = 500
+    mocker.patch(
+        "requests.put", return_value=upload_response, side_effect=upload_side_effect
+    )
+
+    # mock download response
+    download_response = Response()
+    download_response.status_code = 200
+    download_response._content = (
+        b"--ffc537c8d0da305912d6440576ac0d75\r\n"
+        b'Content-Disposition: form-data; name="file"; '
+        b'filename="healthz_tmp-file.txt"\r\n\r\n'
+        b"Test\nTest\n\r\n"
+        b"--ffc537c8d0da305912d6440576ac0d75--\r\n"
+    )
+    mocker.patch("requests.get", return_value=download_response)
+
+    # change object name of existing stat response
+    stat_response = Minio.stat_object.return_value
+    stat_response._object_name = "healthz_tmp-object_" + uuid
+
+    # update responses compatible with media storage service health check
+    Minio.stat_object.side_effect = [stat_response, None]
+
+
+@pytest.fixture
+def roll_back_migrations():
+    """Roll back database migrations to ensure unapplied migrations exist."""
+    # undo applied migrations for app contenttypes
+    management.call_command("migrate", "contenttypes", "zero")
+
+    yield
+
+    # re-apply migrations for app contenttypes
+    management.call_command("migrate", "contenttypes")

--- a/caluma/caluma_core/health_checks.py
+++ b/caluma/caluma_core/health_checks.py
@@ -1,0 +1,133 @@
+import uuid
+from io import StringIO
+
+import requests
+from django.conf import settings
+from django.core import management
+from watchman.decorators import check
+
+from caluma.caluma_form import storage_clients
+from caluma.caluma_logging.models import AccessLog
+
+
+@check
+def _check_pending_migrations(db_name):
+    """Check database for pending migrations.
+
+    Returns JSON mapping if no pending migrations, otherwise raises Exception.
+    @check django-watchman decorator catches and handles exceptions.
+    """
+    # check for unapplied migrations
+    out = StringIO()
+    management.call_command("showmigrations", "--plan", stdout=out)
+    plan = out.getvalue()
+    if "[ ]" in plan:
+        raise Exception("Database has unapplied migrations (migrate).")
+
+    return {db_name: {"ok": True}}
+
+
+@check
+def _check_media_storage_service():
+    """Check media storage service connection and operations."""
+    # generate object name
+    storage_client = storage_clients.client
+    prefix = "healthz_tmp-object_"
+    object_name = prefix + str(uuid.uuid4())
+
+    try:
+        # request upload url and upload
+        upload_url = storage_client.upload_url(object_name)
+
+        filename = "healthz_tmp-file.txt"
+        content = "Test\nTest\n"
+        files = {"file": (filename, content)}
+        upload_request = requests.put(upload_url, files=files)
+        assert upload_request.status_code == 200
+
+        # stat object
+        stat = storage_client.stat_object(object_name)
+        assert stat.object_name == object_name
+
+        # request download url and download file
+        download_url = storage_client.download_url(object_name)
+
+        download_request = requests.get(download_url)
+        assert download_request.status_code == 200
+        assert filename in download_request.text and content in download_request.text
+
+        # remove object
+        storage_client.remove_object(object_name)
+        assert not storage_client.stat_object(object_name)
+
+        return {"ok": True}
+
+    finally:
+        storage_client.remove_object(object_name)
+
+
+@check
+def _check_models(database):
+    """Check model instantion and operations on database."""
+    log = None
+    try:
+        # Instantiate model
+        log = AccessLog.objects.create(status_code=22)
+        assert (
+            log in AccessLog.objects.all()
+        ), "Failed to save model instance to database."
+
+        # Retrieve object
+        retrieved_log = AccessLog.objects.get(pk=log.pk)
+        assert log == retrieved_log, "Unexpected object retrieved from database."
+        assert (
+            retrieved_log.status_code == log.status_code
+        ), "Unexpected object data retrieved from database."
+
+        # Update object
+        log.status_code = 42
+        log.save()
+        retrieved_log = AccessLog.objects.get(pk=log.pk)
+        assert log == retrieved_log, "Unexpected object retrieved from database."
+        assert (
+            retrieved_log.status_code == log.status_code
+        ), "Unexpected object data retrieved from database."
+
+        # Remove object
+        log.delete()
+        log = None
+        assert (
+            log not in AccessLog.objects.all()
+        ), "Failed to delete model instance from database."
+
+        return {database: {"ok": True}}
+
+    finally:
+        # Cleanup
+        if log:  # pragma: no cover
+            log.delete()
+
+
+def check_media_storage_service():
+    """Check media storage service connection and operations."""
+    # Check if media storage service is available
+    if not storage_clients.client:
+        return {"media storage service (not configured)": {"ok": True}}
+
+    return {"media storage service": _check_media_storage_service()}
+
+
+def check_migrations():
+    """Check available databases for unapplied migrations."""
+    databases = sorted(settings.DATABASES)
+    checked_databases = [_check_pending_migrations(db_name) for db_name in databases]
+
+    return {"database migrations": checked_databases}
+
+
+def check_models():
+    """Check model instantiation."""
+    databases = sorted(settings.DATABASES)
+    checked_databases = [_check_models(db_name) for db_name in databases]
+
+    return {"database models": checked_databases}

--- a/caluma/caluma_core/tests/__snapshots__/test_health_checks.ambr
+++ b/caluma/caluma_core/tests/__snapshots__/test_health_checks.ambr
@@ -1,0 +1,420 @@
+# name: test_db_connection_broken
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': False,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': False,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': False,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_db_connection_working
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_db_migrations_applied
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_db_migrations_not_applied
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': False,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_db_model_accessible
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_db_model_read_error
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': False,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_db_model_write_error
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': False,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_minio_connection_broken
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': False,
+    },
+  }
+---
+# name: test_minio_connection_working
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_minio_not_configured
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service (not configured)': <class 'dict'> {
+      'ok': True,
+    },
+  }
+---
+# name: test_minio_read_error
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': False,
+    },
+  }
+---
+# name: test_minio_write_error
+  <class 'dict'> {
+    'caches': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database migrations': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'database models': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'databases': <class 'list'> [
+      <class 'dict'> {
+        'default': <class 'dict'> {
+          'ok': True,
+        },
+      },
+    ],
+    'media storage service': <class 'dict'> {
+      'ok': False,
+    },
+  }
+---

--- a/caluma/caluma_core/tests/test_health_checks.py
+++ b/caluma/caluma_core/tests/test_health_checks.py
@@ -1,0 +1,334 @@
+from django.core import management
+from django.urls import reverse
+from watchman import settings as watchman_settings
+
+
+def test_db_connection_working(
+    disable_logs, track_errors, capsys, client, snapshot, minio_mock_working, db
+):
+    """Test /healthz/ endpoint response with working database connection.
+
+    Provide database access through the 'db' fixture with working connection.
+    Passes health checks for databases (connection), database models and
+    database migrations.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert database checks pass
+    json_response = response.json()
+    assert json_response["databases"] == [{"default": {"ok": True}}]
+    assert json_response["database models"] == [{"default": {"ok": True}}]
+    assert json_response["database migrations"] == [{"default": {"ok": True}}]
+    assert response.status_code == 200
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert not err
+
+
+def test_db_connection_broken(
+    disable_logs,
+    track_errors,
+    capsys,
+    client,
+    snapshot,
+    db_broken_connection,
+    minio_mock_working,
+):
+    """Test /healthz/ endpoint response with broken database connection.
+
+    Uses DB fixture with broken connection.
+    Affects the health checks for databases (connection), database models and
+    database migrations, which should trigger an connection error.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert database checks fail
+    json_response = response.json()
+    assert json_response["databases"] == [{"default": {"ok": False}}]
+    assert json_response["database models"] == [{"default": {"ok": False}}]
+    assert json_response["database migrations"] == [{"default": {"ok": False}}]
+    assert response.status_code == watchman_settings.WATCHMAN_ERROR_CODE
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert (
+        'django.db.utils.OperationalError: could not translate host name "not-db" to address'
+        in err
+    )
+
+
+def test_db_model_accessible(
+    disable_logs,
+    track_errors,
+    capsys,
+    client,
+    snapshot,
+    minio_mock_working,
+    db_privileges_working,
+):
+    """Test /healthz/ endpoint response when necessary DB tables are accessible.
+
+    Provide a database connected through a new test user with the necessary
+    privileges to access the tables needed in the health checks.
+    Passes database models health check and should be able to access the
+    necessary model table.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert database models check passes
+    assert response.json()["database models"] == [{"default": {"ok": True}}]
+    assert response.status_code == 200
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert not err
+
+
+def test_db_model_read_error(
+    disable_logs,
+    track_errors,
+    capsys,
+    client,
+    snapshot,
+    minio_mock_working,
+    db_read_error,
+):
+    """Test /healthz/ endpoint response when necessary DB tables are inaccessible.
+
+    Provide a database connected through a new test user without the necessary
+    privileges to access the tables needed in the health checks.
+    Affects the database models health check when trying to access the
+    specified model table and triggers a read error due to lack of privileges.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert database models check fails
+    assert response.json()["database models"] == [{"default": {"ok": False}}]
+    assert response.status_code == watchman_settings.WATCHMAN_ERROR_CODE
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert (
+        "django.db.utils.ProgrammingError: permission denied for relation caluma_logging_accesslog"
+        in err
+    )
+
+
+def test_db_model_write_error(
+    disable_logs,
+    track_errors,
+    capsys,
+    client,
+    snapshot,
+    minio_mock_working,
+    db_write_error,
+):
+    """Test /healthz/ endpoint response when necessary DB tables are read-only.
+
+    Provide a database connected through a new test user without the necessary
+    privileges to write to the tables needed in the health checks.
+    Affects the database models health check when trying to create, update or
+    delete an object for the specified model table and triggers write error
+    due to lack of privileges.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert database models check fails
+    assert response.json()["database models"] == [{"default": {"ok": False}}]
+    assert response.status_code == watchman_settings.WATCHMAN_ERROR_CODE
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert (
+        "django.db.utils.ProgrammingError: permission denied for relation caluma_logging_accesslog"
+        in err
+    )
+
+
+def test_minio_connection_working(
+    disable_logs, track_errors, capsys, client, snapshot, db, minio_mock_working
+):
+    """Test /healthz/ endpoint response when minio connection is working.
+
+    Provide minio mock that passes the media storage service health check.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert media storage service check passes
+    assert response.json()["media storage service"] == {"ok": True}
+    assert response.status_code == 200
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert not err
+
+
+def test_minio_connection_broken(
+    disable_logs, track_errors, capsys, client, snapshot, db, minio_broken_connection
+):
+    """Test /healthz/ endpoint response when minio connection is broken.
+
+    Provide new minio client with faulty connection information.
+    Affects media storage service health check and should trigger
+    connection error.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert media storage service check fails
+    assert response.json()["media storage service"] == {"ok": False}
+    assert response.status_code == watchman_settings.WATCHMAN_ERROR_CODE
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert "urllib3.exceptions.MaxRetryError" in err
+
+
+def test_minio_not_configured(
+    disable_logs, track_errors, capsys, client, snapshot, db, minio_not_configured
+):
+    """Test /healthz/ endpoint response when minio is not configured.
+
+    Change storage client settings to ensure check assumes no media storage
+    service is configured.
+    Media storage service health check should pass with a 'not configured'
+    annotation.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert media storage service check passes
+    assert response.json()["media storage service (not configured)"] == {"ok": True}
+    assert response.status_code == 200
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert not err
+
+
+def test_minio_read_error(
+    disable_logs, track_errors, capsys, client, snapshot, db, minio_mock_read_error
+):
+    """Test /healthz/ endpoint response when minio receives a read error.
+
+    Mocks minio read functions to produce an error.
+    Affects media storage service health check file download and stat_object
+    functions.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert media storage service check fails
+    assert response.json()["media storage service"] == {"ok": False}
+    assert response.status_code == watchman_settings.WATCHMAN_ERROR_CODE
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert "Exception: stat_object failed" in err
+
+
+def test_minio_write_error(
+    disable_logs, track_errors, capsys, client, snapshot, db, minio_mock_write_error
+):
+    """Test /healthz/ endpoint response when minio receives a write error.
+
+    Mocks minio write functions to produce an error.
+    Affects media storage service health check file upload function.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert media storage service check fails
+    assert response.json()["media storage service"] == {"ok": False}
+    assert response.status_code == watchman_settings.WATCHMAN_ERROR_CODE
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert "requests.exceptions.RequestException: PUT request failed" in err
+
+
+def test_db_migrations_applied(
+    disable_logs, track_errors, capsys, client, snapshot, db, minio_mock_working
+):
+    """Test /healthz/ endpoint response when migrations all created & applied.
+
+    Ensure no changes or unapplied migrations are detected.
+    Database migrations health check should pass.
+    """
+    # Manually migrate database to ensure the database is in the newest
+    # state and no unapplied migrations are still around.
+    # When running migration tests, database might be left in an
+    # inconsistent state.
+    management.call_command("migrate")
+
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert database migrations check passes
+    assert response.json()["database migrations"] == [{"default": {"ok": True}}]
+    assert response.status_code == 200
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert not err
+
+
+def test_db_migrations_not_applied(
+    disable_logs,
+    track_errors,
+    capsys,
+    client,
+    snapshot,
+    db,
+    minio_mock_working,
+    roll_back_migrations,
+):
+    """Test /healthz/ endpoint response when migrations haven't been applied.
+
+    Undo applied migrations for app 'contenttypes'.
+    Affects database migrations health check, which should detect unapplied
+    migrations and fail.
+    """
+    # get /healthz/ response and compare to previous snapshot
+    response = client.get(reverse("healthz"))
+    snapshot.assert_match(response.json())
+
+    # assert database migrations check fails
+    assert response.json()["database migrations"] == [{"default": {"ok": False}}]
+    assert response.status_code == watchman_settings.WATCHMAN_ERROR_CODE
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert "Exception: Database has unapplied migrations (migrate)." in err
+
+
+def test_healthz_disabled(capsys, client, settings):
+    """Assert that /healthz endpoint cannot be retrieved if disabled."""
+    # disable healthz endpoint
+    settings.ENABLE_HEALTHZ_ENDPOINT = False
+
+    # assert accessing health endpoint results in not found error
+    response = client.get(reverse("healthz"))
+    assert response.status_code == 404
+
+    # assert exception type
+    *_, err = capsys.readouterr()
+    assert not err

--- a/caluma/caluma_core/urls.py
+++ b/caluma/caluma_core/urls.py
@@ -1,8 +1,14 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 
+from caluma.caluma_core import views
 from caluma.caluma_user.views import AuthenticationGraphQLView
 
 urlpatterns = [
-    url(r"", AuthenticationGraphQLView.as_view(graphiql=settings.DEBUG), name="graphql")
+    re_path(
+        "graphql/?",
+        AuthenticationGraphQLView.as_view(graphiql=settings.DEBUG),
+        name="graphql",
+    ),
+    re_path("healthz/?", views.health_check_status, name="healthz"),
 ]

--- a/caluma/caluma_core/views.py
+++ b/caluma/caluma_core/views.py
@@ -1,0 +1,46 @@
+import json
+
+from django.conf import settings
+from django.http import Http404, JsonResponse
+from watchman import settings as watchman_settings, views as watchman_views
+
+from caluma.caluma_user.models import AnonymousUser
+
+
+def _remove_keys(dictionary, keys):
+    """Recursively remove given keys from dictionary."""
+    for key in keys:  # delete keys
+        if key in dictionary:
+            del dictionary[key]
+    for value in dictionary.values():  # retrieve nested values
+        if isinstance(value, dict):
+            _remove_keys(value, keys)  # apply to dict
+        if isinstance(value, list):
+            [_remove_keys(v, keys) for v in value]  # apply to list
+
+
+def health_check_status(request):
+    """Modify django-watchman view to remove error / stacktrace output.
+
+    Available django-watchman views:
+    watchman.views.status
+    watchman.views.bare_status
+    """
+    # if health endpoint not enabled, return 404 response
+    if not settings.ENABLE_HEALTHZ_ENDPOINT:
+        raise Http404("Healthz endpoint not enabled.")
+
+    # set anonymous user for requests to health endpoint
+    # caluma expects user to be set on requests
+    request.user = AnonymousUser()
+
+    # Get view response from django-watchman
+    response = watchman_views.status(request)
+    json_data = json.loads(response.content.decode("utf-8"))
+
+    # Remove unwanted keys e.g. 'error', 'stacktrace'
+    if response.status_code == watchman_settings.WATCHMAN_ERROR_CODE:
+        _remove_keys(json_data, ["error", "stacktrace"])
+        return JsonResponse(json_data, status=response.status_code)
+
+    return response

--- a/caluma/settings/caluma.py
+++ b/caluma/settings/caluma.py
@@ -93,3 +93,6 @@ ENABLE_HISTORICAL_API = env.bool("ENABLE_HISTORICAL_API", default=False)
 # Configure the fields you intend to use in the "meta" fields. This will
 # provide corresponding constants in the ordreBy filter.
 META_FIELDS = env.list("META_FIELDS", default=[])
+
+# enable caluma healthz endpoint
+ENABLE_HEALTHZ_ENDPOINT = env.bool("ENABLE_HEALTHZ_ENDPOINT", default=False)

--- a/caluma/settings/django.py
+++ b/caluma/settings/django.py
@@ -12,7 +12,6 @@ DEBUG = env.bool("DEBUG", default=default(True, False))
 SECRET_KEY = env.str("SECRET_KEY", default=default("uuuuuuuuuu"))
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=default(["*"]))
 
-
 # Application definition
 
 INSTALLED_APPS = [
@@ -29,6 +28,7 @@ INSTALLED_APPS = [
     "caluma.caluma_workflow.apps.DefaultConfig",
     "caluma.caluma_data_source.apps.DefaultConfig",
     "caluma.caluma_logging.apps.DefaultConfig",
+    "watchman",
 ]
 
 if DEBUG:
@@ -164,3 +164,17 @@ ENABLE_ACCESS_LOG = env.bool("ENABLE_ACCESS_LOG", default=False)
 
 if ENABLE_ACCESS_LOG:
     MIDDLEWARE.append("caluma.caluma_logging.middleware.AccessLogMiddleware")
+
+
+# health checks
+WATCHMAN_CHECKS = env.list(
+    "WATCHMAN_CHECKS",
+    default=(
+        "caluma.caluma_core.health_checks.check_migrations",
+        "caluma.caluma_core.health_checks.check_media_storage_service",
+        "caluma.caluma_core.health_checks.check_models",
+        "watchman.checks.caches",
+        "watchman.checks.databases",
+    ),
+)
+WATCHMAN_ERROR_CODE = 503

--- a/caluma/urls.py
+++ b/caluma/urls.py
@@ -1,3 +1,3 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
-urlpatterns = [url(r"^graphql", include("caluma.caluma_core.urls"))]
+urlpatterns = [path("", include("caluma.caluma_core.urls"))]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,3 +148,16 @@ We are using the sane uWSGI-defaults researched by [bloomberg](https://www.techa
 - `UWSGI_PROCNAME_PREFIX`=`"caluma "`
 
 See https://git.io/JemA2 for more information.
+
+
+## Healthz Endpoint
+The `healthz` endpoint performs a number of health checks using the
+django-watchman package extended by custom checks. This allows systems, such
+as Kubernetes, to perform monitoring and readiness checks on caluma.
+
+Please note that when you enable it, make sure it is not reachable from the
+outside (proxy configuration!). Due to it's nature, it takes some resources to
+check everything, which makes it prone to abuse (denial of service, DoS).
+
+It's enabled by setting the environment variable:
+`ENABLE_HEALTHZ_ENDPOINT`: Defaults to `false`.

--- a/docs/django-apps.md
+++ b/docs/django-apps.md
@@ -82,14 +82,14 @@ if DEBUG:
 
 ### urls.py
 
-Include the Caluma URLs (this example uses `graphql` as URL prefix):
+Include the Caluma URLs (this example uses `caluma` as URL prefix):
 
 ```python
-from django.conf.urls import include, url
+from django.urls import include, path
 
 urlpatterns = [
     # ...
-    url(r"^graphql", include("caluma.caluma_core.urls")),
+    path("caluma/", include("caluma.caluma_core.urls"))
     # ...
 ]
 ```

--- a/docs/healthz.md
+++ b/docs/healthz.md
@@ -1,0 +1,104 @@
+# Healthz Endpoint
+
+The `healthz` endpoint provides information about the health status of the 
+caluma backend. This allows systems, such as Kubernetes, to monitor and perform 
+readiness checks on caluma.
+
+Please note that when you enable it, make sure it is not reachable from the
+outside (proxy configuration!). Due to it's nature, it takes some resources to
+check everything, which makes it prone to abuse (denial of service, DoS).
+
+It's enabled by setting the environment variable:
+`ENABLE_HEALTHZ_ENDPOINT`: Defaults to `false`.
+
+If enabled, the endpoint is accessible through the `/healthz/` path. When 
+running a development server the health status can therefore be accessed at 
+[localhost:8000/healthz/](http://localhost:8000/healthz/).
+
+The `healthz` endpoint is based on and extends the 
+[django-watchman](https://github.com/mwarkentin/django-watchman) package. 
+
+## Response
+
+The endpoint will return a JSON response listing the performed health checks 
+and their status. If all checks passed, it returns with a `200 OK` HTTP 
+response status code, otherwise with a `503 Service Unavailable` response 
+status. The response is a modified version of the 
+[django-watchman](https://github.com/mwarkentin/django-watchman) status view.
+In case of health check failures, the response doesn't contain any specific
+error message or stacktrace due to security concerns.
+
+An example response of a failed health check is shown below, which returns 
+with a `503 Service Unavailable` status code:
+
+```json
+{
+  "media storage service": {
+    "ok": false
+  },
+  "caches": [
+    {
+      "default": {
+        "ok": true
+      }
+    }
+  ],
+  "database migrations": [
+    {
+      "default": {
+        "ok": true
+      }
+    }
+  ],
+  "databases": [
+    {
+      "default": {
+        "ok": true
+      }
+    }
+  ],
+  "database models": [
+    {
+      "default": {
+        "ok": true
+      }
+    }
+  ]
+}
+```
+
+## Checks
+
+The `healthz` endpoint performs a number of health checks using the 
+[django-watchman](https://github.com/mwarkentin/django-watchman) package 
+extended by custom checks.
+
+The following health checks are performed by django-watchman:
+* Databases:
+Verifies the connection to each database specified in the settings. If a 
+connection failure is detected, the check for that particular database fails. 
+The status of each checked database is listed.
+
+* Caches:
+Performs a set, get and delete operation on each of the caches specified in 
+the settings. If one of the operations fail, the check for that particular
+cache fails. The status of each checked cache is listed.
+
+The following health checks were added to complement the django-watchman checks:
+* Database Models:
+For each database, the check tries to instantiate a model and perform retrieve, 
+update and delete operations on the created model object. If one of the
+operations fail, the check fails for that particular database. The status of 
+the models check of each database is listed.
+
+* Database Migrations:
+Checks whether unapplied migrations are detected for any of the databases. In 
+case unapplied migrations are detected, the check fails for that particular
+database. The status of the migrations check of each database is listed.
+
+* Media Storage Service:
+If a media storage service is configured for storage, it tries to create an
+object and perform stat, upload and download operations on the object. If one
+of the operations fail, the check fails. If no media storage service is
+configured, the check passes with:
+`"media storage service (not configured)": {"ok": True}`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ django-extensions==3.1.1
 django-filter==2.4.0
 django-localized-fields==6.2
 django-postgres-extra==2.0.2
+django-watchman==1.2.0
 djangorestframework==3.12.2
 django_simple_history==2.12.0
 graphene-django==2.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ env =
     LANGUAGES=en,de,fr
     ENABLE_HISTORICAL_API=true
     ENABLE_ACCESS_LOG=true
+    ENABLE_HEALTHZ_ENDPOINT=true
 filterwarnings =
     # switch this back to error::DeprecationWarning when we upgraded graphene-django
     ignore::DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "django-filter<3",
         "django-localized-fields<7",
         "django-postgres-extra<3",
+        "django-watchman~=1.2.0",
         "djangorestframework<4",
         "django_simple_history<3",
         "graphene-django<=2.8.2",


### PR DESCRIPTION
Introduce /healthz endpoint to allow for readiness checks in Kubernetes.
Use Django-Watchman to execute checks (already includes checks for caches and databases)
and is extended with additional checks for minio, db models and db migrations.

Resolves #1137