### PR TITLE
chore: fix gitlint config - remove warning about pending changes

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 ignore=body-is-missing
+regex-style-search=True
 
 [ignore-by-title]
 regex=^chore\(deps.*


### PR DESCRIPTION
Our regex is alredy anchored, so the change it was warning about doesn't affect us