### PR TITLE
fix(filters): fix search filter when used in collection

### DIFF
--- a/caluma/caluma_core/filters.py
+++ b/caluma/caluma_core/filters.py
@@ -81,7 +81,7 @@ class FilterCollectionFilter(Filter):
             invert = flt.pop("invert", False)
             flt_key = list(flt.keys())[0]
             flt_val = flt[flt_key]
-            filter = filter_coll.get_filters()[flt_key]
+            filter = filter_coll.filters[flt_key]
 
             new_qs = filter.filter(qs, flt_val)
 
@@ -99,7 +99,7 @@ class FilterCollectionOrdering(Filter):
 
         assert len(ord) == 1
         filt_name = list(ord.keys())[0]
-        filter = filter_coll.get_filters()[filt_name]
+        filter = filter_coll.filters[filt_name]
         qs, field = filter.get_ordering_value(qs, ord[filt_name])
 
         # Normally, people use ascending order, and in this context it seems

--- a/caluma/caluma_core/tests/test_search_filter.py
+++ b/caluma/caluma_core/tests/test_search_filter.py
@@ -1,0 +1,23 @@
+def test_search_in_filter_collection(db, schema_executor, form_factory):
+    form_factory(name="Test 1")
+    form_factory(name="Test 2")
+    form_factory(name="Test 3")
+
+    query = """
+        query($search: String!) {
+          allForms(filter: [{ search: $search }]) {
+            edges {
+              node {
+                slug
+                name
+              }
+            }
+          }
+        }
+    """
+
+    result = schema_executor(query, variable_values={"search": "Test 2"})
+    assert not result.errors
+
+    assert len(result.data["allForms"]["edges"]) == 1
+    assert result.data["allForms"]["edges"][0]["node"]["name"] == "Test 2"


### PR DESCRIPTION
Using the search filter in the filter collection resulted in an error where the filter did not have a model. This was caused because the
class method `filterset.get_filters()` was used instead of the properly initialized `filterset.filters` where the model was properly set.