### PR TITLE
feat: add show_validation property for action buttons

### DIFF
--- a/caluma/caluma_form/factories.py
+++ b/caluma/caluma_form/factories.py
@@ -90,6 +90,11 @@ class QuestionFactory(DjangoModelFactory):
         yes_declaration=False,
         no_declaration=None,
     )
+    show_validation = Maybe(
+        "is_action_button",
+        yes_declaration=False,
+        no_declaration=None,
+    )
 
     class Meta:
         model = models.Question

--- a/caluma/caluma_form/models.py
+++ b/caluma/caluma_form/models.py
@@ -244,6 +244,14 @@ class Question(core_models.SlugModel):
     def validate_on_enter(self, value):
         self.configuration["validate_on_enter"] = value
 
+    @property
+    def show_validation(self):
+        return self.configuration.get("show_validation")
+
+    @show_validation.setter
+    def show_validation(self, value):
+        self.configuration["show_validation"] = value
+
     def empty_value(self):
         """Return empty value for this question type."""
 

--- a/caluma/caluma_form/schema.py
+++ b/caluma/caluma_form/schema.py
@@ -600,6 +600,7 @@ class ActionButtonQuestion(QuestionQuerysetMixin, FormDjangoObjectType):
     action = ButtonAction(required=True)
     color = ButtonColor(required=True)
     validate_on_enter = graphene.Boolean(required=True)
+    show_validation = graphene.Boolean(required=True)
 
     class Meta:
         model = models.Question

--- a/caluma/caluma_form/serializers.py
+++ b/caluma/caluma_form/serializers.py
@@ -468,6 +468,7 @@ class SaveActionButtonQuestionSerializer(SaveQuestionSerializer):
     action = ButtonActionField(required=True)
     color = ButtonColorField(required=True)
     validate_on_enter = BooleanField(required=True)
+    show_validation = BooleanField(required=True)
 
     def validate(self, data):
         data["type"] = models.Question.TYPE_ACTION_BUTTON
@@ -484,6 +485,7 @@ class SaveActionButtonQuestionSerializer(SaveQuestionSerializer):
             "action",
             "color",
             "validate_on_enter",
+            "show_validation",
         ]
 
 

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -25,6 +25,7 @@
     action: ButtonAction!
     color: ButtonColor!
     validateOnEnter: Boolean!
+    showValidation: Boolean!
   }
   
   input AddFormQuestionInput {
@@ -2190,6 +2191,7 @@
     action: ButtonAction!
     color: ButtonColor!
     validateOnEnter: Boolean!
+    showValidation: Boolean!
     clientMutationId: String
   }
   


### PR DESCRIPTION
This will be used in the frontend to toggle the visibility of validation messages when submitting forms with action buttons:

https://github.com/projectcaluma/ember-caluma/pull/2488