### PR TITLE
Feat: reopen case

### DIFF
--- a/caluma/caluma_workflow/api.py
+++ b/caluma/caluma_workflow/api.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from caluma.caluma_form.models import Form
 from caluma.caluma_user.models import BaseUser
@@ -206,6 +206,34 @@ def resume_case(
     update_model(case, validated_data)
 
     domain_logic.ResumeCaseLogic.post_resume(case, user, context)
+
+    return case
+
+
+def reopen_case(
+    case: models.Case,
+    work_items: List[models.WorkItem],
+    user: BaseUser,
+    context: Optional[dict] = None,
+) -> models.Case:
+    """
+    Reopen a case (just like `ReopenCase`).
+
+    >>> reopen_case(
+    ...     case=models.Case.first(),
+    ...     work_items=[...]
+    ...     user=AnonymousUser()
+    ... )
+    <Case: Case object (some-uuid)>
+    """
+
+    domain_logic.ReopenCaseLogic.validate_for_reopen(case, work_items)
+
+    domain_logic.ReopenCaseLogic.pre_reopen(case, work_items, user, context)
+
+    domain_logic.ReopenCaseLogic.do_reopen(case, work_items)
+
+    domain_logic.ReopenCaseLogic.post_reopen(case, work_items, user, context)
 
     return case
 

--- a/caluma/caluma_workflow/events.py
+++ b/caluma/caluma_workflow/events.py
@@ -8,7 +8,7 @@ module = sys.modules[__name__]
 
 MODEL_ACTIONS = {
     "work_item": ["create", "complete", "cancel", "skip", "suspend", "resume", "redo"],
-    "case": ["create", "complete", "cancel", "suspend", "resume"],
+    "case": ["create", "complete", "cancel", "suspend", "resume", "reopen"],
 }
 
 # create "pre|post"_"create|complete|..."_"work_item|case" events in all given combinations

--- a/caluma/caluma_workflow/schema.py
+++ b/caluma/caluma_workflow/schema.py
@@ -307,6 +307,21 @@ class ResumeCase(Mutation):
         model_operations = ["update"]
 
 
+class ReopenCase(Mutation):
+    class Input:
+        id = graphene.ID()
+        work_items = graphene.List(
+            graphene.ID,
+            required=True,
+            description="List of work item ids to be readied when the case is reopened",
+        )
+
+    class Meta:
+        serializer_class = serializers.ReopenCaseSerializer
+        fields: ["id"]
+        model_operations = ["update"]
+
+
 class CompleteWorkItem(Mutation):
     class Meta:
         serializer_class = serializers.CompleteWorkItemSerializer
@@ -373,6 +388,7 @@ class Mutation(object):
     cancel_case = CancelCase().Field()
     suspend_case = SuspendCase().Field()
     resume_case = ResumeCase().Field()
+    reopen_case = ReopenCase().Field()
     complete_work_item = CompleteWorkItem().Field()
     skip_work_item = SkipWorkItem().Field()
     cancel_work_item = CancelWorkItem().Field()

--- a/caluma/caluma_workflow/tests/test_reopen_case.py
+++ b/caluma/caluma_workflow/tests/test_reopen_case.py
@@ -1,0 +1,202 @@
+import pytest
+from django.core.exceptions import ValidationError
+from graphene_django.utils.str_converters import to_const
+
+from .. import api, models
+
+
+@pytest.fixture
+def reopen_case_setup(case_factory, work_item_factory):
+    def case_work_item_setup(case_status, work_item_statuses):
+        case = case_factory(status=case_status)
+        work_items = []
+
+        for work_item_status in work_item_statuses:
+            work_items.append(work_item_factory(case=case, status=work_item_status))
+
+        return case, work_items
+
+    return case_work_item_setup
+
+
+def test_allow_completed_cases_to_be_reopened_through_api(
+    db, admin_user, reopen_case_setup
+):
+    completed_case, completed_work_items = reopen_case_setup(
+        models.Case.STATUS_COMPLETED,
+        [models.WorkItem.STATUS_COMPLETED],
+    )
+
+    api.reopen_case(completed_case, completed_work_items, admin_user)
+
+    completed_case.refresh_from_db()
+
+    assert completed_case.status == models.Case.STATUS_RUNNING
+    assert completed_work_items[0].status == models.WorkItem.STATUS_READY
+
+
+def test_allow_completed_cases_to_be_reopened_through_graphql(
+    db, admin_user, schema_executor, reopen_case_setup
+):
+    completed_case, completed_work_items = reopen_case_setup(
+        models.Case.STATUS_COMPLETED,
+        [models.WorkItem.STATUS_COMPLETED],
+    )
+
+    query = """
+        mutation ReopenCase($input: ReopenCaseInput!) {
+            reopenCase(input: $input) {
+                case {
+                    status
+                    workItems {
+                        edges {
+                            node {
+                                status
+                            }
+                        }
+                    }
+                }
+                clientMutationId
+            }
+        }
+    """
+
+    inp = {
+        "input": {
+            "id": str(completed_case.pk),
+            "workItems": [str(completed_work_items[0].pk)],
+        }
+    }
+
+    result = schema_executor(query, variable_values=inp)
+    assert not result.errors
+    assert result.data["reopenCase"]["case"]["status"] == to_const(
+        models.Case.STATUS_RUNNING
+    )
+    assert result.data["reopenCase"]["case"]["workItems"]["edges"][0]["node"][
+        "status"
+    ] == to_const(models.WorkItem.STATUS_READY)
+
+
+def test_reject_suspended_cases_during_reopen(db, admin_user, reopen_case_setup):
+    suspended_case, work_items = reopen_case_setup(
+        models.Case.STATUS_SUSPENDED,
+        [models.WorkItem.STATUS_COMPLETED],
+    )
+
+    with pytest.raises(ValidationError):
+        api.reopen_case(suspended_case, work_items, admin_user)
+
+
+def test_require_at_least_1_work_item_during_case_reopening(
+    db, admin_user, schema_executor, reopen_case_setup
+):
+    case, completed_work_items = reopen_case_setup(
+        models.Case.STATUS_COMPLETED,
+        [models.WorkItem.STATUS_COMPLETED],
+    )
+
+    query = """
+        mutation ReopenCase($input: ReopenCaseInput!) {
+            reopenCase(input: $input) {
+                case {
+                    status
+                }
+                clientMutationId
+            }
+        }
+    """
+
+    inp = {"input": {"caseId": str(case.pk), "workItemIds": []}}
+
+    result = schema_executor(query, variable_values=inp)
+    assert result.errors
+
+
+def test_only_supplied_work_items_readied(
+    db, admin_user, schema_executor, reopen_case_setup
+):
+    case, work_items = reopen_case_setup(
+        models.Case.STATUS_COMPLETED,
+        [
+            models.WorkItem.STATUS_COMPLETED,
+            models.WorkItem.STATUS_SKIPPED,
+            models.WorkItem.STATUS_CANCELED,
+        ],
+    )
+
+    api.reopen_case(case, [work_items[0]], admin_user)
+
+    case.refresh_from_db()
+
+    assert work_items[0].status == models.WorkItem.STATUS_READY
+    assert work_items[1].status == models.WorkItem.STATUS_SKIPPED
+    assert work_items[2].status == models.WorkItem.STATUS_CANCELED
+
+
+def test_work_items_not_lost(db, admin_user, schema_executor, reopen_case_setup):
+    case, work_items = reopen_case_setup(
+        models.Case.STATUS_COMPLETED,
+        [
+            models.WorkItem.STATUS_COMPLETED,
+            models.WorkItem.STATUS_SKIPPED,
+            models.WorkItem.STATUS_CANCELED,
+        ],
+    )
+
+    api.reopen_case(case, [work_items[0]], admin_user)
+
+    case.refresh_from_db()
+
+    assert work_items[0] in case.work_items.all()
+    assert work_items[1] in case.work_items.all()
+    assert work_items[2] in case.work_items.all()
+
+
+def test_only_cases_without_parent_case(
+    db, case_factory, work_item_factory, admin_user, reopen_case_setup
+):
+    parent_case = case_factory()
+    child_case, work_items = reopen_case_setup(
+        models.Case.STATUS_COMPLETED,
+        [
+            models.WorkItem.STATUS_COMPLETED,
+            models.WorkItem.STATUS_SKIPPED,
+            models.WorkItem.STATUS_CANCELED,
+        ],
+    )
+
+    child_case.family = parent_case
+    child_case.save()
+
+    with pytest.raises(ValidationError):
+        api.reopen_case(child_case, work_items, admin_user)
+
+
+def test_only_work_items_at_end_of_branch(
+    db, work_item_factory, admin_user, reopen_case_setup
+):
+    case, work_items = reopen_case_setup(
+        models.Case.STATUS_COMPLETED,
+        [models.WorkItem.STATUS_COMPLETED],
+    )
+
+    # add a work item after the one returned by the reopen_case_setup
+    work_item_factory(previous_work_item=work_items[0])
+
+    with pytest.raises(ValidationError):
+        api.reopen_case(case, work_items, admin_user)
+
+
+def test_only_work_items_belonging_to_case(
+    db, case_factory, work_item_factory, admin_user, reopen_case_setup
+):
+    case, work_items = reopen_case_setup(
+        models.Case.STATUS_COMPLETED,
+        [models.WorkItem.STATUS_COMPLETED],
+    )
+
+    other_case_work_item = work_item_factory()
+
+    with pytest.raises(ValidationError):
+        api.reopen_case(case, [other_case_work_item], admin_user)

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -2466,6 +2466,7 @@
     cancelCase(input: CancelCaseInput!): CancelCasePayload
     suspendCase(input: SuspendCaseInput!): SuspendCasePayload
     resumeCase(input: ResumeCaseInput!): ResumeCasePayload
+    reopenCase(input: ReopenCaseInput!): ReopenCasePayload
     completeWorkItem(input: CompleteWorkItemInput!): CompleteWorkItemPayload
     skipWorkItem(input: SkipWorkItemInput!): SkipWorkItemPayload
     cancelWorkItem(input: CancelWorkItemInput!): CancelWorkItemPayload
@@ -3238,6 +3239,20 @@
   
   type RemoveFormQuestionPayload {
     form: Form
+    clientMutationId: String
+  }
+  
+  input ReopenCaseInput {
+    id: ID!
+    workItems: [ID]!
+  
+    """Provide extra context for dynamic jexl transforms and events"""
+    context: JSONString
+    clientMutationId: String
+  }
+  
+  type ReopenCasePayload {
+    case: Case
     clientMutationId: String
   }
   


### PR DESCRIPTION
# Description
Adds the ability to reopen a previously `completed` case.

During re-opening of a case the ID of the case as well as an array of `work-items` have to be supplied.

## Implemented checks/validations for case reopening:
### Case reopen validation:
- Case status has to be `STATUS_COMPLETED` or `STATUS_CANCELED`. Suspended cases can not be reopend.
- A case can not be a child case
### Work item validation:
- Only work items at the end of a branch can be re-opened
- Only work items belonging to the case that is being re-opened can be re-opened

