### PR TITLE
feat: allow using client id as user for client-secret auth

### DIFF
--- a/caluma/caluma_user/models.py
+++ b/caluma/caluma_user/models.py
@@ -24,7 +24,16 @@ class OIDCUser(BaseUser):
         super().__init__()
 
         self.claims, self.claims_source = self._get_claims(userinfo, introspection)
-        self.username = self.claims[settings.OIDC_USERNAME_CLAIM]
+
+        if (
+            self.claims_source == "introspection"
+            and settings.OIDC_CLIENT_AS_USERNAME
+            and settings.OIDC_USERNAME_CLAIM not in self.claims
+        ):
+            self.username = self.claims[settings.OIDC_CLIENT_CLAIM]
+        else:
+            self.username = self.claims[settings.OIDC_USERNAME_CLAIM]
+
         self.groups = self.claims.get(settings.OIDC_GROUPS_CLAIM)
         self.group = self.groups[0] if self.groups else None
         self.token = token

--- a/caluma/settings/caluma.py
+++ b/caluma/settings/caluma.py
@@ -58,6 +58,12 @@ OIDC_USERINFO_ENDPOINT = env.str("OIDC_USERINFO_ENDPOINT", default=None)
 OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
 OIDC_GROUPS_CLAIM = env.str("OIDC_GROUPS_CLAIM", default="caluma_groups")
 OIDC_USERNAME_CLAIM = env.str("OIDC_USERNAME_CLAIM", default="sub")
+# Claim to use for the "client" claim. Should normally be left to the default value
+OIDC_CLIENT_CLAIM = env.str("OIDC_CLIENT_CLAIM", default="client_id")
+
+# When service clients are used, should we pretend they're users?
+OIDC_CLIENT_AS_USERNAME = env.bool("OIDC_CLIENT_AS_USERNAME", default=False)
+
 OIDC_BEARER_TOKEN_REVALIDATION_TIME = env.int(
     "OIDC_BEARER_TOKEN_REVALIDATION_TIME", default=0
 )


### PR DESCRIPTION
When authentication happens with a "service user" instead of a regular user, we may not get a username. However, we can now configure Caluma to use the client ID as username instead.

This is optional to ensure that the behaviour is intended, and no "wrong" fallback happens in case the username claim was just configured incorrectly.