### PR TITLE
fix: do not crash when django-extensions is missing

### DIFF
--- a/caluma/settings/django.py
+++ b/caluma/settings/django.py
@@ -33,7 +33,14 @@ INSTALLED_APPS = [
 ]
 
 if DEBUG:
-    INSTALLED_APPS.append("django_extensions")
+    try:
+        __import__("django_extensions")
+        INSTALLED_APPS.append("django_extensions")
+    except ImportError:  # pragma: no cover
+        # Nothing bad, just won't have django-extensions
+        # niceties installed (Most likely Caluma was built)
+        # without dev dependencies
+        pass
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
When enabling dev mode, we should not rely on all the dev dependencies being installed. Instead, try to see if `django-extensions` is even installed, and only add it to the `INSTALLED_APPS` list if it is.

Fixes #1932 