### PR TITLE
chore: bump pyjexl to 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ graphene-django==2.8.2
 idna==3.3
 minio==7.0.3
 psycopg2-binary==2.8.6
-pyjexl @ git+https://github.com/mozilla/pyjexl.git@dab0618f0d81926759cd0e6ccfd3dcdb08a13ca1#egg=pyjexl
+pyjexl==0.3.0
 python-memcached==1.59
 requests==2.26.0
 urllib3==1.26.7

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "idna<4",
         "minio >= 7, < 8",
         "psycopg2-binary >= 2.8, <2.9",
-        "pyjexl @ https://github.com/projectcaluma/pyjexl/archive/edd40f4b14b6b14c9915d40d4ad37a540adeec0a.tar.gz",
+        "pyjexl >= 0.3.0",
         "python-memcached<2",
         "requests<3",
         "urllib3<2",


### PR DESCRIPTION
This should make Caluma releaseable again