### PR TITLE
chore: drop deprecated id filter on cases filterset

### DIFF
--- a/caluma/caluma_workflow/filters.py
+++ b/caluma/caluma_workflow/filters.py
@@ -90,8 +90,6 @@ class FlowOrderSet(BaseFilterSet):
 
 
 class CaseFilterSet(MetaFilterSet):
-    id = GlobalIDFilter()
-    id.deprecation_reason = "Use ids filter instead"
     ids = GlobalIDMultipleChoiceFilter(field_name="pk")
 
     document_form = CharFilter(field_name="document__form_id")

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -520,7 +520,6 @@
     modifiedAfter: DateTime
     metaHasKey: String
     metaValue: [JSONValueFilterType]
-    id: ID
     ids: [ID]
     documentForm: String
     documentForms: [String]


### PR DESCRIPTION
BREAKING CHANGE: you now must use the `ids` filter instead

This should go in before the 10.0.0 release