### PR TITLE
fix(workflow): remove and fix ordering keys

### DIFF
--- a/caluma/caluma_workflow/filters.py
+++ b/caluma/caluma_workflow/filters.py
@@ -109,13 +109,8 @@ class CaseOrderSet(BaseFilterSet):
         fields=[
             "created_at",
             "modified_at",
-            "allow_all_forms",
-            "description",
-            "is_archived",
-            "is_published",
-            "name",
             "status",
-            "slug",
+            "document__form__name",
         ],
     )
     document_answer = AnswerValueOrdering(document_via="document")
@@ -140,12 +135,10 @@ class TaskOrderSet(BaseFilterSet):
         fields=[
             "created_at",
             "modified_at",
-            "allow_all_forms",
             "lead_time",
             "type",
             "description",
             "is_archived",
-            "is_published",
             "name",
             "slug",
         ],
@@ -200,10 +193,7 @@ class WorkItemOrderSet(BaseFilterSet):
             "created_at",
             "modified_at",
             "closed_at",
-            "allow_all_forms",
             "description",
-            "is_archived",
-            "is_published",
             "name",
             "deadline",
             "status",

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -2887,13 +2887,8 @@
   enum SortableCaseAttributes {
     CREATED_AT
     MODIFIED_AT
-    ALLOW_ALL_FORMS
-    DESCRIPTION
-    IS_ARCHIVED
-    IS_PUBLISHED
-    NAME
     STATUS
-    SLUG
+    DOCUMENT__FORM__NAME
   }
   
   enum SortableDocumentAttributes {
@@ -2952,12 +2947,10 @@
   enum SortableTaskAttributes {
     CREATED_AT
     MODIFIED_AT
-    ALLOW_ALL_FORMS
     LEAD_TIME
     TYPE
     DESCRIPTION
     IS_ARCHIVED
-    IS_PUBLISHED
     NAME
     SLUG
   }
@@ -2966,10 +2959,7 @@
     CREATED_AT
     MODIFIED_AT
     CLOSED_AT
-    ALLOW_ALL_FORMS
     DESCRIPTION
-    IS_ARCHIVED
-    IS_PUBLISHED
     NAME
     DEADLINE
     STATUS


### PR DESCRIPTION
remove non exsisting ordering keys for work item and
task, fix relational ordering keys for case and work item

removes allow_all_forms and is_published from work item and task
rename is_archived on work item to task__is_archived
append workflow__ to keys on case which are from workflow relation