### PR TITLE
Fix analytics sql generation

### DIFF
--- a/caluma/caluma_analytics/schema.py
+++ b/caluma/caluma_analytics/schema.py
@@ -89,12 +89,14 @@ class AnalyticsOutput(ObjectType):
     @staticmethod
     def resolve_summary(table, info, *args, **kwargs):
         summary_row = table.get_summary()
-        return AnalyticsRow(
-            edges=[
-                {"node": {"alias": alias, "value": summary_row[alias]}}
-                for alias in table.field_ordering
-            ]
-        )
+        if summary_row:
+            return AnalyticsRow(
+                edges=[
+                    {"node": {"alias": alias, "value": summary_row[alias]}}
+                    for alias in table.field_ordering
+                ]
+            )
+        return AnalyticsRow(edges=[])
 
 
 StartingObject = enum_type_from_field(

--- a/caluma/caluma_analytics/tests/__snapshots__/test_simple_table.ambr
+++ b/caluma/caluma_analytics/tests/__snapshots__/test_simple_table.ambr
@@ -120,6 +120,10 @@
             }),
           ]),
         }),
+        'summary': dict({
+          'edges': list([
+          ]),
+        }),
       }),
     }),
   })
@@ -129,6 +133,10 @@
     'analyticsTable': dict({
       'resultData': dict({
         'records': dict({
+          'edges': list([
+          ]),
+        }),
+        'summary': dict({
           'edges': list([
           ]),
         }),

--- a/caluma/caluma_analytics/tests/test_simple_table.py
+++ b/caluma/caluma_analytics/tests/test_simple_table.py
@@ -42,22 +42,30 @@ def test_run_analytics_gql(
     query = """
         query run ($input: String!) {
           analyticsTable(slug: $input) {
-              resultData {
-                records {
-                  edges {
-                    node {
-                      edges {
-                        node {
-                          alias
-                          value
-                        }
+            resultData {
+              records {
+                edges {
+                  node {
+                    edges {
+                      node {
+                        alias
+                        value
                       }
                     }
                   }
                 }
-             }
+              }
+              summary {
+                edges {
+                  node {
+                    alias
+                    value
+                  }
+                }
+              }
+            }
           }
-       }
+        }
     """
 
     example_analytics.fields.filter(alias="from_the_doc").delete()


### PR DESCRIPTION
Analytics uses generated SQL from the visibility layer of the application. However, only the part after the WHERE is actually used. Now if a visibility layer adds expressions that affect the FROM bit of an SQL statement, and these expressions contain query parameters, we have too many parameters in for the remaining SQL fragment.

Those parameters need to be discarded, as we don't use the SQL that came along with them.

Then, as a drive-by fix: It doesn't make sense to extract a summary row for simple tables - there is nothing to summarize in a meaningful way. Fixe a crash where the frontend would request a summary nonetheless.
