### PR TITLE
fix(log): minio stat errors shouldn't be errors

### DIFF
--- a/caluma/caluma_form/storage_clients.py
+++ b/caluma/caluma_form/storage_clients.py
@@ -32,7 +32,7 @@ def _retry_on_missing_bucket(fn):
                 and settings.MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET
             ):
                 log.warning(
-                    b"Minio bucket '{self.bucket}' missing, trying to create it"
+                    f"Minio bucket '{self.bucket}' missing, trying to create it"
                 )
                 self.client.make_bucket(self.bucket)
                 return fn(self, *args, **kwargs)
@@ -81,7 +81,7 @@ class Minio:
         try:
             return self.client.stat_object(self.bucket, object_name)
         except S3Error as exc:
-            log.error(f"Minio error, cannot stat object: {exc.code}")
+            log.warning(f"Minio error, cannot stat object '{object_name}': {exc.code}")
             return None
 
     @_retry_on_missing_bucket

--- a/caluma/caluma_form/tests/test_minio.py
+++ b/caluma/caluma_form/tests/test_minio.py
@@ -101,4 +101,6 @@ def test_minio_handle_exceptions(exc_code, caplog, mocker):
     client = storage_clients.Minio()
     stat = client.stat_object("test_object")
     assert stat is None
-    assert caplog.messages == [f"Minio error, cannot stat object: {exc_code}"]
+    assert caplog.messages == [
+        f"Minio error, cannot stat object 'test_object': {exc_code}"
+    ]


### PR DESCRIPTION
When an object in Minio cannot be `stat`ed, this should not be logged
as an error: It may be quite a normal result, for example if a file has
not been uploaded yet, and Caluma for some reason wants to check it.
Therefore, degrading the log message from "error" to "warning".

Also, for debugging reasons, we're adding the object name to the
log message: Without it, we're getting errors in the log and have no
chance of figuring out why it happened.