### PR TITLE
fix(document): pass current user to copy document function

### DIFF
--- a/caluma/caluma_form/serializers.py
+++ b/caluma/caluma_form/serializers.py
@@ -686,7 +686,10 @@ class CopyDocumentSerializer(serializers.ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data):
-        return validated_data["source"].copy()
+        return validated_data["source"].copy(
+            family=None,
+            user=self.context["request"].user,
+        )
 
     class Meta:
         model = models.Document


### PR DESCRIPTION
This makes sure that the `created_by_*` and `modified_by_*` properties
are set correctly.