### PR TITLE
fix: fix calc answer evaluation when adding new table rows

### DIFF
--- a/caluma/caluma_analytics/tests/test_migrate_form_slugs.py
+++ b/caluma/caluma_analytics/tests/test_migrate_form_slugs.py
@@ -5,7 +5,7 @@ from django.db.migrations.executor import MigrationExecutor
 from caluma.caluma_analytics import simple_table
 
 
-def test_migrate_rename_form_slugs(transactional_db):
+def test_migrate_rename_form_slugs(post_migrate_to_current_state):
     executor = MigrationExecutor(connection)
     migrate_from = [
         ("caluma_analytics", "0005_analytics_field_ordering"),

--- a/caluma/caluma_form/migrations/0047_recalculate_calc_answers.py
+++ b/caluma/caluma_form/migrations/0047_recalculate_calc_answers.py
@@ -1,0 +1,54 @@
+from django.db import migrations
+
+from caluma.caluma_form.jexl import QuestionJexl
+from caluma.caluma_form.structure import FieldSet
+
+
+def recalculate_answer(answer):
+    """
+    Recalculate a single calc-answer.
+
+    This is more or less a copy/paste from `_update_or_create_calc_answer` in order to
+    use the old models.
+    """
+    root_doc = answer.document.family
+
+    struc = FieldSet(root_doc, root_doc.form)
+    field = struc.get_field(answer.question.slug)
+
+    # skip if question doesn't exist in this document structure
+    if field is None:  # pragma: no cover
+        return
+
+    jexl = QuestionJexl(
+        {"form": field.form, "document": field.document, "structure": field.parent()}
+    )
+
+    # Ignore errors because we might evaluate partially built forms. So we might be
+    # missing some answers or the expression might be invalid, in which case we return
+    # None
+    value = jexl.evaluate(field.question.calc_expression, raise_on_error=False)
+
+    answer.value = value
+    answer.save()
+
+
+def recalculate_all_answers(apps, _):
+    AnswerModel = apps.get_model("caluma_form.Answer")
+
+    calc_answers = AnswerModel.objects.filter(
+        question__type="calculated_float", document__isnull=False
+    )
+    for answer in calc_answers.iterator():
+        recalculate_answer(answer)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("caluma_form", "0046_file_answer_reverse_keys"),
+    ]
+
+    operations = [
+        migrations.RunPython(recalculate_all_answers, migrations.RunPython.noop),
+    ]

--- a/caluma/caluma_form/signals.py
+++ b/caluma/caluma_form/signals.py
@@ -187,12 +187,12 @@ def update_calc_from_answer(sender, instance, **kwargs):
 
 @receiver(post_save, sender=models.Document)
 @disable_raw
-@filter_events(lambda created: created)
+# We're only interested in table row forms
+@filter_events(lambda instance, created: instance.pk != instance.family_id or created)
 def update_calc_from_document(sender, instance, created, **kwargs):
-
-    for question in instance.form.questions.filter(
-        type=models.Question.TYPE_CALCULATED_FLOAT
-    ):
+    for question in models.Form.get_all_questions(
+        [(instance.family or instance).form_id]
+    ).filter(type=models.Question.TYPE_CALCULATED_FLOAT):
         _update_or_create_calc_answer(question, instance)
 
 

--- a/caluma/caluma_form/tests/__snapshots__/test_filter_by_answer.ambr
+++ b/caluma/caluma_form/tests/__snapshots__/test_filter_by_answer.ambr
@@ -71,7 +71,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -118,7 +118,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -281,7 +281,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -368,7 +368,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -454,7 +454,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -615,7 +615,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -662,7 +662,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -1056,7 +1056,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -1248,7 +1248,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -1404,7 +1404,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -1969,7 +1969,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -2016,7 +2016,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -2179,7 +2179,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -2266,7 +2266,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -2352,7 +2352,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -2513,7 +2513,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -2560,7 +2560,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -3846,7 +3846,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -3893,7 +3893,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -4056,7 +4056,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -4143,7 +4143,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -4229,7 +4229,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -4390,7 +4390,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -4437,7 +4437,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -4833,7 +4833,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -4880,7 +4880,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -5043,7 +5043,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -5130,7 +5130,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -5216,7 +5216,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -5377,7 +5377,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -5424,7 +5424,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -5785,7 +5785,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -5834,7 +5834,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -6000,7 +6000,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -6209,7 +6209,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -6779,7 +6779,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -6826,7 +6826,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -6947,7 +6947,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -7033,7 +7033,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -7193,7 +7193,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -7746,7 +7746,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -7793,7 +7793,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -7914,7 +7914,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -8000,7 +8000,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),
@@ -8160,7 +8160,7 @@
             dict({
               'node': dict({
                 'form': dict({
-                  'slug': 'subform',
+                  'slug': 'song-light',
                 }),
               }),
             }),

--- a/caluma/caluma_form/tests/test_filter_by_answer.py
+++ b/caluma/caluma_form/tests/test_filter_by_answer.py
@@ -58,8 +58,6 @@ def test_query_all_questions(
         question__sub_form__slug="subform",
     ).question
 
-    subform_document = document_factory(form=subform_question.sub_form)
-
     # "randomly" set the hierarchy lookup mode. Not parametrized, as it would
     # explode the test run time three-fold
     possible_hierarchy_lookups = [None, *AnswerHierarchyMode._meta.enum.__members__]
@@ -111,7 +109,7 @@ def test_query_all_questions(
         if qtype == models.Question.TYPE_DATE:
             answer_factory(
                 question=question,
-                document=subform_document,
+                document=document,
                 date=TEST_VALUES[qtype][form_value],
             )
         elif qtype == models.Question.TYPE_CALCULATED_FLOAT:
@@ -123,7 +121,7 @@ def test_query_all_questions(
         else:
             answer_factory(
                 question=question,
-                document=subform_document,
+                document=document,
                 value=TEST_VALUES[qtype][form_value],
             )
 

--- a/caluma/caluma_form/tests/test_migrate_to_multiple_files.py
+++ b/caluma/caluma_form/tests/test_migrate_to_multiple_files.py
@@ -11,7 +11,7 @@ def migrate_and_get_apps(state):
     return apps
 
 
-def test_migrate_to_multiple_files(transactional_db):
+def test_migrate_to_multiple_files(post_migrate_to_current_state):
     app = "caluma_form"
     migrate_from = [(app, "0045_simple_history")]
     migrate_to = [(app, "0046_file_answer_reverse_keys")]

--- a/caluma/caluma_form/tests/test_migration.py
+++ b/caluma/caluma_form/tests/test_migration.py
@@ -12,7 +12,7 @@ from caluma.utils import col_type_from_db
 
 
 @pytest.mark.xfail(reason="Migration dependency issue, migration not required anymore.")
-def test_migrate_to_flat_answers(transactional_db):  # pragma: no cover
+def test_migrate_to_flat_answers(post_migrate_to_current_state):  # pragma: no cover
     executor = MigrationExecutor(connection)
     app = "caluma_form"
     migrate_from = [(app, "0017_auto_20190619_1320")]
@@ -82,7 +82,7 @@ def test_migrate_to_flat_answers(transactional_db):  # pragma: no cover
     assert text_answer.document.pk == main_document.pk
 
 
-def test_migrate_to_form_question_natural_key_forward(transactional_db):
+def test_migrate_to_form_question_natural_key_forward(post_migrate_to_current_state):
     executor = MigrationExecutor(connection)
     app = "caluma_form"
     migrate_from = [(app, "0023_auto_20190729_1448")]
@@ -117,7 +117,7 @@ def test_migrate_to_form_question_natural_key_forward(transactional_db):
     assert form_question.pk == "form-1.question-1"
 
 
-def test_migrate_to_form_question_natural_key_reverse(transactional_db):
+def test_migrate_to_form_question_natural_key_reverse(post_migrate_to_current_state):
     executor = MigrationExecutor(connection)
     app = "caluma_form"
     migrate_from = [(app, "0024_auto_20190919_1244")]
@@ -143,7 +143,7 @@ def test_migrate_to_form_question_natural_key_reverse(transactional_db):
         executor.migrate(migrate_to)
 
 
-def test_dynamic_option_unique_together(transactional_db):
+def test_dynamic_option_unique_together(post_migrate_to_current_state):
     executor = MigrationExecutor(connection)
     app = "caluma_form"
     migrate_from = [(app, "0028_auto_20200210_0929")]
@@ -226,7 +226,7 @@ def test_dynamic_option_unique_together(transactional_db):
     )
 
 
-def test_migrate_to_family_as_pk(transactional_db, caplog):
+def test_migrate_to_family_as_pk(post_migrate_to_current_state, caplog):
     """Ensure correct behaviour when moving family to PK.
 
     Document family may not match an existing document.
@@ -309,7 +309,7 @@ def _verify_foreign_key_types(apps):
                 ), f"Foreign key field {field}: type mismatch with destination in DB"
 
 
-def test_slugfield_length_correctness(transactional_db):
+def test_slugfield_length_correctness(post_migrate_to_current_state):
     """Detect deviation of foreign key types from target field types.
 
     Note: If this test fails, you'll most likely need to create a new
@@ -324,7 +324,7 @@ def test_slugfield_length_correctness(transactional_db):
 
 
 @pytest.mark.xfail(reason="Seems to be fixed upstream.")
-def test_migrate_slugfield_length(transactional_db):  # pragma: no cover
+def test_migrate_slugfield_length(post_migrate_to_current_state):  # pragma: no cover
     """Ensure migration of slugfield length works correctly."""
 
     # we need to migrate down and up again to consistently trigger
@@ -352,7 +352,7 @@ def test_migrate_slugfield_length(transactional_db):  # pragma: no cover
     _verify_foreign_key_types(new_apps)
 
 
-def test_migrate_answer_history_question_type(transactional_db):
+def test_migrate_answer_history_question_type(post_migrate_to_current_state):
     """Make sure migration to custom history field history_question_type works."""
 
     executor = MigrationExecutor(connection)

--- a/caluma/caluma_workflow/tests/test_migrations.py
+++ b/caluma/caluma_workflow/tests/test_migrations.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from caluma.caluma_workflow.models import Case
 
 
-def test_add_case_families(transactional_db):
+def test_add_case_families(post_migrate_to_current_state):
     executor = MigrationExecutor(connection)
     app = "caluma_workflow"
     migrate_from = [(app, "0019_slugfield_length")]
@@ -106,7 +106,7 @@ def test_set_family_with_broken_data(
     migra_module.set_family(apps, schema_editor=FakeEditor)
 
 
-def test_workitem_name_description(transactional_db):
+def test_workitem_name_description(post_migrate_to_current_state):
     executor = MigrationExecutor(connection)
     app = "caluma_workflow"
     migrate_from = [(app, "0021_work_item_controlling_groups")]


### PR DESCRIPTION
* fix: fix calc answer evaluation when adding new table rows
* chore(tests): do not use nested documents
   In the past we've had some misconceptions about document structure and
   introduced nested documents. This commit cleansup a remnant of this
   mistake, that was forgotten back then.
 * chore(tests): migrate to current state after migration tests
   This commit introduces a `post_migrate_to_current_state`-fixture to properly
   cleanup after our migration tests.
