### PR TITLE
feat(config): validate permission decorators

### DIFF
--- a/caluma/caluma_core/tests/test_mutation_params.py
+++ b/caluma/caluma_core/tests/test_mutation_params.py
@@ -3,14 +3,13 @@ import json
 from graphql_relay import to_global_id
 
 from ...caluma_form import models as form_models, schema as form_schema
-from .. import permissions, types
+from .. import permissions
 
 
 class _TestPermission(permissions.BasePermission):
     def permission_impl(self, mutation, info):  # pragma: no cover
         raise NotImplementedError("You need to mock permission_impl")
 
-    @permissions.permission_for(types.Node)
     def has_permission(self, mutation, info):
         # We need this indirection as this method will be registered
         # with the permissions system, but we need to mock the functionality

--- a/caluma/caluma_core/tests/test_permissions.py
+++ b/caluma/caluma_core/tests/test_permissions.py
@@ -1,6 +1,8 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
+from caluma.caluma_core.types import Node
+
 from .. import models, serializers
 from ..mutation import Mutation
 from ..permissions import BasePermission, object_permission_for, permission_for
@@ -150,3 +152,18 @@ def test_custom_permission_override_has_object_permission_with_multiple_mutation
 
     assert not CustomPermission().has_object_permission(CustomMutation, info, instance)
     assert not CustomPermission().has_object_permission(AnotherMutation, info, instance)
+
+
+def test_validate_permission():
+
+    with pytest.raises(ImproperlyConfigured) as exc:
+
+        @object_permission_for(Node)
+        def has_object_permission_for_both_mutations(
+            self, mutation, info, instance
+        ):  # pragma: no cover
+            return False
+
+    assert exc.match(
+        r"Mutation caluma.caluma_core.types.Node is not a recognized mutation"
+    )

--- a/caluma/schema.py
+++ b/caluma/schema.py
@@ -14,10 +14,13 @@ from .caluma_workflow import schema as workflow_schema
 
 convert_django_field.register(LocalizedField, convert_field_to_string)
 
-
-class Mutation(form_schema.Mutation, workflow_schema.Mutation, graphene.ObjectType):
-    pass
-
+# The consolidated mutation is created procedurally here to avoid
+# exporting it as `Mutation`, which can be confusing
+_mutation = type(
+    "Mutation",
+    (form_schema.Mutation, workflow_schema.Mutation, graphene.ObjectType),
+    {},
+)
 
 query_inherit_from = [
     form_schema.Query,
@@ -77,7 +80,7 @@ class Query(*query_inherit_from):
 
 schema = graphene.Schema(
     query=Query,
-    mutation=Mutation,
+    mutation=_mutation,
     # TODO: define what app exposes what types
     types=types,
 )


### PR DESCRIPTION
When usig an invalid mutation class in the permission classes, things
might work unexpectedly, even though not actually being correct.

This validation checks that your permission classes actually
use a mutation that exists in the system.

fixes #1614 