### PR TITLE
fix: coverage in new status fields

### DIFF
--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -37,12 +37,16 @@ class GroupJexlField(serializers.JexlField):
 
 
 class CaseStatusField(serializers.CalumaChoiceField):
-    def __init__(self, **kwargs):
+    # Required for the type system, case status is
+    # never part of an input
+    def __init__(self, **kwargs):  # pragma: no cover
         super().__init__([s for s, _ in models.Case.STATUS_CHOICE_TUPLE], **kwargs)
 
 
 class WorkItemStatusField(serializers.CalumaChoiceField):
-    def __init__(self, **kwargs):
+    # Required for the type system, workitem status is
+    # never part of an input
+    def __init__(self, **kwargs):  # pragma: no cover
         super().__init__([s for s, _ in models.WorkItem.STATUS_CHOICE_TUPLE], **kwargs)
 
 


### PR DESCRIPTION
Those status fields are only used for the type system, but not as actual
input types. Thus, they're never actually instantiated