### PR TITLE
fix(build): conftest should be in generated package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ classifiers = [
 ]
 include = ["CHANGELOG.md"]
 exclude = [
-    "caluma/conftest.py",
-    "caluma/**/conftest.py",
     "caluma/**/tests",
 ]
 


### PR DESCRIPTION
When an application uses Caluma as a Django package, it is often very
beneficial to be able to reuse Caluma's fixtures. In fact, we do have
projects that do depend on Caluma's conftest. So, this should be built
into the package.