### PR TITLE
feat(jexl): improve mapby and add stringify transform

### DIFF
--- a/caluma/caluma_core/tests/test_jexl.py
+++ b/caluma/caluma_core/tests/test_jexl.py
@@ -111,6 +111,8 @@ def test_jexl_cache():
         ("[{ key: 1 }]|mapby('key')", [1]),
         ("[{ otherkey: 1 }]|mapby('key')", [None]),
         ("[]|mapby('key')", []),
+        ("[{ a: 1, b: 2 }]|mapby('a', 'b', 'c')", [[1, 2, None]]),
+        ("0|mapby('key')", None),
     ],
 )
 def test_mapby_operator(expression, result):
@@ -188,6 +190,17 @@ def test_intersects_operator(expression, result):
     ],
 )
 def test_math_transforms(expression, result):
+    assert JEXL().evaluate(expression) == result
+
+
+@pytest.mark.parametrize(
+    "expression,result",
+    [
+        ("[['test1', 'test2'], [1,2]]|stringify", '[["test1", "test2"], [1, 2]]'),
+        ("1|stringify", "1"),
+    ],
+)
+def test_stringify_transform(expression, result):
     assert JEXL().evaluate(expression) == result
 
 

--- a/caluma/caluma_form/tests/test_question.py
+++ b/caluma/caluma_form/tests/test_question.py
@@ -961,9 +961,9 @@ def test_calculated_question(
         ("'table'|answer|mapby('column')[0]", 722550.2, ["table", "column"]),
         ("'other'|answer", 3.0, ["other"]),
         (
-            "'sub_question'|answer && 'table'|answer|mapby('column') ? 'other'|answer: -1",
+            "'sub_question'|answer && 'table'|answer|mapby('column', 'column2') ? 'other'|answer: -1",
             3.0,
-            ["sub_question", "table", "column", "other"],
+            ["sub_question", "table", "column", "column2", "other"],
         ),
     ],
 )
@@ -972,6 +972,7 @@ def test_nested_calculated_question(
     schema_executor,
     form_and_document,
     form_question_factory,
+    question_factory,
     expr,
     expected,
     calc_deps,
@@ -988,6 +989,13 @@ def test_nested_calculated_question(
     questions["other"] = form_question_factory(
         form=form, question__slug="other", question__type=models.Question.TYPE_INTEGER
     ).question
+
+    questions["column2"] = question_factory(
+        slug="column2", is_required="false", is_hidden="false"
+    )
+    form_question_factory(
+        form=questions["table"].row_form, question=questions["column2"]
+    )
 
     api.save_answer(question=questions["other"], document=document, value=3)
 


### PR DESCRIPTION
This extends the mapby transform to accept multiple keys as argument
which then returns an array instead of the single value. This will
result in nested arrays which is why we added a stringify transform that
converts such a collection into a string to be used in comparisons.