### PR TITLE
Feat: analytics summary

### DIFF
--- a/caluma/caluma_analytics/schema.py
+++ b/caluma/caluma_analytics/schema.py
@@ -71,6 +71,7 @@ class AnalyticsTableContent(graphene.Connection):
 
 class AnalyticsOutput(ObjectType):
     records = ConnectionField(AnalyticsTableContent)
+    summary = graphene.Field(AnalyticsRow)
 
     @staticmethod
     def resolve_records(table, info, *args, **kwargs):
@@ -84,6 +85,16 @@ class AnalyticsOutput(ObjectType):
             for row in table.get_records()
         ]
         return rows
+
+    @staticmethod
+    def resolve_summary(table, info, *args, **kwargs):
+        summary_row = table.get_summary()
+        return AnalyticsRow(
+            edges=[
+                {"node": {"alias": alias, "value": val}}
+                for alias, val in summary_row.items()
+            ]
+        )
 
 
 StartingObject = enum_type_from_field(

--- a/caluma/caluma_analytics/tests/test_pivot_table.py
+++ b/caluma/caluma_analytics/tests/test_pivot_table.py
@@ -62,6 +62,14 @@ def test_run_analytics_gql(
                     }
                   }
                 }
+                summary {
+                  edges {
+                    node {
+                      alias
+                      value
+                    }
+                  }
+                }
              }
           }
        }
@@ -85,4 +93,12 @@ def test_run_analytics_gql(
             "running": "2022-02-03 00:00:00+00:00",
             "completed": "2022-02-04 00:00:00+00:00",
             "suspended": "2022-02-05 00:00:00+00:00",
+        }
+
+        summary = result.data["analyticsTable"]["resultData"]["summary"]["edges"]
+
+        summary_dict = {col["node"]["alias"]: col["node"]["value"] for col in summary}
+        assert summary_dict == {
+            "last_created": "2022-02-05 00:00:00+00:00",
+            "quarter": "4",
         }

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -153,6 +153,7 @@
   
   type AnalyticsOutput {
     records(before: String = null, after: String = null, first: Int = null, last: Int = null): AnalyticsTableContentConnection
+    summary: AnalyticsRowConnection
   }
   
   type AnalyticsRowConnection {


### PR DESCRIPTION
Add a summary output to pivot tables. This gives the same aggregates,
but without grouping, thus applying the aggregates over all results.


Note: Stacks on top of #1719 and must be rebased before merge.