### PR TITLE
fix: extend uwsgi buffer

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -67,3 +67,5 @@ harakiri = 60
 # Auto rename worker processes
 auto-procname = true
 procname-prefix = "caluma "  ; note the space
+
+buffer-size = 16384


### PR DESCRIPTION
UWSGI has a buffer of 4096 bytes by default, in which all request headers
must fit. If a user has particularly many roles/groups in their JWT token,
this limit is exceeded. UWSGI will then abort the request, and the reverse
proxy in front will respond with an error such as HTTP/502.