### PR TITLE
fix(analytics): provide more correct supported functions in analytics

### DIFF
--- a/caluma/caluma_analytics/simple_table.py
+++ b/caluma/caluma_analytics/simple_table.py
@@ -233,9 +233,23 @@ class AttributeField(BaseField):
         return not self.is_date
 
     def is_value(self):
-        return True
+        # meta fields cannot be a value - they *contain* values
+        return self.identifier != "meta"
 
     def supported_functions(self):
+        if not self.is_value:  # pragma: no cover
+            # Non-value fields cannot have functions applied to them.
+            # This mainly applies to "meta" fields in this context
+            return []
+        elif self.identifier == "id":
+            # Identifiers cannot have aggregate functions applied in a
+            # meaningful manner, except counts. Potentially, we *could"
+            # imagine some string functions being useful for slug identifiers,
+            # but we'll keep it simple for now
+            return [
+                models.AnalyticsField.FUNCTION_COUNT.upper(),
+                models.AnalyticsField.FUNCTION_VALUE.upper(),
+            ]
         return [
             models.AnalyticsField.FUNCTION_VALUE.upper(),
             models.AnalyticsField.FUNCTION_MAX.upper(),

--- a/caluma/caluma_analytics/tests/__snapshots__/test_starting_objects.ambr
+++ b/caluma/caluma_analytics/tests/__snapshots__/test_starting_objects.ambr
@@ -337,9 +337,8 @@
       'is_leaf': True,
       'is_value': True,
       'supported_functions': list([
+        'COUNT',
         'VALUE',
-        'MAX',
-        'MIN',
       ]),
     }),
     'meta': dict({
@@ -5847,9 +5846,8 @@
       'is_leaf': True,
       'is_value': True,
       'supported_functions': list([
+        'COUNT',
         'VALUE',
-        'MAX',
-        'MIN',
       ]),
     }),
     'meta': dict({
@@ -6042,9 +6040,8 @@
       'is_leaf': True,
       'is_value': True,
       'supported_functions': list([
+        'COUNT',
         'VALUE',
-        'MAX',
-        'MIN',
       ]),
     }),
     'meta': dict({


### PR DESCRIPTION
Identifier fields cannot be sorted or have string functions applied to them in a
meaningful manner - nobody should require the "max" of an UUID for example.

Also, Meta fields (not their contents!) cannot have any useful aggregate
function applied to them either