### PR TITLE
fix: extract_global_id should not be too eager in decoding

### DIFF
--- a/caluma/caluma_core/relay.py
+++ b/caluma/caluma_core/relay.py
@@ -1,5 +1,7 @@
 from graphql_relay import from_global_id
 
+_valid_types = set()
+
 
 def extract_global_id(id):
     """
@@ -8,9 +10,32 @@ def extract_global_id(id):
     In case it is not a base64 encoded value it will return id as is.
     This way it can be used as input type by simply defining id without its specific type.
     """
+    if not _valid_types:
+        # Lazy import due to circular dependency
+        from caluma import schema
+        from caluma.caluma_core import types
+
+        all_types_dict = {
+            **vars(schema.workflow_schema),
+            **vars(schema.form_schema),
+            **vars(schema.form_historical_schema),
+        }
+        all_types = [
+            typename
+            for typename, gql_type in all_types_dict.items()
+            if isinstance(gql_type, type) and issubclass(gql_type, types.Node)
+        ]
+
+        _valid_types.update(all_types)
 
     try:
-        _, result = from_global_id(id)
+        gql_type, result = from_global_id(id)
+
+        # some valid ids could decode to a string that from_global_id()
+        # assumes is a global id, so we need to verify that it is indeed
+        # the case.
+        if gql_type and gql_type not in _valid_types:
+            return id
     except ValueError:
         result = id
 

--- a/caluma/caluma_core/tests/test_relay.py
+++ b/caluma/caluma_core/tests/test_relay.py
@@ -1,3 +1,5 @@
+from base64 import b64encode
+
 import pytest
 
 from ..relay import extract_global_id
@@ -7,7 +9,9 @@ from ..relay import extract_global_id
     "id,expected",
     [
         ("slug", "slug"),
-        ("V29ya2Zsb3dTcGVjaWZpY2F0aW9uOmxpc3RlbmVpbnRyYWc=", "listeneintrag"),
+        ("V29ya2Zsb3c6bGlzdGVuZWludHJhZw==", "listeneintrag"),
+        ("b106", "b106"),
+        (b64encode(b"NonExistantModel:foobar"),) * 2,
     ],
 )
 def test_extract_global_id(id, expected):

--- a/caluma/caluma_form/tests/test_form.py
+++ b/caluma/caluma_form/tests/test_form.py
@@ -256,7 +256,7 @@ def test_reorder_form_questions(db, form, form_question_factory, schema_executor
             "input": {
                 "form": to_global_id(type(form).__name__, form.pk),
                 "questions": [
-                    to_global_id(type(models.Question).__name__, question_id)
+                    to_global_id(models.Question.__name__, question_id)
                     for question_id in question_ids
                 ],
             }


### PR DESCRIPTION
We need to validate the extracted type in `extract_global_id()`, as it
may lead to errors when passing a valid slug, that's also valid base64,
and happens to contain a colon.

Instead of naively decoding and returning an invalid (type, identifier)
pair, validate the type's name and behave correctly in those cases.