### PR TITLE
feat(settings): add setting to limit query depth

### DIFF
--- a/caluma/settings/caluma.py
+++ b/caluma/settings/caluma.py
@@ -59,6 +59,10 @@ GRAPHENE = {
 # the source).
 DISABLE_INTROSPECTION = env.bool("DISABLE_INTROSPECTION", default=default(False, True))
 
+# DOS protection: Limit query depth to a given level. Default is 0, which means
+# it is disabled
+QUERY_DEPTH_LIMIT = env.int("QUERY_DEPTH_LIMIT", default=0)
+
 # OpenID connect
 
 OIDC_USERINFO_ENDPOINT = env.str("OIDC_USERINFO_ENDPOINT", default=None)


### PR DESCRIPTION
This should avoid overly comples GraphQL queries which might overload the backend. Note: We do not yet have experience with the exact useful value of this settings, so the default is zero (which implies the limit is disabled)

Edit: Ran some manual tests (It's hard to do automated tests for stuff like that). The setting works, but I'm still not sure what a reasonable limit would be. I assume it will be around 15-20 realistically

![image](https://github.com/projectcaluma/caluma/assets/303759/fc70f75e-97f1-480d-b815-6ed448618a8e)
