### PR TITLE
test: allow minio cert checks to fail if badssl.com is down

### DIFF
--- a/caluma/caluma_form/tests/test_minio.py
+++ b/caluma/caluma_form/tests/test_minio.py
@@ -1,14 +1,24 @@
 import minio.error
 import pytest
+import requests
 import urllib3
 
 from .. import storage_clients
+
+
+def is_badssl_down():
+    """Return True if badssl.com is not reachable or down."""
+    try:
+        requests.get("https://badssl.com")
+    except:  # noqa
+        return True  # pragma: no cover
 
 
 @pytest.mark.parametrize(
     "disable_cert_checks, debug",
     [(False, False), (False, True), (True, False), (True, True)],
 )
+@pytest.mark.xfail(is_badssl_down(), reason="Badssl.com unreachable")
 def test_minio_disable_cert_checks(db, settings, disable_cert_checks, debug):
     settings.MINIO_DISABLE_CERT_CHECKS = disable_cert_checks
     settings.DEBUG = debug


### PR DESCRIPTION
We should avoid having this external dependency, but for now, it
servers it's purpose (unless it's down, as of right now).

Since the test is not verifying an overly critical behaviour, we
allow it to fail if the external dependency is not available.

See https://github.com/chromium/badssl.com/issues/500