### PR TITLE
feat(ordering): remove unused ordering attributes and add missing 

### DIFF
--- a/caluma/caluma_analytics/filters.py
+++ b/caluma/caluma_analytics/filters.py
@@ -1,13 +1,13 @@
-from django_filters.rest_framework import FilterSet
+from django_filters.rest_framework import FilterSet, MultipleChoiceFilter
 
-from ..caluma_core.filters import MetaFilterSet, SearchFilter, SlugMultipleChoiceFilter
+from ..caluma_core.filters import MetaFilterSet, SearchFilter
 from ..caluma_core.ordering import AttributeOrderingFactory, MetaFieldOrdering
 from . import models
 
 
 class AnalyticsTableFilterSet(MetaFilterSet):
     search = SearchFilter(fields=("slug", "name"))
-    slugs = SlugMultipleChoiceFilter(field_name="slug")
+    slugs = MultipleChoiceFilter(field_name="slug")
 
     class Meta:
         model = models.AnalyticsTable
@@ -27,7 +27,7 @@ class AnalyticsFieldFilterSet(MetaFilterSet):
             "source_field__alias",
         )
     )
-    slugs = SlugMultipleChoiceFilter(field_name="slug")
+    slugs = MultipleChoiceFilter(field_name="slug")
 
     class Meta:
         model = models.AnalyticsField
@@ -37,20 +37,23 @@ class AnalyticsFieldFilterSet(MetaFilterSet):
         )
 
 
+class AnalyticsFieldOrderSet(FilterSet):
+    meta = MetaFieldOrdering()
+    attribute = AttributeOrderingFactory(
+        models.AnalyticsField,
+        fields=["created_at", "modified_at", "alias"],
+    )
+
+    class Meta:
+        model = models.AnalyticsField
+        fields = ("meta", "attribute")
+
+
 class AnalyticsTableOrderSet(FilterSet):
     meta = MetaFieldOrdering()
     attribute = AttributeOrderingFactory(
         models.AnalyticsTable,
-        fields=[
-            "created_at",
-            "modified_at",
-            "created_by_user",
-            "created_by_group",
-            "modified_by_user",
-            "modified_by_group",
-            "slug",
-            "name",
-        ],
+        fields=["created_at", "modified_at", "slug", "name"],
     )
 
     class Meta:

--- a/caluma/caluma_analytics/schema.py
+++ b/caluma/caluma_analytics/schema.py
@@ -4,7 +4,7 @@ from graphene.types import ObjectType, generic
 
 from ..caluma_core.filters import (
     CollectionFilterSetFactory,
-    DjangoFilterSetConnectionField,
+    DjangoFilterConnectionField,
 )
 from ..caluma_core.mutation import Mutation, UserDefinedPrimaryKeyMixin
 from ..caluma_core.types import (
@@ -213,18 +213,21 @@ class Mutation:
 
 
 class Query:
-    all_analytics_tables = DjangoFilterSetConnectionField(
-        AnalyticsTable._meta.connection,
+    all_analytics_tables = DjangoFilterConnectionField(
+        AnalyticsTable,
         filterset_class=CollectionFilterSetFactory(
-            filters.AnalyticsTableFilterSet,
+            filterset_class=filters.AnalyticsTableFilterSet,
             orderset_class=filters.AnalyticsTableOrderSet,
         ),
     )
     analytics_table = graphene.Field(AnalyticsTable, slug=String(required=True))
 
-    all_analytics_fields = DjangoFilterSetConnectionField(
-        AnalyticsField._meta.connection,
-        filterset_class=CollectionFilterSetFactory(filters.AnalyticsFieldFilterSet),
+    all_analytics_fields = DjangoFilterConnectionField(
+        AnalyticsField,
+        filterset_class=CollectionFilterSetFactory(
+            filterset_class=filters.AnalyticsFieldFilterSet,
+            orderset_class=filters.AnalyticsFieldOrderSet,
+        ),
     )
 
     @staticmethod

--- a/caluma/caluma_core/filters.py
+++ b/caluma/caluma_core/filters.py
@@ -32,11 +32,7 @@ from graphene_django.forms.converter import convert_form_field
 from graphene_django.registry import get_global_registry
 from localized_fields.fields import LocalizedField
 
-from .forms import (
-    GlobalIDFormField,
-    GlobalIDMultipleChoiceField,
-    SlugMultipleChoiceField,
-)
+from .forms import GlobalIDFormField, GlobalIDMultipleChoiceField
 from .ordering import CalumaOrdering
 from .relay import extract_global_id
 from .types import DjangoConnectionField
@@ -272,16 +268,9 @@ class GlobalIDMultipleChoiceFilter(MultipleChoiceFilter):
         return super(GlobalIDMultipleChoiceFilter, self).filter(qs, gids)
 
 
-class SlugMultipleChoiceFilter(MultipleChoiceFilter):
-    field_class = SlugMultipleChoiceField
-
-    def filter(self, qs, value):
-        return super().filter(qs, value)
-
-
 class LocalizedFilter(Filter):
     def filter(self, qs, value):
-        if value in EMPTY_VALUES:
+        if value in EMPTY_VALUES:  # pragma: no cover
             return qs
 
         lang = translation.get_language()
@@ -334,7 +323,7 @@ class SearchFilter(Filter):
         return field_lookup
 
     def filter(self, qs, value):
-        if value in EMPTY_VALUES:
+        if value in EMPTY_VALUES:  # pragma: no cover
             return qs
 
         qs = qs.annotate(
@@ -405,7 +394,7 @@ class JSONValueFilter(Filter):
         super().__init__(*args, lookup_expr=lookup_expr, **kwargs)
 
     def filter(self, qs, value):
-        if value in EMPTY_VALUES:
+        if value in EMPTY_VALUES:  # pragma: no cover
             return qs
 
         for expr in value:
@@ -507,7 +496,9 @@ class DjangoFilterConnectionField(
         return clean(args)
 
 
-class DjangoFilterSetConnectionField(DjangoFilterConnectionField):
+class DjangoFilterInterfaceConnectionField(DjangoFilterConnectionField):
+    """Filter connection field for abstract interface types like Answer, Question and Task."""
+
     @property
     def model(self):
         return self.filterset_class._meta.model

--- a/caluma/caluma_core/forms.py
+++ b/caluma/caluma_core/forms.py
@@ -1,6 +1,4 @@
-from graphene import List, String
 from graphene_django import forms
-from graphene_django.forms.converter import convert_form_field
 
 
 class GlobalIDFormField(forms.GlobalIDFormField):
@@ -11,7 +9,7 @@ class GlobalIDFormField(forms.GlobalIDFormField):
     or plain primary key.
     """
 
-    def clean(self, value):
+    def clean(self, value):  # pragma: no cover
         return value
 
 
@@ -25,20 +23,3 @@ class GlobalIDMultipleChoiceField(forms.GlobalIDMultipleChoiceField):
 
     def valid_value(self, value):  # pragma: no cover
         return True
-
-
-class SlugMultipleChoiceField(GlobalIDMultipleChoiceField):
-    """
-    Slug multiple choice field which allows listing multiple slugs.
-
-    Disable cleaning as we don't know which slugs may be valid down
-    the line
-    """
-
-    def valid_value(self, value):  # pragma: no cover
-        return True
-
-
-@convert_form_field.register(SlugMultipleChoiceField)
-def slug_to_list(field):
-    return List(String, required=field.required)

--- a/caluma/caluma_core/ordering.py
+++ b/caluma/caluma_core/ordering.py
@@ -62,17 +62,11 @@ class AttributeOrderingMixin(CalumaOrdering):
         return qs, F(value)
 
 
-def AttributeOrderingFactory(model, fields=None, exclude_fields=None):
+def AttributeOrderingFactory(model, fields):
     """Build ordering field for a given model.
 
     Used to define an ordering field that is presented as an enum
     """
-    if not exclude_fields:
-        exclude_fields = []
-
-    if not fields:
-        fields = [f.name for f in model._meta.fields if f.name not in exclude_fields]
-
     field_enum = type(
         f"Sortable{model.__name__}Attributes",
         (Enum,),

--- a/caluma/caluma_form/schema.py
+++ b/caluma/caluma_form/schema.py
@@ -7,7 +7,7 @@ from graphene_django.rest_framework import serializer_converter
 from ..caluma_core.filters import (
     CollectionFilterSetFactory,
     DjangoFilterConnectionField,
-    DjangoFilterSetConnectionField,
+    DjangoFilterInterfaceConnectionField,
 )
 from ..caluma_core.mutation import Mutation, UserDefinedPrimaryKeyMixin
 from ..caluma_core.relay import extract_global_id
@@ -122,7 +122,7 @@ class Question(Node, graphene.Interface):
     forms = DjangoFilterConnectionField(
         "caluma.caluma_form.schema.Form",
         filterset_class=CollectionFilterSetFactory(
-            filters.FormFilterSet, orderset_class=filters.FormOrderSet
+            filterset_class=filters.FormFilterSet, orderset_class=filters.FormOrderSet
         ),
     )
     source = graphene.Field("caluma.caluma_form.schema.Question")
@@ -270,7 +270,8 @@ class ChoiceQuestion(QuestionQuerysetMixin, FormDjangoObjectType):
     options = DjangoFilterConnectionField(
         Option,
         filterset_class=CollectionFilterSetFactory(
-            filters.OptionFilterSet, orderset_class=filters.OptionOrderSet
+            filterset_class=filters.OptionFilterSet,
+            orderset_class=filters.OptionOrderSet,
         ),
     )
     hint_text = graphene.String()
@@ -300,7 +301,8 @@ class MultipleChoiceQuestion(QuestionQuerysetMixin, FormDjangoObjectType):
     options = DjangoFilterConnectionField(
         Option,
         filterset_class=CollectionFilterSetFactory(
-            filters.OptionFilterSet, orderset_class=filters.OptionOrderSet
+            filterset_class=filters.OptionFilterSet,
+            orderset_class=filters.OptionOrderSet,
         ),
     )
     hint_text = graphene.String()
@@ -599,8 +601,12 @@ class ActionButtonQuestion(QuestionQuerysetMixin, FormDjangoObjectType):
 
 
 class Form(FormDjangoObjectType):
-    questions = DjangoFilterSetConnectionField(
-        QuestionConnection, filterset_class=filters.QuestionFilterSet
+    questions = DjangoFilterInterfaceConnectionField(
+        QuestionConnection,
+        filterset_class=CollectionFilterSetFactory(
+            filterset_class=filters.QuestionFilterSet,
+            orderset_class=filters.QuestionOrderSet,
+        ),
     )
     meta = generic.GenericScalar()
 
@@ -863,10 +869,11 @@ class AnswerConnection(CountableConnectionBase):
 
 
 class Document(FormDjangoObjectType):
-    answers = DjangoFilterSetConnectionField(
+    answers = DjangoFilterInterfaceConnectionField(
         AnswerConnection,
         filterset_class=CollectionFilterSetFactory(
-            filters.AnswerFilterSet, orderset_class=filters.AnswerOrderSet
+            filterset_class=filters.AnswerFilterSet,
+            orderset_class=filters.AnswerOrderSet,
         ),
     )
     meta = generic.GenericScalar()
@@ -1146,25 +1153,31 @@ class Query:
     all_forms = DjangoFilterConnectionField(
         Form,
         filterset_class=CollectionFilterSetFactory(
-            filters.FormFilterSet, orderset_class=filters.FormOrderSet
+            filterset_class=filters.FormFilterSet,
+            orderset_class=filters.FormOrderSet,
         ),
     )
-    all_questions = DjangoFilterSetConnectionField(
+    all_questions = DjangoFilterInterfaceConnectionField(
         QuestionConnection,
         filterset_class=CollectionFilterSetFactory(
-            filters.QuestionFilterSet, orderset_class=filters.QuestionOrderSet
+            filterset_class=filters.QuestionFilterSet,
+            orderset_class=filters.QuestionOrderSet,
         ),
     )
     all_documents = DjangoFilterConnectionField(
         Document,
         filterset_class=CollectionFilterSetFactory(
-            filters.DocumentFilterSet, filters.DocumentOrderSet
+            filterset_class=filters.DocumentFilterSet,
+            orderset_class=filters.DocumentOrderSet,
         ),
     )
     all_format_validators = ConnectionField(FormatValidatorConnection)
     all_used_dynamic_options = DjangoFilterConnectionField(
         DynamicOption,
-        filterset_class=CollectionFilterSetFactory(filters.DynamicOptionFilterSet),
+        filterset_class=CollectionFilterSetFactory(
+            filterset_class=filters.DynamicOptionFilterSet,
+            orderset_class=filters.DynamicOptionOrderSet,
+        ),
     )
 
     document_validity = ConnectionField(

--- a/caluma/caluma_form/tests/test_form.py
+++ b/caluma/caluma_form/tests/test_form.py
@@ -36,7 +36,7 @@ def test_query_all_forms(
                 name
                 description
                 meta
-                questions(search: $question) {
+                questions(filter: [{ search: $question }]) {
                   edges {
                     node {
                       id

--- a/caluma/caluma_workflow/filters.py
+++ b/caluma/caluma_workflow/filters.py
@@ -1,5 +1,5 @@
 import graphene
-from django_filters.rest_framework import BooleanFilter
+from django_filters.rest_framework import BooleanFilter, MultipleChoiceFilter
 
 from ..caluma_core.filters import (
     BaseFilterSet,
@@ -8,7 +8,6 @@ from ..caluma_core.filters import (
     JSONValueFilter,
     MetaFilterSet,
     SearchFilter,
-    SlugMultipleChoiceFilter,
     StringListFilter,
     generate_list_filter_class,
 )
@@ -49,9 +48,9 @@ class WorkflowOrderSet(BaseFilterSet):
     attribute = AttributeOrderingFactory(
         models.Workflow,
         fields=[
+            "created_at",
+            "modified_at",
             "allow_all_forms",
-            "created_by_group",
-            "created_by_user",
             "description",
             "is_archived",
             "is_published",
@@ -73,11 +72,23 @@ class FlowFilterSet(BaseFilterSet):
         fields = ("task",)
 
 
+class FlowOrderSet(BaseFilterSet):
+    meta = MetaFieldOrdering()
+    attribute = AttributeOrderingFactory(
+        models.Flow,
+        fields=["created_at", "modified_at", "task"],
+    )
+
+    class Meta:
+        model = models.Flow
+        fields = ("meta", "attribute")
+
+
 class CaseFilterSet(MetaFilterSet):
     id = GlobalIDFilter()
 
     document_form = CharFilter(field_name="document__form_id")
-    document_forms = SlugMultipleChoiceFilter(field_name="document__form_id")
+    document_forms = MultipleChoiceFilter(field_name="document__form_id")
     has_answer = HasAnswerFilter(document_id="document__pk")
     work_item_document_has_answer = HasAnswerFilter(
         document_id="work_items__document__pk"
@@ -96,9 +107,9 @@ class CaseOrderSet(BaseFilterSet):
     attribute = AttributeOrderingFactory(
         models.Case,
         fields=[
+            "created_at",
+            "modified_at",
             "allow_all_forms",
-            "created_by_group",
-            "created_by_user",
             "description",
             "is_archived",
             "is_published",
@@ -127,11 +138,11 @@ class TaskOrderSet(BaseFilterSet):
     attribute = AttributeOrderingFactory(
         models.Task,
         fields=[
+            "created_at",
+            "modified_at",
             "allow_all_forms",
             "lead_time",
             "type",
-            "created_by_group",
-            "created_by_user",
             "description",
             "is_archived",
             "is_published",
@@ -156,7 +167,7 @@ class WorkItemFilterSet(MetaFilterSet):
     case_meta_value = JSONValueFilter(field_name="case__meta")
     root_case_meta_value = JSONValueFilter(field_name="case__family__meta")
 
-    tasks = SlugMultipleChoiceFilter(field_name="task_id")
+    tasks = MultipleChoiceFilter(field_name="task_id")
 
     has_deadline = BooleanFilter(
         field_name="deadline", lookup_expr="isnull", exclude=True
@@ -186,13 +197,11 @@ class WorkItemOrderSet(BaseFilterSet):
     attribute = AttributeOrderingFactory(
         models.WorkItem,
         fields=[
-            "allow_all_forms",
-            "created_by_group",
-            "created_by_user",
-            "description",
             "created_at",
             "modified_at",
             "closed_at",
+            "allow_all_forms",
+            "description",
             "is_archived",
             "is_published",
             "name",

--- a/caluma/caluma_workflow/schema.py
+++ b/caluma/caluma_workflow/schema.py
@@ -9,7 +9,7 @@ from graphene_django.rest_framework import serializer_converter
 from ..caluma_core.filters import (
     CollectionFilterSetFactory,
     DjangoFilterConnectionField,
-    DjangoFilterSetConnectionField,
+    DjangoFilterInterfaceConnectionField,
 )
 from ..caluma_core.mutation import Mutation, UserDefinedPrimaryKeyMixin
 from ..caluma_core.types import (
@@ -173,7 +173,11 @@ class Workflow(DjangoObjectType):
         return self.start_tasks.all()
 
     flows = DjangoFilterConnectionField(
-        Flow, filterset_class=CollectionFilterSetFactory(filters.FlowFilterSet)
+        Flow,
+        filterset_class=CollectionFilterSetFactory(
+            filterset_class=filters.FlowFilterSet,
+            orderset_class=filters.FlowOrderSet,
+        ),
     )
 
     class Meta:
@@ -202,13 +206,15 @@ class Case(DjangoObjectType):
     work_items = DjangoFilterConnectionField(
         WorkItem,
         filterset_class=CollectionFilterSetFactory(
-            filters.WorkItemFilterSet, orderset_class=filters.WorkItemOrderSet
+            filterset_class=filters.WorkItemFilterSet,
+            orderset_class=filters.WorkItemOrderSet,
         ),
     )
     family_work_items = DjangoFilterConnectionField(
         WorkItem,
         filterset_class=CollectionFilterSetFactory(
-            filters.WorkItemFilterSet, orderset_class=filters.WorkItemOrderSet
+            filterset_class=filters.WorkItemFilterSet,
+            orderset_class=filters.WorkItemOrderSet,
         ),
     )
     meta = generic.GenericScalar()
@@ -402,25 +408,29 @@ class Query(object):
     all_workflows = DjangoFilterConnectionField(
         Workflow,
         filterset_class=CollectionFilterSetFactory(
-            filters.WorkflowFilterSet, orderset_class=filters.WorkflowOrderSet
+            filterset_class=filters.WorkflowFilterSet,
+            orderset_class=filters.WorkflowOrderSet,
         ),
     )
-    all_tasks = DjangoFilterSetConnectionField(
+    all_tasks = DjangoFilterInterfaceConnectionField(
         TaskConnection,
         filterset_class=CollectionFilterSetFactory(
-            filters.TaskFilterSet, orderset_class=filters.TaskOrderSet
+            filterset_class=filters.TaskFilterSet,
+            orderset_class=filters.TaskOrderSet,
         ),
     )
     all_cases = DjangoFilterConnectionField(
         Case,
         filterset_class=CollectionFilterSetFactory(
-            filters.CaseFilterSet, orderset_class=filters.CaseOrderSet
+            filterset_class=filters.CaseFilterSet,
+            orderset_class=filters.CaseOrderSet,
         ),
     )
 
     all_work_items = DjangoFilterConnectionField(
         WorkItem,
         filterset_class=CollectionFilterSetFactory(
-            filters.WorkItemFilterSet, orderset_class=filters.WorkItemOrderSet
+            filterset_class=filters.WorkItemFilterSet,
+            orderset_class=filters.WorkItemOrderSet,
         ),
     )

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -120,6 +120,12 @@
     invert: Boolean
   }
   
+  input AnalyticsFieldOrderSetType {
+    meta: String
+    attribute: SortableAnalyticsFieldAttributes
+    direction: AscDesc
+  }
+  
   type AnalyticsOutput {
     records(before: String = null, after: String = null, first: Int = null, last: Int = null): AnalyticsTableContentConnection
     summary: AnalyticsRowConnection
@@ -1036,6 +1042,12 @@
     invert: Boolean
   }
   
+  input DynamicOptionOrderSetType {
+    meta: String
+    attribute: SortableDynamicOptionAttributes
+    direction: AscDesc
+  }
+  
   interface DynamicQuestion {
     options(before: String = null, after: String = null, first: Int = null, last: Int = null): DataSourceDataConnection
     dataSource: String!
@@ -1198,6 +1210,12 @@
   """
   scalar FlowJexl
   
+  input FlowOrderSetType {
+    meta: String
+    attribute: SortableFlowAttributes
+    direction: AscDesc
+  }
+  
   type Form implements Node {
     createdAt: DateTime!
     modifiedAt: DateTime!
@@ -1211,34 +1229,7 @@
     meta: GenericScalar
     isPublished: Boolean!
     isArchived: Boolean!
-    questions(
-      offset: Int = null
-      before: String = null
-      after: String = null
-      first: Int = null
-      last: Int = null
-      label: String = null
-      isRequired: String = null
-      isHidden: String = null
-      isArchived: Boolean = null
-      subForm: ID = null
-      rowForm: ID = null
-      createdByUser: String = null
-      createdByGroup: String = null
-      modifiedByUser: String = null
-      modifiedByGroup: String = null
-  
-      """Only return entries created before the given DateTime (exclusive)"""
-      createdBefore: DateTime = null
-  
-      """Only return entries created at or after the given DateTime (inclusive)"""
-      createdAfter: DateTime = null
-      metaHasKey: String = null
-      metaValue: [JSONValueFilterType] = null
-      excludeForms: [ID] = null
-      search: String = null
-      slugs: [String] = null
-    ): QuestionConnection
+    questions(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [QuestionFilterSetType] = null, order: [QuestionOrderSetType] = null): QuestionConnection
   
     """Reference this form has been copied from"""
     source: Form
@@ -1859,7 +1850,7 @@
     documentAsOf(id: ID!, asOf: DateTime!): HistoricalDocument
     allAnalyticsTables(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [AnalyticsTableFilterSetType] = null, order: [AnalyticsTableOrderSetType] = null): AnalyticsTableConnection
     analyticsTable(slug: String!): AnalyticsTable
-    allAnalyticsFields(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [AnalyticsFieldFilterSetType] = null): AnalyticsFieldConnection
+    allAnalyticsFields(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [AnalyticsFieldFilterSetType] = null, order: [AnalyticsFieldOrderSetType] = null): AnalyticsFieldConnection
     allDataSources(before: String = null, after: String = null, first: Int = null, last: Int = null): DataSourceConnection
     dataSource(name: String!, before: String = null, after: String = null, first: Int = null, last: Int = null): DataSourceDataConnection
     allWorkflows(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [WorkflowFilterSetType] = null, order: [WorkflowOrderSetType] = null): WorkflowConnection
@@ -1870,7 +1861,7 @@
     allQuestions(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [QuestionFilterSetType] = null, order: [QuestionOrderSetType] = null): QuestionConnection
     allDocuments(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [DocumentFilterSetType] = null, order: [DocumentOrderSetType] = null): DocumentConnection
     allFormatValidators(before: String = null, after: String = null, first: Int = null, last: Int = null): FormatValidatorConnection
-    allUsedDynamicOptions(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [DynamicOptionFilterSetType] = null): DynamicOptionConnection
+    allUsedDynamicOptions(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [DynamicOptionFilterSetType] = null, order: [DynamicOptionOrderSetType] = null): DynamicOptionConnection
     documentValidity(id: ID!, before: String = null, after: String = null, first: Int = null, last: Int = null): DocumentValidityConnection
     node(
       """The ID of the object"""
@@ -2872,13 +2863,15 @@
     clientMutationId: String
   }
   
+  enum SortableAnalyticsFieldAttributes {
+    CREATED_AT
+    MODIFIED_AT
+    ALIAS
+  }
+  
   enum SortableAnalyticsTableAttributes {
     CREATED_AT
     MODIFIED_AT
-    CREATED_BY_USER
-    CREATED_BY_GROUP
-    MODIFIED_BY_USER
-    MODIFIED_BY_GROUP
     SLUG
     NAME
   }
@@ -2886,21 +2879,15 @@
   enum SortableAnswerAttributes {
     CREATED_AT
     MODIFIED_AT
-    CREATED_BY_USER
-    CREATED_BY_GROUP
-    MODIFIED_BY_USER
-    MODIFIED_BY_GROUP
     QUESTION
     VALUE
-    DOCUMENT
     DATE
-    FILE
   }
   
   enum SortableCaseAttributes {
+    CREATED_AT
+    MODIFIED_AT
     ALLOW_ALL_FORMS
-    CREATED_BY_GROUP
-    CREATED_BY_USER
     DESCRIPTION
     IS_ARCHIVED
     IS_PUBLISHED
@@ -2912,21 +2899,26 @@
   enum SortableDocumentAttributes {
     CREATED_AT
     MODIFIED_AT
-    CREATED_BY_USER
-    CREATED_BY_GROUP
-    MODIFIED_BY_USER
-    MODIFIED_BY_GROUP
     FORM
-    SOURCE
+  }
+  
+  enum SortableDynamicOptionAttributes {
+    CREATED_AT
+    MODIFIED_AT
+    SLUG
+    LABEL
+    QUESTION
+  }
+  
+  enum SortableFlowAttributes {
+    CREATED_AT
+    MODIFIED_AT
+    TASK
   }
   
   enum SortableFormAttributes {
     CREATED_AT
     MODIFIED_AT
-    CREATED_BY_USER
-    CREATED_BY_GROUP
-    MODIFIED_BY_USER
-    MODIFIED_BY_GROUP
     SLUG
     NAME
     DESCRIPTION
@@ -2937,10 +2929,6 @@
   enum SortableOptionAttributes {
     CREATED_AT
     MODIFIED_AT
-    CREATED_BY_USER
-    CREATED_BY_GROUP
-    MODIFIED_BY_USER
-    MODIFIED_BY_GROUP
     SLUG
     LABEL
     IS_ARCHIVED
@@ -2949,10 +2937,6 @@
   enum SortableQuestionAttributes {
     CREATED_AT
     MODIFIED_AT
-    CREATED_BY_USER
-    CREATED_BY_GROUP
-    MODIFIED_BY_USER
-    MODIFIED_BY_GROUP
     SLUG
     LABEL
     TYPE
@@ -2966,11 +2950,11 @@
   }
   
   enum SortableTaskAttributes {
+    CREATED_AT
+    MODIFIED_AT
     ALLOW_ALL_FORMS
     LEAD_TIME
     TYPE
-    CREATED_BY_GROUP
-    CREATED_BY_USER
     DESCRIPTION
     IS_ARCHIVED
     IS_PUBLISHED
@@ -2979,13 +2963,11 @@
   }
   
   enum SortableWorkItemAttributes {
-    ALLOW_ALL_FORMS
-    CREATED_BY_GROUP
-    CREATED_BY_USER
-    DESCRIPTION
     CREATED_AT
     MODIFIED_AT
     CLOSED_AT
+    ALLOW_ALL_FORMS
+    DESCRIPTION
     IS_ARCHIVED
     IS_PUBLISHED
     NAME
@@ -2995,9 +2977,9 @@
   }
   
   enum SortableWorkflowAttributes {
+    CREATED_AT
+    MODIFIED_AT
     ALLOW_ALL_FORMS
-    CREATED_BY_GROUP
-    CREATED_BY_USER
     DESCRIPTION
     IS_ARCHIVED
     IS_PUBLISHED
@@ -3442,7 +3424,7 @@
   
     """List of tasks referenced in workflow"""
     tasks: [Task]!
-    flows(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [FlowFilterSetType] = null): FlowConnection
+    flows(offset: Int = null, before: String = null, after: String = null, first: Int = null, last: Int = null, filter: [FlowFilterSetType] = null, order: [FlowOrderSetType] = null): FlowConnection
   }
   
   type WorkflowConnection {


### PR DESCRIPTION
BREAKING CHANGE: This removes various orderings that do not make sense
and were not used:

- On all connections:
  - `created_by_user`
  - `created_by_group`
  - `modified_by_user`
  - `modified_by_group`
- `Answer`
  - `document`
  - `file`
- `Document`
  - `source`

The following ordering attributes were added because they make sense:

- `Case`
  - `created_at`
  - `modified_at`
- `Flow`
  - `created_at`
  - `modified_at`
- `Task`
  - `created_at`
  - `modified_at`
- `Workflow`
  - `created_at`
  - `modified_at`
- `AnalyticsField`
  - `created_at`
  - `modified_at`
  - `alias`
- `DynamicOption`
  - `created_at`
  - `modified_at`
  - `slug`
  - `label`
  - `question`
- `Flow`
  - `created_at`
  - `modified_at`
  - `task`