### PR TITLE
fix: use homebrew jexl analyzer for question extraction

### DIFF
--- a/caluma/caluma_core/tests/test_jexl.py
+++ b/caluma/caluma_core/tests/test_jexl.py
@@ -3,7 +3,7 @@ import functools
 import pyjexl
 import pytest
 
-from ..jexl import JEXL, Cache, ExtractTransformSubjectAnalyzer
+from ..jexl import JEXL, Cache, CalumaAnalyzer, ExtractTransformSubjectAnalyzer
 
 
 @pytest.mark.parametrize(
@@ -189,3 +189,21 @@ def test_intersects_operator(expression, result):
 )
 def test_math_transforms(expression, result):
     assert JEXL().evaluate(expression) == result
+
+
+@pytest.mark.parametrize(
+    "expression,expected",
+    [
+        ("1 + 1", [1, 1]),
+        ('["1", 2, 3]', ["1", 2, 3]),
+        ('{key: ["foo", "bar"]}', ["foo", "bar"]),
+        ("[1|round, [2, 3]|min]|avg", [1, 2, 3]),
+    ],
+)
+def test_caluma_analyzer(expression, expected):
+    class NodeAnalyzer(CalumaAnalyzer):
+        def visit_Literal(self, node):
+            yield node.value
+
+    jexl = JEXL()
+    assert list(jexl.analyze(expression, NodeAnalyzer)) == expected

--- a/caluma/caluma_form/jexl.py
+++ b/caluma/caluma_form/jexl.py
@@ -67,13 +67,13 @@ class QuestionJexl(JEXL):
         return super().validate(expression, QuestionValidatingAnalyzer)
 
     def extract_referenced_questions(self, expr):
-        transforms = ["answer", "mapby"]
+        transforms = ["answer"]
         yield from self.analyze(
             expr, partial(ExtractTransformSubjectAnalyzer, transforms=transforms)
         )
 
     def extract_referenced_mapby_questions(self, expr):
-        transforms = ["answer", "mapby"]
+        transforms = ["mapby"]
         yield from self.analyze(
             expr, partial(ExtractTransformArgumentAnalyzer, transforms=transforms)
         )

--- a/caluma/caluma_form/tests/test_question.py
+++ b/caluma/caluma_form/tests/test_question.py
@@ -805,7 +805,7 @@ def test_calc_dependents(db, question_factory):
 
     calc_q = question_factory(
         type=models.Question.TYPE_CALCULATED_FLOAT,
-        calc_expression=f"'{dep1.slug}'|answer + '{dep2.slug}'|answer",
+        calc_expression=f"['{dep1.slug}'|answer, '{dep2.slug}'|answer]|sum",
     )
     other_calc_q = question_factory(
         type=models.Question.TYPE_CALCULATED_FLOAT,


### PR DESCRIPTION
Change analyzer baseclass to include array literals when walking AST.

Previously the ValidatingAnalyzer would not walk Array or ObjectLiterals, thus not reaching nested AST nodes.