### PR TITLE
Improve docker image

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
 
-  # Publish `main` as Docker `latest` image.
+  # Publish `main` as Docker `dev` image.
   push:
     branches:
       - main
@@ -20,10 +20,11 @@ concurrency:
 
 env:
   IMAGE_NAME: caluma
+  REGISTRY: ghcr.io
 
 jobs:
   # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
+  # See also https://docs.docker.com/build/ci/github-actions/
   container-registry:
     runs-on: ubuntu-latest
     permissions:
@@ -33,36 +34,30 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
-
-      - name: Log in to registry
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
         if: github.event_name != 'pull_request'
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push image
-        if: github.event_name != 'pull_request'
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=dev,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          # Use Docker `latest` tag convention
-          if [[ "$VERSION" == "main" ]]; then
-            # only push "dev" image from main branch build
-            echo "Pushing $IMAGE_ID:dev"
-            docker tag $IMAGE_NAME $IMAGE_ID:dev
-            docker push $IMAGE_ID:dev
-          else
-            # new version released - push "latest" and version tag
-            echo "Pushing $IMAGE_ID:$VERSION"
-            docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-            docker push $IMAGE_ID:$VERSION
-            echo "Pushing $IMAGE_ID:latest"
-            docker tag $IMAGE_NAME $IMAGE_ID:latest
-            docker push $IMAGE_ID:latest
-          fi
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,13 +66,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Build the project
         run: |
           echo "UID=$(id --user)" > .env
-          docker-compose up -d --build
+          docker compose up -d --build
 
       - name: Run tests
-        run: docker-compose exec -T caluma poetry run pytest --no-cov-on-fail --cov --create-db -vv
+        run: docker compose exec -T caluma poetry run pytest --no-cov-on-fail --cov --create-db -vv
 
   package-tests:
     name: Package tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ FROM python:3.8.12-slim@sha256:8be266ad3b9d0381396ad4fe705d39217773343fdb1efdf90
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget build-essential \
-&& wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -P /usr/local/bin \
-&& chmod +x /usr/local/bin/wait-for-it.sh \
+RUN apt-get update && apt-get install -y --no-install-recommends wget build-essential wait-for-it \
 && mkdir -p /app \
 && useradd -u 901 -r caluma --create-home \
 # all project specific folders need to be accessible by newly created user but also for unknown users (when UID is set manually). Such users are in group root.
@@ -31,4 +29,4 @@ COPY . $APP_HOME
 
 EXPOSE 8000
 
-CMD /bin/sh -c "wait-for-it.sh $DATABASE_HOST:${DATABASE_PORT:-5432} -- poetry run python manage.py migrate && poetry run uwsgi"
+CMD /bin/sh -c "wait-for-it $DATABASE_HOST:${DATABASE_PORT:-5432} -- poetry run python manage.py migrate && poetry run uwsgi"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,7 +18,7 @@ services:
       [
         "/bin/sh",
         "-c",
-        "wait-for-it.sh db:${DATABASE_PORT:-5432} -- poetry run python manage.py migrate && poetry run python manage.py runserver 0.0.0.0:8000",
+        "wait-for-it db:${DATABASE_PORT:-5432} -- poetry run python manage.py migrate && poetry run python manage.py runserver 0.0.0.0:8000",
       ]
     # example for profiling
     # command: ./manage.py runprofileserver --use-cprofile 0.0.0.0:8000 --nothreading --prof-path /app


### PR DESCRIPTION
- Install `wait-for-it` from debian packages
- Use dedicated run cache for apt commands
- Reorder dockerfile to improve caching
- Use docker github actions for publishing the image. **NEW:** a release `v8.2.1` will produce / update the following image tags:
  - `latest`
  - `8.2.1`
  - `8.2`
  - `8`

Closes #1972