### PR TITLE
feat: make selected option(s) accessible from answers

### DIFF
--- a/caluma/caluma_form/models.py
+++ b/caluma/caluma_form/models.py
@@ -440,6 +440,24 @@ class Answer(core_models.BaseModel):
             )
         return new_answer
 
+    @property
+    def selected_options(self):
+        map = {
+            Question.TYPE_CHOICE: (Option, {"slug": self.value}),
+            Question.TYPE_MULTIPLE_CHOICE: (Option, {"slug__in": self.value}),
+            Question.TYPE_DYNAMIC_CHOICE: (DynamicOption, {"slug": self.value}),
+            Question.TYPE_DYNAMIC_MULTIPLE_CHOICE: (
+                DynamicOption,
+                {"slug__in": self.value},
+            ),
+        }
+
+        if not self.value or self.question.type not in map:
+            return None
+
+        model, filters = map[self.question.type]
+        return model.objects.filter(**filters)
+
     def __repr__(self):
         return f"Answer(document={self.document!r}, question={self.question!r}, value={self.value!r})"
 

--- a/caluma/caluma_form/schema.py
+++ b/caluma/caluma_form/schema.py
@@ -739,8 +739,23 @@ class DateAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
         interfaces = (Answer, graphene.Node)
 
 
+class SelectedOption(ObjectType):
+    label = graphene.String(required=True)
+    slug = graphene.String(required=True)
+
+
+class SelectedOptionConnection(CountableConnectionBase):
+    class Meta:
+        node = SelectedOption
+
+
 class StringAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
     value = graphene.String()
+    selected_option = graphene.Field(SelectedOption)
+
+    def resolve_selected_option(self, info, **args):
+        selected_options = self.selected_options
+        return selected_options.first() if selected_options else None
 
     class Meta:
         model = models.Answer
@@ -751,6 +766,7 @@ class StringAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
 
 class ListAnswer(AnswerQuerysetMixin, FormDjangoObjectType):
     value = graphene.List(graphene.String)
+    selected_options = ConnectionField(SelectedOptionConnection)
 
     class Meta:
         model = models.Answer

--- a/caluma/caluma_form/tests/__snapshots__/test_document.ambr
+++ b/caluma/caluma_form/tests/__snapshots__/test_document.ambr
@@ -803,3 +803,85 @@
     },
   }
 ---
+# name: test_selected_options[choice-somevalue]
+  <class 'dict'> {
+    'node': <class 'dict'> {
+      'selectedOption': <class 'dict'> {
+        'label': 'Calvin Graham',
+        'slug': 'somevalue',
+      },
+      'string_value': 'somevalue',
+    },
+  }
+---
+# name: test_selected_options[dynamic_choice-somevalue]
+  <class 'dict'> {
+    'node': <class 'dict'> {
+      'selectedOption': <class 'dict'> {
+        'label': 'Angela Brown',
+        'slug': 'somevalue',
+      },
+      'string_value': 'somevalue',
+    },
+  }
+---
+# name: test_selected_options[dynamic_multiple_choice-answer__value3]
+  <class 'dict'> {
+    'node': <class 'dict'> {
+      'list_value': <class 'list'> [
+        'somevalue',
+        'anothervalue',
+      ],
+      'selectedOptions': <class 'dict'> {
+        'edges': <class 'list'> [
+          <class 'dict'> {
+            'node': <class 'dict'> {
+              'label': 'Angela Brown',
+              'slug': 'somevalue',
+            },
+          },
+          <class 'dict'> {
+            'node': <class 'dict'> {
+              'label': 'Michael Sherman',
+              'slug': 'anothervalue',
+            },
+          },
+        ],
+      },
+    },
+  }
+---
+# name: test_selected_options[multiple_choice-answer__value1]
+  <class 'dict'> {
+    'node': <class 'dict'> {
+      'list_value': <class 'list'> [
+        'somevalue',
+        'anothervalue',
+      ],
+      'selectedOptions': <class 'dict'> {
+        'edges': <class 'list'> [
+          <class 'dict'> {
+            'node': <class 'dict'> {
+              'label': 'Calvin Graham',
+              'slug': 'somevalue',
+            },
+          },
+          <class 'dict'> {
+            'node': <class 'dict'> {
+              'label': 'Mary White',
+              'slug': 'anothervalue',
+            },
+          },
+        ],
+      },
+    },
+  }
+---
+# name: test_selected_options[text-somevalue]
+  <class 'dict'> {
+    'node': <class 'dict'> {
+      'selectedOption': None,
+      'string_value': 'somevalue',
+    },
+  }
+---

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -1043,6 +1043,7 @@
     historyDate: DateTime!
     historyChangeReason: String
     historyType: String
+    selectedOptions(before: String, after: String, first: Int, last: Int): SelectedOptionConnection
   }
   
   type HistoricalStringAnswer implements HistoricalAnswer, Node {
@@ -1062,6 +1063,7 @@
     historyDate: DateTime!
     historyChangeReason: String
     historyType: String
+    selectedOption: SelectedOption
   }
   
   type HistoricalTableAnswer implements HistoricalAnswer, Node {
@@ -1151,6 +1153,7 @@
     question: Question!
     value: [String]
     meta: GenericScalar!
+    selectedOptions(before: String, after: String, first: Int, last: Int): SelectedOptionConnection
   }
   
   type MultipleChoiceQuestion implements Question, Node {
@@ -2043,6 +2046,22 @@
     TEXT
   }
   
+  type SelectedOption {
+    label: String!
+    slug: String!
+  }
+  
+  type SelectedOptionConnection {
+    pageInfo: PageInfo!
+    edges: [SelectedOptionEdge]!
+    totalCount: Int
+  }
+  
+  type SelectedOptionEdge {
+    node: SelectedOption
+    cursor: String!
+  }
+  
   type SimpleTask implements Task, Node {
     createdAt: DateTime!
     modifiedAt: DateTime!
@@ -2237,6 +2256,7 @@
     question: Question!
     value: String
     meta: GenericScalar!
+    selectedOption: SelectedOption
   }
   
   input SuspendCaseInput {


### PR DESCRIPTION
This commit adds a new field `selected_option` to `StringAnswer`,
holding the selected option for (dynamic) choice-questions and a new
connection `selected_options` to `ListAnswer` for (dynamic)
multiple-choice-questions.

Closes #1301