### PR TITLE
fix(workflow): provide context to WorkItemValidator

### DIFF
--- a/caluma/caluma_form/schema.py
+++ b/caluma/caluma_form/schema.py
@@ -1144,13 +1144,13 @@ class DocumentValidityConnection(CountableConnectionBase):
         node = ValidationResult
 
 
-def validate_document(info, document_global_id):
+def validate_document(info, document_global_id, **kwargs):
     document_id = extract_global_id(document_global_id)
 
     document_qs = Document.get_queryset(models.Document.objects.all(), info)
 
     document = get_object_or_404(document_qs, pk=document_id)
-    result = get_document_validity(document, info.context.user)
+    result = get_document_validity(document, info.context.user, **kwargs)
 
     errors = result.pop("errors")
     result = ValidationResult(
@@ -1192,14 +1192,16 @@ class Query:
     )
 
     document_validity = ConnectionField(
-        DocumentValidityConnection, id=graphene.ID(required=True)
+        DocumentValidityConnection,
+        id=graphene.ID(required=True),
+        data_source_context=graphene.JSONString(),
     )
 
     def resolve_all_format_validators(self, info, **kwargs):
         return get_format_validators()
 
     def resolve_document_validity(self, info, id, **kwargs):
-        return validate_document(info, id)
+        return validate_document(info, id, **kwargs)
 
 
 QUESTION_ANSWER_TYPES = {

--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -463,13 +463,13 @@ class QuestionValidator:
             self._validate_data_source(data["dataSource"])
 
 
-def get_document_validity(document, user):
+def get_document_validity(document, user, **kwargs):
     validator = DocumentValidator()
     is_valid = True
     errors = []
 
     try:
-        validator.validate(document, user)
+        validator.validate(document, user, **kwargs)
     except CustomValidationError as exc:
         is_valid = False
         detail = str(exc.detail[0])

--- a/caluma/caluma_workflow/api.py
+++ b/caluma/caluma_workflow/api.py
@@ -54,7 +54,9 @@ def complete_work_item(
     <WorkItem: WorkItem object (some-uuid)>
     ```
     """
-    domain_logic.CompleteWorkItemLogic.validate_for_complete(work_item, user)
+    domain_logic.CompleteWorkItemLogic.validate_for_complete(
+        work_item, user, context=context
+    )
     validated_data = domain_logic.CompleteWorkItemLogic.pre_complete(
         work_item, {}, user, context
     )

--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -113,7 +113,7 @@ class CompleteWorkItemLogic:
         ).exists()
 
     @staticmethod
-    def validate_for_complete(work_item, user):
+    def validate_for_complete(work_item, user, context=None):
         validators.WorkItemValidator().validate(
             status=work_item.status,
             child_case=work_item.child_case,
@@ -121,6 +121,8 @@ class CompleteWorkItemLogic:
             case=work_item.case,
             document=work_item.document,
             user=user,
+            validation_context=context.get("validation_context") if context else None,
+            data_source_context=context.get("data_source_context") if context else None,
         )
 
     @staticmethod

--- a/caluma/caluma_workflow/serializers.py
+++ b/caluma/caluma_workflow/serializers.py
@@ -363,7 +363,7 @@ class CompleteWorkItemSerializer(ContextModelSerializer):
     def validate(self, data):
         try:
             domain_logic.CompleteWorkItemLogic.validate_for_complete(
-                self.instance, self.context["request"].user
+                self.instance, self.context["request"].user, context=data.get("context")
             )
         except ValidationError as e:
             raise exceptions.ValidationError(str(e))

--- a/caluma/caluma_workflow/validators.py
+++ b/caluma/caluma_workflow/validators.py
@@ -5,16 +5,47 @@ from . import models
 
 
 class WorkItemValidator:
-    def _validate_task_simple(self, task, case, document, user):
+    def _validate_task_simple(self, task, case, document, user, **kwargs):
         pass
 
-    def _validate_task_complete_workflow_form(self, task, case, document, user):
-        self._validate_task_complete_task_form(task, case, case.document, user)
+    def _validate_task_complete_workflow_form(
+        self, task, case, document, user, **kwargs
+    ):
+        self._validate_task_complete_task_form(
+            task, case, case.document, user, **kwargs
+        )
 
-    def _validate_task_complete_task_form(self, task, case, document, user):
-        DocumentValidator().validate(document, user)
+    def _validate_task_complete_task_form(
+        self,
+        task,
+        case,
+        document,
+        user,
+        validation_context=None,
+        data_source_context=None,
+        **kwargs,
+    ):
+        DocumentValidator().validate(
+            document,
+            user,
+            validation_context=validation_context,
+            data_source_context=data_source_context,
+            **kwargs,
+        )
 
-    def validate(self, *, status, child_case, case, task, document, user, **kwargs):
+    def validate(
+        self,
+        *,
+        status,
+        child_case,
+        case,
+        task,
+        document,
+        user,
+        validation_context=None,
+        data_source_context=None,
+        **kwargs,
+    ):
         if case.status != models.Case.STATUS_RUNNING:
             raise ValidationError("Only work items of running cases can be completed.")
 
@@ -27,4 +58,12 @@ class WorkItemValidator:
                     "Work item can only be completed when child case is in a finish state."
                 )
 
-        getattr(self, f"_validate_task_{task.type}")(task, case, document, user)
+        getattr(self, f"_validate_task_{task.type}")(
+            task,
+            case,
+            document,
+            user,
+            validation_context=validation_context,
+            data_source_context=data_source_context,
+            **kwargs,
+        )

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -1916,7 +1916,7 @@
     allDocuments(offset: Int, before: String, after: String, first: Int, last: Int, filter: [DocumentFilterSetType], order: [DocumentOrderSetType]): DocumentConnection
     allFormatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
     allUsedDynamicOptions(offset: Int, before: String, after: String, first: Int, last: Int, filter: [DynamicOptionFilterSetType], order: [DynamicOptionOrderSetType]): DynamicOptionConnection
-    documentValidity(id: ID!, before: String, after: String, first: Int, last: Int): DocumentValidityConnection
+    documentValidity(id: ID!, dataSourceContext: JSONString, before: String, after: String, first: Int, last: Int): DocumentValidityConnection
     node(
       """The ID of the object"""
       id: ID!


### PR DESCRIPTION
Provide context information such as validation context or data source
context to the WorkItemValidator. This information can for example be
relevant for validating dynamic questions in the document validator.