### PR TITLE
chore(build): cleanup docker build process

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -52,8 +52,17 @@ jobs:
           # Strip "v" prefix from tag name
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          if [[ "$VERSION" == "main" ]]; then
+            # only push "dev" image from main branch build
+            echo "Pushing $IMAGE_ID:dev"
+            docker tag $IMAGE_NAME $IMAGE_ID:dev
+            docker push $IMAGE_ID:dev
+          else
+            # new version released - push "latest" and version tag
+            echo "Pushing $IMAGE_ID:$VERSION"
+            docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+            docker push $IMAGE_ID:$VERSION
+            echo "Pushing $IMAGE_ID:latest"
+            docker tag $IMAGE_NAME $IMAGE_ID:latest
+            docker push $IMAGE_ID:latest
+          fi


### PR DESCRIPTION
* Builds on the `main` branch will push a tag named `dev`
* Builds on releases (tags) will push a tag named `latest`
  as well as a tag with the proper version number.

Thus, `latest` should always be the last-properly-released version,
and if you need tha latest development version, you can use the `dev`
docker tag instead.