### PR TITLE
fix(healthz): do not warn about expected events

### DIFF
--- a/caluma/caluma_core/health_checks.py
+++ b/caluma/caluma_core/health_checks.py
@@ -58,7 +58,7 @@ def _check_media_storage_service():
 
         # remove object
         storage_client.remove_object(object_name)
-        assert not storage_client.stat_object(object_name)
+        assert not storage_client.stat_object(object_name, suppress_warning=True)
 
         return {"ok": True}
 

--- a/caluma/caluma_form/storage_clients.py
+++ b/caluma/caluma_form/storage_clients.py
@@ -71,17 +71,21 @@ class Minio:
         self.bucket = settings.MINIO_STORAGE_MEDIA_BUCKET_NAME
 
     @_retry_on_missing_bucket
-    def stat_object(self, object_name):
+    def stat_object(self, object_name, suppress_warning=False):
         """
         Get stat of object in bucket.
 
         :param object_name: str
+        :param suppress_warning: bool
         :return: stat response if successful, otherwise None
         """
         try:
             return self.client.stat_object(self.bucket, object_name)
         except S3Error as exc:
-            log.warning(f"Minio error, cannot stat object '{object_name}': {exc.code}")
+            if not suppress_warning:
+                log.warning(
+                    f"Minio error, cannot stat object '{object_name}': {exc.code}"
+                )
             return None
 
     @_retry_on_missing_bucket

--- a/caluma/caluma_form/tests/test_minio.py
+++ b/caluma/caluma_form/tests/test_minio.py
@@ -104,3 +104,7 @@ def test_minio_handle_exceptions(exc_code, caplog, mocker):
     assert caplog.messages == [
         f"Minio error, cannot stat object 'test_object': {exc_code}"
     ]
+    assert len(caplog.messages) == 1
+    stat = client.stat_object("test_object", suppress_warning=True)
+    assert stat is None
+    assert len(caplog.messages) == 1


### PR DESCRIPTION
As part of the health-check routines, a file is removed in minio and afterwards it's asserted that the file is gone. This call to `Minio.stat_object()` led to a warning being issued during every health-check iteration like the following:

```
Minio error, cannot stat object 'healthz_tmp-object_{UUID}': NoSuchKey
```

This commit extends `Minio.stat_object()`, so that issuing of the log-warning can be suppressed by profiding the argument `warn_missing=False`. Default behaviour doesn't change and will still issue this warning.