### PR TITLE
feat(events): add argument to on decorator to raise exceptions in the receiver

### DIFF
--- a/caluma/caluma_core/events.py
+++ b/caluma/caluma_core/events.py
@@ -1,35 +1,65 @@
 import logging
 from warnings import warn
 
-from django.dispatch import receiver
-
 logger = logging.getLogger(__name__)
 
 
-def on(event, *args, **kwargs):
+class SignalHandlingError(RuntimeError):
+    def __init__(self, exceptions, *args, **kwargs):
+        self.caught_exceptions = exceptions
+
+        super().__init__(*args, **kwargs)
+
+    def __str__(self):
+        return ", ".join([str(e) for e in self.caught_exceptions])
+
+
+def on(event, raise_exception=False, *args, **kwargs):
     deprecation_reason = getattr(event, "_deprecation_reason", None)
 
     if deprecation_reason:  # pragma: no cover
         warn(deprecation_reason, DeprecationWarning)
 
-    return receiver(event, *args, **kwargs)
+    def _decorator(func):
+        func._raise_exception = raise_exception
+
+        if isinstance(event, (list, tuple)):
+            for e in event:
+                e.connect(func, **kwargs)
+        else:
+            event.connect(func, **kwargs)
+        return func
+
+    return _decorator
 
 
 def send_event(signal, **kwargs):
     """
     Send events and handle exceptions in receiver functions.
 
-    This wrapper handles the sending of signals as well as handling of any Exceptions that
-    occur. Exceptions are logged with `ERROR` level, but not raised, in order to prevent
-    rollback of the transaction.
+    This wrapper handles the sending of signals as well as handling of any
+    Exceptions that occur. Exceptions are logged with `ERROR` level per
+    default, but not raised, in order to prevent rollback of the transaction.
+    However, if the `raise_exception` flag on the receiver is set to `True`
+    it will collect those errors and raise a `SignalHandlingError` containing
+    all caught exceptions.
     """
     result = signal.send_robust(**kwargs)
+
+    caught_exceptions = []
     for func, exc in result:
         if exc is not None:
+            if func._raise_exception:
+                caught_exceptions.append(exc)
+
             logger.error(
                 f'Error in event handler "{func.__module__}.{func.__name__}":',
                 exc_info=exc,
             )
+
+    if caught_exceptions:
+        raise SignalHandlingError(caught_exceptions)
+
     return result
 
 

--- a/caluma/caluma_workflow/tests/test_events.py
+++ b/caluma/caluma_workflow/tests/test_events.py
@@ -1,15 +1,17 @@
-from caluma.caluma_core.events import on
+import pytest
+
+from caluma.caluma_core.events import SignalHandlingError, on
+from caluma.caluma_workflow.api import skip_work_item
 from caluma.caluma_workflow.events import (
     post_complete_case,
     post_complete_work_item,
     post_skip_work_item,
 )
-
-from .. import models
+from caluma.caluma_workflow.models import WorkItem
 
 
 def test_events(db, work_item_factory, schema_executor):
-    work_item = work_item_factory(status=models.WorkItem.STATUS_READY, child_case=None)
+    work_item = work_item_factory(status=WorkItem.STATUS_READY, child_case=None)
 
     @on(post_complete_work_item)
     def complete_work_item_event_receiver(sender, work_item, **kwargs):
@@ -40,7 +42,7 @@ def test_events(db, work_item_factory, schema_executor):
 
 
 def test_skip_event(db, work_item_factory, schema_executor):
-    work_item = work_item_factory(status=models.WorkItem.STATUS_READY, child_case=None)
+    work_item = work_item_factory(status=WorkItem.STATUS_READY, child_case=None)
 
     @on(post_complete_work_item)
     def complete_work_item_event_receiver(sender, work_item, **kwargs):
@@ -67,3 +69,33 @@ def test_skip_event(db, work_item_factory, schema_executor):
     assert not result.errors
     work_item.refresh_from_db()
     assert work_item.meta == {"been-there": "done that"}
+
+
+@pytest.mark.parametrize(
+    "event,raise_exception",
+    [
+        (post_skip_work_item, False),
+        (post_skip_work_item, True),
+        ([post_skip_work_item], True),
+    ],
+)
+def test_event_raise_exceptions(
+    db, admin_user, work_item_factory, event, raise_exception
+):
+    work_item = work_item_factory(status=WorkItem.STATUS_READY, child_case=None)
+
+    @on(event, raise_exception=raise_exception)
+    def receiver1(sender, **kwargs):
+        raise AssertionError("Error 1")
+
+    @on(event, raise_exception=raise_exception)
+    def receiver2(sender, **kwargs):
+        raise AssertionError("Error 2")
+
+    if raise_exception:
+        with pytest.raises(SignalHandlingError) as exc:
+            skip_work_item(work_item, admin_user)
+
+        assert str(exc.value) == "Error 1, Error 2"
+    else:
+        assert skip_work_item(work_item, admin_user)

--- a/docs/events.md
+++ b/docs/events.md
@@ -37,11 +37,12 @@ def send_mail_on_complete_work_item_2(sender, work_item, user, context, **kwargs
 
 ## @on
 
-`@on` is just a wrapper for `django.dispatch.receiver` which takes two
-arguments:
+`@on` is a customized implementation of `django.dispatch.receiver` which
+takes three arguments:
 
 1. `event` (required): Event or list of events to listen to.
 2. `sender` (optional): Class of sender.
+3. `raise_exception` (optional): Whether to raise exceptions inside the receivers. This is `False` by default.
 
 ## Event receiver signature
 
@@ -97,6 +98,8 @@ There are plans to provide non-blocking event receivers, so stay tuned.
 
 Exceptions in event receivers are logged, but will not affect the current db transaction.
 That way, you can be sure the transaction will not be rolled-back because of an Exception in an event receiver.
+However, if the `raise_exception` argument of the receiver is `True` it will raise any
+exception that ocurred in the receiver function and the transaction will be rolled back.
 
 ## Built-in django signals
 


### PR DESCRIPTION
This allows us to control (on a per receiver basis) whether an exception in the receiver will cause an exception in the current transaction and therefore rollback said transaction.