### PR TITLE
feat(config): introduce configurable user factory

### DIFF
--- a/caluma/settings/caluma.py
+++ b/caluma/settings/caluma.py
@@ -62,6 +62,11 @@ OIDC_INTROSPECT_ENDPOINT = env.str("OIDC_INTROSPECT_ENDPOINT", default=None)
 OIDC_INTROSPECT_CLIENT_ID = env.str("OIDC_INTROSPECT_CLIENT_ID", default=None)
 OIDC_INTROSPECT_CLIENT_SECRET = env.str("OIDC_INTROSPECT_CLIENT_SECRET", default=None)
 
+CALUMA_OIDC_USER_FACTORY = env.str(
+    "CALUMA_OIDC_USER_FACTORY", default="caluma.caluma_user.models.OIDCUser"
+)
+
+
 # Extensions
 
 VISIBILITY_CLASSES = env.list(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ Caluma expects a bearer token to be passed on as [Authorization Request Header F
 * `OIDC_GROUPS_CLAIM`: Name of claim to be used to represent groups (default: caluma_groups)
 * `OIDC_USERNAME_CLAIM`: Name of claim to be used to represent the username (default: sub)
 * `OIDC_BEARER_TOKEN_REVALIDATION_TIME`: Time in seconds before bearer token validity is verified again. For best security token is validated on each request per default. It might be helpful though in case of slow Open ID Connect provider to cache it. It uses [cache](#cache) mechanism for memorizing userinfo result. Number has to be lower than access token expiration time. (default: 0)
+* `CALUMA_OIDC_USER_FACTORY`: User object factory (default: `caluma.caluma_user.models.OIDCUser`). Use it to provide a custom OIDC user object. The factory is expected to accept a mandatory `token` parameter and two optional parameters `userinfo` and `introspection`. Only one of them will be filled, depending on which OIDC endpoint the user information comes from.
 
 ## Cache
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -361,3 +361,33 @@ will raise an exception.
 ## Caluma events
 
 For reacting upon Caluma Events, you can setup [event receivers](events.md)
+
+## OIDC User factory
+
+Especially when using Caluma embedded in another Django project, you need to
+ensure compatibility with other components. Caluma does not represent users
+as a database object, but instead uses a "shim" object in it's role as an OIDC
+relying party (RP) that represents the requesting user.
+Oher projects may have differing requirements however.
+
+Therefore, you can define a custom `CALUMA_OIDC_USER_FACTORY`. The setting is a string
+that points to a callable, which is expected to return an OIDC user object.
+By default it points to `caluma.caluma_user.models.OIDCUser`.
+
+The factory needs to provide the following interface:
+
+```python
+    def user_factory(token, userinfo=None, introspection=None):
+        # Either `userinfo` or `introspection` is filled with a dict
+        # with information about the user.
+        return SomeOIDCUserObject(...)
+```
+
+The resulting object is expected to provide the following properties:
+* `username` - returns the username.
+* `group` - The primary group of the user. Used to fill in `created_by_group` etc
+* `is_authenticated` - Boolean, should always be `True`
+
+You may extend the object as you please, for example by providing
+shortcuts to data you need often  (reference to a Django user model if
+you use one, etc).


### PR DESCRIPTION
Allow users to provide a custom user factory to build the OIDCUser
object. This enables us to extend it and make it compatible with
other OIDC RP apps (such as Emeis, Alexandria etc).