### PR TITLE
fix(deps): lock graphql-core to 3.1.x to avoid import error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ python-memcached = "^1.59"
 requests = "^2.27.1"
 urllib3 = "^1.26.8"
 uWSGI = "^2.0.20"
+graphql-core = "~3.1.7"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
`graphene-django` uses a removed function `format_error` from
`graphql-core` but accepts the version in which it was removed as a
valid dependency. This commit makes sure we only use working versions of
`graphql-core`.

https://github.com/graphql-python/graphql-core/commit/09ff14f68bdce1e9cd71decc871fd38274b01971