### PR TITLE
fix(form): fix migration problem with historicalanswer

### DIFF
--- a/caluma/caluma_form/historical_schema.py
+++ b/caluma/caluma_form/historical_schema.py
@@ -125,7 +125,9 @@ class HistoricalFilesAnswer(FilesAnswer):
 
     def resolve_value(self, info, as_of, **args):
         # we need to use the HistoricalFile of the correct revision
-        return models.File.history.filter(answer_id=self.id, history_date__lte=as_of)
+        return historical_qs_as_of(models.File.history, as_of, pk_attr="id").filter(
+            answer_id=self.id
+        )
 
     class Meta:
         model = models.Answer.history.model

--- a/caluma/caluma_form/tests/test_migrate_to_multiple_files.py
+++ b/caluma/caluma_form/tests/test_migrate_to_multiple_files.py
@@ -1,5 +1,6 @@
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
+from django.utils import timezone
 
 
 def migrate_and_get_apps(state):
@@ -22,6 +23,7 @@ def test_migrate_to_multiple_files(transactional_db):
     Document = old_apps.get_model(app, "Document")
     Form = old_apps.get_model(app, "Form")
     Answer = old_apps.get_model(app, "Answer")
+    HistoricalAnswer = old_apps.get_model(app, "HistoricalAnswer")
     File = old_apps.get_model(app, "File")
     Question = old_apps.get_model(app, "Question")
     FormQuestion = old_apps.get_model(app, "FormQuestion")
@@ -36,6 +38,14 @@ def test_migrate_to_multiple_files(transactional_db):
     the_file = File.objects.create(name="foo.txt")
     file_ans = Answer.objects.create(
         question=file_question, document=doc, file=the_file
+    )
+    HistoricalAnswer.objects.create(
+        history_date=timezone.now(),
+        created_at=timezone.now(),
+        modified_at=timezone.now(),
+        question=file_question,
+        document=doc,
+        file=the_file,
     )
 
     new_apps = migrate_and_get_apps(migrate_to)


### PR DESCRIPTION
We cannot handle historical answers and "current" answers the same way
when migrating their files: Historical answer's files need to be fetched
from history as well, and their history needs to be updated also.

When fetching the historical files of an answer, we need to fetch
exactly the files that were there at the given date/time, not all that
have ever been created (but may have been deleted in the mean time)


This supersedes #1839 