### PR TITLE
fix(caluma): fix regression for union visibilities

### DIFF
--- a/caluma/caluma_core/visibilities.py
+++ b/caluma/caluma_core/visibilities.py
@@ -78,7 +78,9 @@ class Union(BaseVisibility):
     def filter_queryset(self, node, queryset, info):
         result_queryset = None
         for visibility_class in self.visibility_classes:
-            class_result = visibility_class().filter_queryset(node, queryset, info)
+            class_result = (
+                visibility_class().filter_queryset(node, queryset, info).all()
+            )
             if result_queryset is None:
                 result_queryset = class_result
             else:


### PR DESCRIPTION
This commit fixes a regression that was first introduced with
cf1f91dd88480d3ae206fc790db49c649f91ccc3 and then fixed with
2c195534db89a5622b62ae93a56ad5fe9ffec2c4, but then re-introduced with
b85ae9676fb4245a6d2817f376c23c495db0c146.

This time I was able to reproduce it and this commit contains a test.

Related issues and PRs:

* #569
* #598
* #599
* #841