### PR TITLE
chore(schema): remove obsolete fields type definition

### DIFF
--- a/caluma/caluma_workflow/schema.py
+++ b/caluma/caluma_workflow/schema.py
@@ -318,7 +318,6 @@ class ReopenCase(Mutation):
 
     class Meta:
         serializer_class = serializers.ReopenCaseSerializer
-        fields: ["id"]
         model_operations = ["update"]
 
 


### PR DESCRIPTION
`fields: ["id"]` is type definition but was (I think) intended to be a property definition. However, since that field is already defined in the `Input` this isn't necessary.