### PR TITLE
feat(workflow): only create work item if they don't exist yet

### DIFF
--- a/caluma/caluma_workflow/utils.py
+++ b/caluma/caluma_workflow/utils.py
@@ -90,6 +90,18 @@ def create_work_items(tasks, case, user, prev_work_item=None, context: dict = No
             work_item_groups = [addressed_groups]
 
         for groups in work_item_groups:
+            if (
+                not task.is_multiple_instance
+                and models.WorkItem.objects.filter(
+                    addressed_groups=groups,
+                    controlling_groups=controlling_groups,
+                    task_id=task.pk,
+                    case=case,
+                ).exists()
+            ):
+                # work item already exists, do not create a new one
+                continue
+
             work_items.append(
                 models.WorkItem.objects.create(
                     addressed_groups=groups,


### PR DESCRIPTION
Work items should only be created if they don't exist yet or if the task allows multiple instances. This makes sure that we don't have accidental duplicate of work items. This intentionally doesn't use `get_or_create` to avoid the creation of an obsolete documents since django doesn't support lazy defaults.

Closes #1512

*Disclaimer: This is basically copy paste of #1659 with a refactoring to use a preliminary query instead of `get_or_create` to avoid obsolete documents and deadline computations.*

Closes #1659 