### PR TITLE
fix(workflow): correctly set workitem name from task

### DIFF
--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -73,7 +73,7 @@ class StartCaseLogic:
         workflow = case.workflow
         tasks = workflow.start_tasks.all()
 
-        work_items = utils.bulk_create_work_items(tasks, case, user, None, context)
+        work_items = utils.create_work_items(tasks, case, user, None, context)
 
         send_event_with_deprecations(
             "post_create_case",
@@ -179,7 +179,7 @@ class CompleteWorkItemLogic:
             )
 
             if all_siblings_complete:
-                created_work_items = utils.bulk_create_work_items(
+                created_work_items = utils.create_work_items(
                     next_tasks, case, user, work_item, context
                 )
 

--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -2,7 +2,6 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from rest_framework import exceptions
 from rest_framework.serializers import CharField, JSONField, ListField
-from simple_history.utils import bulk_create_with_history
 
 from caluma.caluma_core.events import SendEventSerializerMixin
 
@@ -82,10 +81,9 @@ class AddWorkflowFlowSerializer(serializers.ModelSerializer):
             created_by_user=user.username,
             created_by_group=user.group,
         )
-        task_flows = [
-            models.TaskFlow(task=task, workflow=instance, flow=flow) for task in tasks
-        ]
-        bulk_create_with_history(task_flows, models.TaskFlow)
+
+        for task in tasks:
+            models.TaskFlow.objects.create(task=task, workflow=instance, flow=flow)
 
         return instance
 

--- a/caluma/caluma_workflow/tests/test_work_item.py
+++ b/caluma/caluma_workflow/tests/test_work_item.py
@@ -465,6 +465,11 @@ def test_complete_work_item_with_next(
     inp = {"input": {"id": work_item.pk}}
     result = schema_executor(query, variable_values=inp, info=info)
 
+    # newly created work items must inherit task's name and description
+    next_work_item = task_next.work_items.all().first()
+    assert next_work_item.name == task_next.name
+    assert next_work_item.description == task_next.description
+
     assert not result.errors
     assert result.data == sorted_snapshot("edges", lambda x: json.dumps(x))
 

--- a/caluma/caluma_workflow/utils.py
+++ b/caluma/caluma_workflow/utils.py
@@ -1,5 +1,3 @@
-from simple_history.utils import bulk_create_with_history
-
 from ..caluma_form.models import Document
 from . import models
 from .jexl import FlowJexl, GroupJexl
@@ -49,9 +47,7 @@ def get_jexl_tasks(jexl, case, user, prev_work_item, context=None):
     return []
 
 
-def bulk_create_work_items(
-    tasks, case, user, prev_work_item=None, context: dict = None
-):
+def create_work_items(tasks, case, user, prev_work_item=None, context: dict = None):
     work_items = []
 
     for task in tasks:
@@ -84,7 +80,7 @@ def bulk_create_work_items(
 
         for groups in work_item_groups:
             work_items.append(
-                models.WorkItem(
+                models.WorkItem.objects.create(
                     addressed_groups=groups,
                     controlling_groups=controlling_groups,
                     task_id=task.pk,
@@ -98,5 +94,4 @@ def bulk_create_work_items(
                 )
             )
 
-    bulk_create_with_history(work_items, models.WorkItem)
     return work_items


### PR DESCRIPTION
When a work item is created from a workflow event (triggered via task),
we used bulk_create_with_history(), which doesn't send signals. Thus,
the `set_name_and_description` signal was not triggered, leaving us with
anonymous work items.