### PR TITLE
feat: dump_caluma command for entire forms

### DIFF
--- a/caluma/caluma_core/management/commands/dump_caluma_config.py
+++ b/caluma/caluma_core/management/commands/dump_caluma_config.py
@@ -1,0 +1,112 @@
+import itertools
+
+from django.apps import apps
+from django.core import serializers
+from django.core.management.base import BaseCommand, CommandError
+from django.db import DEFAULT_DB_ALIAS
+from django.db.models import Q
+
+
+def get_form_filters(form_slugs):
+    return {
+        "caluma_form.Form": Q(pk__in=form_slugs),
+        "caluma_form.Option": Q(questions__forms__pk__in=form_slugs),
+        "caluma_form.Question": Q(forms__pk__in=form_slugs),
+        "caluma_form.QuestionOption": Q(question__forms__pk__in=form_slugs),
+        "caluma_form.FormQuestion": Q(form__pk__in=form_slugs),
+        "caluma_form.Answer": Q(
+            question__forms__pk__in=form_slugs, document__isnull=True
+        ),
+    }
+
+
+class Command(BaseCommand):
+    help = "Dump caluma objects. Currently supported: caluma_form.Form"
+
+    def add_arguments(self, parser):
+        parser.add_argument("args", nargs="*", help="Primary keys of given model")
+        parser.add_argument(
+            "--model", type=str, help="Model to dump, eg. 'caluma_form.Form'"
+        )
+        parser.add_argument(
+            "--format",
+            default="json",
+            help="Specifies the output serialization format for fixtures.",
+        )
+        parser.add_argument(
+            "--indent",
+            type=int,
+            default=2,
+            help="Specifies the indent level to use when pretty-printing output.",
+        )
+        parser.add_argument(
+            "--database",
+            default=DEFAULT_DB_ALIAS,
+            help="Nominates a specific database to dump fixtures from. "
+            'Defaults to the "default" database.',
+        )
+        parser.add_argument(
+            "-o", "--output", help="Specifies file to which the output is written."
+        )
+
+    def handle(self, *pks, **options):
+        format = options["format"]
+        indent = options["indent"]
+        stream = open(options["output"], "w") if options["output"] else None
+
+        if not pks:
+            raise CommandError("Must provide primary keys")
+
+        if format not in serializers.get_public_serializer_formats():
+            try:
+                serializers.get_serializer(format)
+            except serializers.SerializerDoesNotExist:
+                pass
+
+            raise CommandError("Unknown serialization format: %s" % format)
+
+        if not options.get("model"):
+            raise CommandError("Missing `--model` option")
+
+        app_label, model_label = options["model"].split(".")
+        querysets = self.get_objects(pks)
+
+        self.stdout.ending = None
+        serializers.serialize(
+            format,
+            itertools.chain(*querysets),
+            indent=indent,
+            stream=stream or self.stdout,
+        )
+
+        if stream:
+            stream.close()
+
+    def get_objects(
+        self, pks, app_label="caluma_form", model_label="Form", excluded_pks=None
+    ):
+        """Collect all objects including their "downwards" dependencies recursively."""
+
+        querysets = []
+        excluded_pks = excluded_pks or []
+        sub_forms = []
+
+        for model_identifier, model_filter in get_form_filters(pks).items():
+            app_label, model_label = model_identifier.split(".")
+            model = apps.get_model(app_label, model_label)
+
+            qs = model.objects.filter(model_filter)
+            querysets.append(qs)
+
+            if model_label == "Question":
+                sub_forms += qs.filter(row_form__isnull=False).values_list(
+                    "row_form_id", flat=True
+                )
+                sub_forms += qs.filter(sub_form__isnull=False).values_list(
+                    "sub_form_id", flat=True
+                )
+
+        if sub_forms:
+            querysets += self.get_objects(set(sub_forms), excluded_pks=excluded_pks)
+
+        return querysets

--- a/caluma/caluma_core/tests/test_dump_caluma.py
+++ b/caluma/caluma_core/tests/test_dump_caluma.py
@@ -1,0 +1,70 @@
+import json
+from tempfile import NamedTemporaryFile
+
+import pytest
+from django.core.management import CommandError, call_command
+
+from ..management.commands.dump_caluma_config import get_form_filters
+
+FORM_MODELS = get_form_filters([]).keys()
+
+
+def sort_dump(dump):
+    return sorted(json.loads(dump), key=lambda x: x["pk"])
+
+
+def test_dump_caluma_config(db, form_and_document, snapshot, form_factory):
+    temp_file = NamedTemporaryFile()
+
+    # first: no content
+    call_command(
+        "dump_caluma_config",
+        "test-slug",
+        model="caluma_form.Form",
+        output=temp_file.name,
+    )
+    assert not json.loads(temp_file.read())
+
+    form, document, questions_dict, answers_dict = form_and_document(
+        use_table=True, use_subform=True
+    )
+
+    call_command("dumpdata", *FORM_MODELS, output=temp_file.name)
+
+    temp_file.seek(0)
+    dumpdata = sort_dump(temp_file.read())
+
+    # remove non-default answers
+    dumpdata = [
+        d
+        for d in dumpdata
+        if d["model"] != "caluma_form.answer" or not d["fields"]["document"]
+    ]
+
+    form_factory(slug="unrelated")
+
+    call_command(
+        "dump_caluma_config", form.pk, model="caluma_form.Form", output=temp_file.name
+    )
+
+    temp_file.seek(0)
+    dumpcaluma = sort_dump(temp_file.read())
+
+    assert dumpdata == dumpcaluma
+    assert not any(
+        (obj["model"], obj["pk"]) == ("caluma_form.form", "unrelated")
+        for obj in dumpcaluma
+    )
+
+
+@pytest.mark.parametrize(
+    "args,kwargs",
+    [
+        ([], {"model": "caluma_form.Form"}),
+        (["foo"], {"format": "jpeg", "model": "caluma_form.Form"}),
+        (["foo"], {}),
+    ],
+)
+def test_dump_caluma_config_error(args, kwargs):
+    with pytest.raises(CommandError):
+        call_command("dump_caluma_config", *args, **kwargs)

--- a/caluma/caluma_form/tests/test_jexl.py
+++ b/caluma/caluma_form/tests/test_jexl.py
@@ -343,7 +343,7 @@ def test_answer_transform_on_hidden_question_types(
     table = questions["table"]
     row_form = table.row_form
     row_doc = document_factory(form=row_form)
-    answer_factory(document=row_doc, question_id="column")
+    answer_factory(document=row_doc, question=questions["column"])
     answers["table"].documents.add(row_doc)
 
     questions["form"].is_hidden = (

--- a/caluma/conftest.py
+++ b/caluma/conftest.py
@@ -234,7 +234,7 @@ def form_and_document(
 
         form_question_factory(form=form, question=questions["top_question"])
         answers["top_question"] = answer_factory(
-            document=document, question_id="top_question"
+            document=document, question=questions["top_question"]
         )
 
         if use_table:
@@ -280,7 +280,7 @@ def form_and_document(
             form_question_factory(form=sub_form, question=questions["sub_question"])
 
             answers["sub_question"] = answer_factory(
-                document=document, question_id="sub_question"
+                document=document, question=questions["sub_question"]
             )
 
         return (form, document, questions, answers)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,19 @@
+# Commands
+
+A set of custom commands that can help with routine tasks around a caluma installation.
+
+## `cleanup_history`
+
+Cleanup historical records, eg. historical answers for old, inexistent questions.
+See [Historical Records](historical-records.md) for details.
+
+
+## `dump_caluma_config`
+
+Similarly to djangos built-in `dumpdata`, `dump_caluma_config` dumps database entries to django fixtures.
+It's tailored for the usage of (design-time) configuration and currently supports dumping of forms with all its attached questions, options etc.
+
+Example usage:
+`python manage.py dump_caluma_config --model caluma_form.Form my-form other-form`
+
+For more options see `python manage.py dump_caluma_config --help`


### PR DESCRIPTION
Dump an entire form as django fixtures using `./manage.py dump_caluma --model caluma_form.Form my-form-slug`.
This command lives in core so it can extended to other design-time aspects such as workflows, questions etc.

`load_caluma` is not necessary as the built-in `loaddata` does this already.

Partially addresses #1359