### PR TITLE
test(analytics): fix flaky test using creation date

### DIFF
--- a/caluma/caluma_analytics/tests/test_starting_objects.py
+++ b/caluma/caluma_analytics/tests/test_starting_objects.py
@@ -25,6 +25,7 @@ def test_get_fields(
     snapshot.assert_match(field_info_dict)
 
 
+@pytest.mark.freeze_time("2022-04-01")
 @pytest.mark.parametrize(
     "analytics_table__starting_object, fields",
     [


### PR DESCRIPTION
This test checks the month of a creation date which just changed some days ago. By freezing the date for the test this won't be an issue in the future.