### PR TITLE
Redo work item / reopen case improvements

### DIFF
--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -180,8 +180,16 @@ class CompleteWorkItemLogic:
             )
 
             if all_siblings_complete:
+                redo_work_items = work_item.case.work_items.filter(
+                    task__in=next_tasks, status=models.WorkItem.STATUS_REDO
+                )
+
                 created_work_items = utils.create_work_items(
-                    next_tasks, case, user, work_item, context
+                    next_tasks.exclude(pk__in=redo_work_items.values("task")),
+                    case,
+                    user,
+                    work_item,
+                    context,
                 )
 
                 for created_work_item in created_work_items:  # pragma: no cover
@@ -192,6 +200,8 @@ class CompleteWorkItemLogic:
                         user=user,
                         context=context,
                     )
+
+                redo_work_items.update(status=models.WorkItem.STATUS_READY)
 
         if (
             not next_tasks.exists()

--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -612,13 +612,18 @@ class RedoWorkItemLogic:
         if work_item.status == models.WorkItem.STATUS_READY:
             raise ValidationError("Ready work items can't be redone.")
 
+        if not cls.is_work_item_redoable(work_item):
+            raise ValidationError("Workflow doesn't allow to redo this work item.")
+
+    @classmethod
+    def is_work_item_redoable(cls, work_item):
         for wi in cls._find_ready_in_work_item_tree(
             work_item, allowed_states=[models.WorkItem.STATUS_READY]
         ):
             if work_item.task in wi.get_redoable():
-                return
+                return True
 
-        raise ValidationError("Workflow doesn't allow to redo this work item.")
+        return False
 
     @classmethod
     def set_succeeding_work_item_status_redo(cls, work_item):

--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -379,8 +379,13 @@ class ReopenCaseLogic:
         ]:
             raise ValidationError("Only completed and canceled cases can be reopened.")
 
-        if not case.family == case:
-            raise ValidationError("Child cases can not be reopened.")
+        if (
+            case.family != case
+            and case.parent_work_item.status != models.WorkItem.STATUS_READY
+        ):
+            raise ValidationError(
+                "Only child cases of ready work items can be reopened."
+            )
 
         for work_item in work_items:
             if work_item.succeeding_work_items.exclude(

--- a/caluma/caluma_workflow/tests/__snapshots__/test_workflow.ambr
+++ b/caluma/caluma_workflow/tests/__snapshots__/test_workflow.ambr
@@ -72,6 +72,40 @@
     }),
   })
 # ---
+# name: test_add_workflow_flow[task-slug-[]|tasks-"task-slug"|task-True]
+  dict({
+    'addWorkflowFlow': dict({
+      'clientMutationId': None,
+      'workflow': dict({
+        'flows': dict({
+          'edges': list([
+            dict({
+              'node': dict({
+                'createdByGroup': 'admin',
+                'createdByUser': 'admin',
+                'next': '[]|tasks',
+                'tasks': list([
+                  dict({
+                    'slug': 'task-slug',
+                  }),
+                ]),
+              }),
+            }),
+          ]),
+          'totalCount': 1,
+        }),
+        'tasks': list([
+          dict({
+            'slug': 'season-fish-share',
+          }),
+          dict({
+            'slug': 'song-light',
+          }),
+        ]),
+      }),
+    }),
+  })
+# ---
 # name: test_query_all_workflows
   dict({
     'allWorkflows': dict({

--- a/caluma/caluma_workflow/tests/test_work_item.py
+++ b/caluma/caluma_workflow/tests/test_work_item.py
@@ -1640,6 +1640,16 @@ def test_redo_work_item(
     assert case.work_items.get(task=tasks[3]).status == models.WorkItem.STATUS_REDO
     assert case.work_items.get(task=tasks[4]).status == models.WorkItem.STATUS_REDO
 
+    api.complete_work_item(
+        work_item=case.work_items.get(task=tasks[0]), user=admin_user
+    )
+
+    assert case.work_items.get(task=tasks[0]).status == models.WorkItem.STATUS_COMPLETED
+    assert case.work_items.get(task=tasks[1]).status == models.WorkItem.STATUS_READY
+    assert case.work_items.get(task=tasks[2]).status == models.WorkItem.STATUS_READY
+    assert case.work_items.get(task=tasks[3]).status == models.WorkItem.STATUS_REDO
+    assert case.work_items.get(task=tasks[4]).status == models.WorkItem.STATUS_REDO
+
 
 @pytest.mark.parametrize("use_graphql", [False, True])
 def test_redo_work_item_not_redoable(

--- a/caluma/caluma_workflow/tests/test_work_item.py
+++ b/caluma/caluma_workflow/tests/test_work_item.py
@@ -946,6 +946,57 @@ def test_filter_document_has_answer(
         assert node_id == str(expected.id)
 
 
+def test_is_redoable(
+    db,
+    schema_executor,
+    work_item_factory,
+    task_flow_factory,
+    case,
+):
+    redoable_work_item = work_item_factory(
+        case=case, status=models.WorkItem.STATUS_COMPLETED
+    )
+    ready_redoable_work_item = work_item_factory(
+        case=case, status=models.WorkItem.STATUS_READY
+    )
+    non_redoable_work_item = work_item_factory(
+        case=case,
+        previous_work_item=redoable_work_item,
+        status=models.WorkItem.STATUS_READY,
+    )
+    task_flow_factory(
+        workflow=case.workflow,
+        task=non_redoable_work_item.task,
+        redoable=f"['{redoable_work_item.task.slug}', '{ready_redoable_work_item}']|tasks",
+    )
+
+    result = schema_executor(
+        """
+        query {
+            allWorkItems {
+                edges {
+                    node {
+                        id
+                        isRedoable
+                    }
+                }
+            }
+        }
+    """
+    )
+
+    assert not result.errors
+
+    is_redoable = {
+        extract_global_id(work_item["node"]["id"]): work_item["node"]["isRedoable"]
+        for work_item in result.data["allWorkItems"]["edges"]
+    }
+
+    assert is_redoable[str(redoable_work_item.pk)]
+    assert not is_redoable[str(ready_redoable_work_item.pk)]
+    assert not is_redoable[str(non_redoable_work_item.pk)]
+
+
 @pytest.mark.parametrize(
     "lookup_expr,int,value,len_results",
     [

--- a/caluma/caluma_workflow/tests/test_workflow.py
+++ b/caluma/caluma_workflow/tests/test_workflow.py
@@ -105,9 +105,11 @@ def test_save_workflow(
     [
         ("task-slug", '"task-slug"|task', None, True),
         ("task-slug", '"task-slug"|task', '"task-slug"|task', True),
+        ("task-slug", "[]|tasks", '"task-slug"|task', True),
         ("task-slug", '"not-a-task-slug"|task', None, False),
         ("task-slug", '["not-a-task-slug"]|tasks', None, False),
         ("task-slug", '"not-a-task-slug"|invalid', None, False),
+        ("task-slug", "[]|tasks", None, False),
         ("task-slug", '""', None, False),
     ],
 )

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -3333,6 +3333,11 @@
     document: Document
     previousWorkItem: WorkItem
     succeedingWorkItems(offset: Int, before: String, after: String, first: Int, last: Int): WorkItemConnection!
+  
+    """
+    This property potentially performs poorly if used in a large setof entries, as the evaluation of the redoable jexl configurationcannot be performed on the database level. Please use carefully.
+    """
+    isRedoable: Boolean
   }
   
   type WorkItemConnection {


### PR DESCRIPTION
- Add `is_redoable` property to work item schema
- Allow empty `next` on flows if `redoable` is given
- Allow reopening child cases if the parent work item is ready
- Don't create a new work item after completing a redone work item if there are succeeding work items in status redo