### PR TITLE
chore: set default auto field in settings

### DIFF
--- a/caluma/settings/django.py
+++ b/caluma/settings/django.py
@@ -75,6 +75,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 # Cache
 # https://docs.djangoproject.com/en/1.11/ref/settings/#caches
 


### PR DESCRIPTION
Django now wants to have DEFAULT_AUTO_FIELD as a setting. This doesn't
need to be configurable, so we just set it to the value it has always
been implicitly.