### PR TITLE
feat: Expose more CORS related configurations via environment variables

### DIFF
--- a/caluma/settings/django.py
+++ b/caluma/settings/django.py
@@ -145,12 +145,8 @@ CORS_ALLOW_HEADERS = env.list("CORS_ALLOW_HEADERS", default=[
     'x-requested-with'
 ])
 CORS_ALLOW_METHODS = env.list("CORS_ALLOW_METHODS", default=[
-    'DELETE',
-    'GET',
     'OPTIONS',
-    'PATCH',
-    'POST',
-    'PUT'
+    'POST'
 ])
 
 

--- a/caluma/settings/django.py
+++ b/caluma/settings/django.py
@@ -130,6 +130,28 @@ ADMINS = parse_admins(env.list("ADMINS", default=[]))
 # Cors headers
 CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL", default=False)
 CORS_ORIGIN_WHITELIST = env.list("CORS_ORIGIN_WHITELIST", default=[])
+CORS_ALLOW_CREDENTIALS = env.bool("CORS_ALLOW_CREDENTIALS", default=True)
+CORS_ALLOW_HEADERS = env.list("CORS_ALLOW_HEADERS", default=[
+    'accept',
+    'accept-encoding',
+    'accept-language', # Custom added default value since ember-caluma uses it
+    'authorization',
+    'content-type',
+    'dnt',
+    'origin',
+    'user-agent',
+    'language', # Custom added default value since ember-caluma uses it
+    'x-csrftoken',
+    'x-requested-with'
+])
+CORS_ALLOW_METHODS = env.list("CORS_ALLOW_METHODS", default=[
+    'DELETE',
+    'GET',
+    'OPTIONS',
+    'PATCH',
+    'POST',
+    'PUT'
+])
 
 
 # Logging

--- a/caluma/settings/django.py
+++ b/caluma/settings/django.py
@@ -131,23 +131,23 @@ ADMINS = parse_admins(env.list("ADMINS", default=[]))
 CORS_ORIGIN_ALLOW_ALL = env.bool("CORS_ORIGIN_ALLOW_ALL", default=False)
 CORS_ORIGIN_WHITELIST = env.list("CORS_ORIGIN_WHITELIST", default=[])
 CORS_ALLOW_CREDENTIALS = env.bool("CORS_ALLOW_CREDENTIALS", default=True)
-CORS_ALLOW_HEADERS = env.list("CORS_ALLOW_HEADERS", default=[
-    'accept',
-    'accept-encoding',
-    'accept-language', # Custom added default value since ember-caluma uses it
-    'authorization',
-    'content-type',
-    'dnt',
-    'origin',
-    'user-agent',
-    'language', # Custom added default value since ember-caluma uses it
-    'x-csrftoken',
-    'x-requested-with'
-])
-CORS_ALLOW_METHODS = env.list("CORS_ALLOW_METHODS", default=[
-    'OPTIONS',
-    'POST'
-])
+CORS_ALLOW_HEADERS = env.list(
+    "CORS_ALLOW_HEADERS",
+    default=[
+        "accept",
+        "accept-encoding",
+        "accept-language",  # Custom added default value since ember-caluma uses it
+        "authorization",
+        "content-type",
+        "dnt",
+        "origin",
+        "user-agent",
+        "language",  # Custom added default value since ember-caluma uses it
+        "x-csrftoken",
+        "x-requested-with",
+    ],
+)
+CORS_ALLOW_METHODS = env.list("CORS_ALLOW_METHODS", default=["OPTIONS", "GET", "POST"])
 
 
 # Logging

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -32,7 +32,7 @@ from caluma.caluma_form.schema import Form
 class CustomVisibility(BaseVisibility):
     @filter_queryset_for(Node)
     def filter_queryset_for_all(self, node, queryset, info):
-        return queryset.filter(created_by_user=info.context.request.user.username)
+        return queryset.filter(created_by_user=info.context.user.username)
 
     @filter_queryset_for(Form)
     def filter_queryset_for_form(self, node, queryset, info):


### PR DESCRIPTION
With the current django configurations exposed, it was not possible to deploy and use caluma in a CORS scenario. 
With this change more CORS header configurations are exposed via environment variables. Furthermore it enhances the django default values with some caluma required stuff like the language header.