### PR TITLE
fix: only save updated fields in post_complete case logic

### DIFF
--- a/caluma/caluma_workflow/domain_logic.py
+++ b/caluma/caluma_workflow/domain_logic.py
@@ -210,7 +210,14 @@ class CompleteWorkItemLogic:
             case.closed_at = timezone.now()
             case.closed_by_user = user.username
             case.closed_by_group = user.group
-            case.save()
+            case.save(
+                update_fields=[
+                    "status",
+                    "closed_at",
+                    "closed_by_user",
+                    "closed_by_group",
+                ]
+            )
 
             send_event(
                 events.post_complete_case,


### PR DESCRIPTION
This prevents untouched fields of the case model which were updated in a event to be overwritten with an old value.