### PR TITLE
feat(auth)!: only use userinfo for auth (drop introspect)

### DIFF
--- a/caluma/settings/caluma.py
+++ b/caluma/settings/caluma.py
@@ -61,16 +61,9 @@ OIDC_USERNAME_CLAIM = env.str("OIDC_USERNAME_CLAIM", default="sub")
 # Claim to use for the "client" claim. Should normally be left to the default value
 OIDC_CLIENT_CLAIM = env.str("OIDC_CLIENT_CLAIM", default="client_id")
 
-# When service clients are used, should we pretend they're users?
-OIDC_CLIENT_AS_USERNAME = env.bool("OIDC_CLIENT_AS_USERNAME", default=False)
-
 OIDC_BEARER_TOKEN_REVALIDATION_TIME = env.int(
     "OIDC_BEARER_TOKEN_REVALIDATION_TIME", default=0
 )
-
-OIDC_INTROSPECT_ENDPOINT = env.str("OIDC_INTROSPECT_ENDPOINT", default=None)
-OIDC_INTROSPECT_CLIENT_ID = env.str("OIDC_INTROSPECT_CLIENT_ID", default=None)
-OIDC_INTROSPECT_CLIENT_SECRET = env.str("OIDC_INTROSPECT_CLIENT_SECRET", default=None)
 
 CALUMA_OIDC_USER_FACTORY = env.str(
     "CALUMA_OIDC_USER_FACTORY", default="caluma.caluma_user.models.OIDCUser"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ DJANGO_SETTINGS_MODULE = "caluma.settings.django"
 env = [
     "META_FIELDS=test-key,foobar",
     "OIDC_USERINFO_ENDPOINT=mock://caluma.io/openid/userinfo",
-    "OIDC_INTROSPECT_ENDPOINT=mock://caluma.io/openid/introspect",
     "OIDC_BEARER_TOKEN_REVALIDATION_TIME=60",
     "LANGUAGES=en,de,fr",
     "ENABLE_HISTORICAL_API=true",


### PR DESCRIPTION
For OIDC-auth it's not necessary to have a fallback to the introspect endpoint, so this commit drops it. For this to work, make sure to include the `openid`-scope in the request.

BREAKING CHANGE: setting the `OIDC_INTROSPECT_*` and `OIDC_CLIENT_AS_USERNAME` env vars is obsolete now. Auth now only calls the userinfo endpoint without any fallback to the introspect endpoint. This will possibly have an impact on the `username` property of the user object. If your extensions depend on that property, please update them if necessary.
Additionally, all requests sent to Caluma must include the `openid`-scope.