### PR TITLE
chore(deps): update graphql-relay

### DIFF
--- a/caluma/caluma_analytics/tests/test_table.py
+++ b/caluma/caluma_analytics/tests/test_table.py
@@ -224,9 +224,7 @@ def test_remove_field(db, schema_executor, analytics_field):
     query = """
         mutation remove($input: RemoveAnalyticsFieldInput!) {
           removeAnalyticsField(input: $input) {
-            analyticsField {
-              id
-            }
+            clientMutationId
           }
         }
     """
@@ -250,9 +248,7 @@ def test_remove_table(db, schema_executor, analytics_table):
     query = """
         mutation remove($input: RemoveAnalyticsTableInput!) {
           removeAnalyticsTable(input: $input) {
-            analyticsTable {
-              id
-            }
+            clientMutationId
           }
         }
     """

--- a/caluma/caluma_core/relay.py
+++ b/caluma/caluma_core/relay.py
@@ -29,15 +29,17 @@ def extract_global_id(id):
 
         _valid_types.update(all_types)
 
-    try:
-        gql_type, result = from_global_id(id)
+    gql_type, result = from_global_id(id)
 
-        # some valid ids could decode to a string that from_global_id()
-        # assumes is a global id, so we need to verify that it is indeed
-        # the case.
-        if gql_type and gql_type not in _valid_types:
-            return id
-    except ValueError:
-        result = id
+    # from_global_id() now returns an empty string if the passed id could not be
+    # decoded from base64 which is the case for raw ids
+    if result == "":
+        return id
+
+    # some valid ids could decode to a string that from_global_id()
+    # assumes is a global id, so we need to verify that it is indeed
+    # the case.
+    if gql_type and gql_type not in _valid_types:
+        return id
 
     return result

--- a/caluma/caluma_core/types.py
+++ b/caluma/caluma_core/types.py
@@ -8,9 +8,9 @@ from graphene.relay.connection import ConnectionField
 from graphene_django import types
 from graphene_django.fields import DjangoConnectionField
 from graphene_django.utils import maybe_queryset
-from graphql_relay.connection.arrayconnection import get_offset_with_default
+from graphql_relay import get_offset_with_default
 
-from .pagination import connection_from_list, connection_from_list_slice
+from .pagination import connection_from_array, connection_from_array_slice
 
 
 class Node(object):
@@ -85,22 +85,22 @@ class DjangoConnectionField(DjangoConnectionField):
         else:  # pragma: no cover
             _len = len(iterable)
 
-        # If after is higher than list_length, connection_from_list_slice
+        # If after is higher than list_length, connection_from_array_slice
         # would try to do a negative slicing which makes django throw an
         # AssertionError
         after = min(get_offset_with_default(args.get("after"), -1) + 1, _len)
         if max_limit is not None and "first" not in args:  # pragma: no cover
             args["first"] = max_limit
 
-        connection = connection_from_list_slice(
+        connection = connection_from_array_slice(
             iterable[after:],
             args,
             slice_start=0,
-            list_length=_len,
-            list_slice_length=_len,
+            array_length=_len,
+            array_slice_length=_len,
             connection_type=connection,
             edge_type=connection.Edge,
-            pageinfo_type=PageInfo,
+            page_info_type=PageInfo,
         )
         connection.iterable = iterable
         connection.length = _len
@@ -127,12 +127,12 @@ class ConnectionField(ConnectionField):
             "Resolved value from the connection field have to be iterable or instance of {0}. "
             'Received "{1}"'
         ).format(connection_type, resolved)
-        connection = connection_from_list(
+        connection = connection_from_array(
             resolved,
             args,
             connection_type=connection_type,
             edge_type=connection_type.Edge,
-            pageinfo_type=PageInfo,
+            page_info_type=PageInfo,
         )
         connection.iterable = resolved
         return connection

--- a/caluma/caluma_form/tests/__snapshots__/test_answer.ambr
+++ b/caluma/caluma_form/tests/__snapshots__/test_answer.ambr
@@ -1,12 +1,6 @@
 # name: test_remove_answer[integer-23]
   <class 'dict'> {
     'removeAnswer': <class 'dict'> {
-      'answer': <class 'dict'> {
-        '__typename': 'IntegerAnswer',
-        'id': 'SW50ZWdlckFuc3dlcjpOb25l',
-        'meta': <class 'dict'> {
-        },
-      },
       'clientMutationId': None,
     },
   }

--- a/caluma/caluma_form/tests/test_answer.py
+++ b/caluma/caluma_form/tests/test_answer.py
@@ -20,11 +20,6 @@ def test_remove_answer(db, snapshot, question, answer, schema_executor):
     query = """
         mutation RemoveAnswer($input: RemoveAnswerInput!) {
           removeAnswer(input: $input) {
-            answer {
-              id
-              meta
-              __typename
-            }
             clientMutationId
           }
         }

--- a/caluma/caluma_form/tests/test_document.py
+++ b/caluma/caluma_form/tests/test_document.py
@@ -1160,9 +1160,6 @@ def test_remove_document_without_case(db, document, answer, schema_executor):
     query = """
         mutation RemoveDocument($input: RemoveDocumentInput!) {
           removeDocument(input: $input) {
-            document {
-              id
-            }
             clientMutationId
           }
         }
@@ -1183,9 +1180,6 @@ def test_remove_document_with_case(db, document, answer, case, schema_executor):
     query = """
         mutation RemoveDocument($input: RemoveDocumentInput!) {
           removeDocument(input: $input) {
-            document {
-              id
-            }
             clientMutationId
           }
         }
@@ -1226,9 +1220,6 @@ def test_remove_document_without_case_table(
     query = """
         mutation RemoveDocument($input: RemoveDocumentInput!) {
           removeDocument(input: $input) {
-            document {
-              id
-            }
             clientMutationId
           }
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-watchman==1.2.0
 djangorestframework==3.13.1
 django_simple_history==3.0.0
 graphene-django==3.0.0b7
-graphql-relay>3,<3.1.1  # >= 3.1 has breaking changes
+graphql-relay==3.1.5
 idna==3.3
 minio==7.1.3
 psycopg2-binary==2.9.3

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "djangorestframework<4",
         "django_simple_history<4",
         "graphene-django<=3.0.0b7",
-        "graphql-relay>3,<3.1.1",
+        "graphql-relay>=3.1.5,<4",
         "idna<4",
         "minio >= 7, < 8",
         "psycopg2-binary >= 2.9",


### PR DESCRIPTION
Closes #1683

`connection_from_list` and `connection_from_list_splice` are deprecated in favor of `connection_from_array` and `connection_from_array_splice`. Since we override it this is not really necessary but it makes sure that we don't use deprecated functions when https://github.com/graphql-python/graphql-relay-py/issues/12 is fixed.

This also fixes old imports that are now exposed in the top level of `graphql_relay`.