### PR TITLE
fix: catch ValueError and ZeroDivision errors on early jexl evaluation

### DIFF
--- a/caluma/caluma_form/jexl.py
+++ b/caluma/caluma_form/jexl.py
@@ -201,7 +201,7 @@ class QuestionJexl(JEXL):
     def evaluate(self, expr, raise_on_error=True):
         try:
             return super().evaluate(expr)
-        except TypeError:
+        except (TypeError, ValueError, ZeroDivisionError):
             if raise_on_error:
                 raise
             return None


### PR DESCRIPTION
# Description
Currently, starting a new case fails if any of the JEXL evaluations in a form return a `ZeroDivisionError` in the signal layer.

# Fix
Add `ValueError` and `ZeroDivisionError` to catch block around JEXL evaluation in signal layer.

# More detailed description
We evaluate JEXL expressions greedily in the signal layer, but do so without raising:

https://github.com/projectcaluma/caluma/blob/7125c6a801f76d95ea30b2e90aff3d16d307a6b3/caluma/caluma_form/signals.py#L104

However, in the `jexl.update` function we only catch `TypeError`:
https://github.com/projectcaluma/caluma/blob/7125c6a801f76d95ea30b2e90aff3d16d307a6b3/caluma/caluma_form/jexl.py#L201

This is also not consistent with the catch block here, where we catch `TypeError`, `ValueError` and `ZeroDivisionError`:
https://github.com/projectcaluma/caluma/blob/7125c6a801f76d95ea30b2e90aff3d16d307a6b3/caluma/caluma_core/jexl.py#L81

This fix is time-critical as it is currently not possible to start a certain form which uses many calculated fields.