### PR TITLE
chore(release): v8.0.0-beta.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v8.0.0-beta.26 (20 February 2023)
+
+### Fix
+* **form:** Fix validation in document validity graph ([`6b859fa`](https://github.com/projectcaluma/caluma/commit/6b859fa1f76762a8fcfadff7f1010ec4b17d02f4))
+
+
 # v8.0.0-beta.25 (17 February 2023)
 
 This release provides a management command for recalculating calculated Answers that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caluma"
-version = "8.0.0-beta.25"
+version = "8.0.0-beta.26"
 description = "Caluma Service providing GraphQL API"
 homepage = "https://caluma.io"
 repository = "https://github.com/projectcaluma/caluma"


### PR DESCRIPTION
# v8.0.0-beta.26 (20 February 2023)

### Fix
* **form:** Fix validation in document validity graph ([`6b859fa`](https://github.com/projectcaluma/caluma/commit/6b859fa1f76762a8fcfadff7f1010ec4b17d02f4))
