### PR TITLE
feat(filters): Support word combinations in SearchAnswersFilter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated:DeprecationWarning", # deprecation in pytest-freezegun
     "ignore:'django_extensions' defines default_app_config:PendingDeprecationWarning", # deprecation in django_extensions
     "ignore::requests.packages.urllib3.exceptions.InsecureRequestWarning", # MinIO tests do "insecure" requests - that's ok
+    "ignore:invalid escape sequence",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
This commit implements searching for exact word combinations if words are enclosed in quotations. If the amount of quotation marks is uneven, we implicitly add an ending quotation at the end of the search string.

Closes #1927