### PR TITLE
fix: do not query for non-existent buckets in healthz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v10.1.1 (8 February 2024)
+### Fix
+
+* Do not query for non-existent buckets in healthz ([`7d5e8ab`](https://github.com/projectcaluma/caluma/commit/7d5e8ab0d2188ee10f9b304737c5835ccb0d0e49))
+
+
 # v10.1.0 (8 February 2024)
 
 ### Feature

--- a/caluma/caluma_core/conftest.py
+++ b/caluma/caluma_core/conftest.py
@@ -84,7 +84,7 @@ def db_broken_connection(transactional_db):
 def minio_mock_working(mocker):
     """Provide working minio mock for health checks."""
     return mocker.patch.object(
-        storage_clients.client.client, "bucket_exists", return_value=False
+        storage_clients.client.client, "bucket_exists", return_value=True
     )
 
 

--- a/caluma/caluma_core/health_checks.py
+++ b/caluma/caluma_core/health_checks.py
@@ -1,5 +1,4 @@
 from io import StringIO
-from uuid import uuid4
 
 from django.conf import settings
 from django.core import management
@@ -28,8 +27,11 @@ def _check_pending_migrations(db_name):
 @check
 def _check_media_storage_service():
     """Check media storage service connectivity."""
-    assert not storage_clients.client.client.bucket_exists(str(uuid4()))
-    return {"ok": True}
+    return {
+        "ok": storage_clients.client.client.bucket_exists(
+            settings.MINIO_STORAGE_MEDIA_BUCKET_NAME
+        )
+    }
 
 
 def check_media_storage_service():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caluma"
-version = "10.1.0"
+version = "10.1.1"
 description = "Caluma Service providing GraphQL API"
 homepage = "https://caluma.io"
 repository = "https://github.com/projectcaluma/caluma"


### PR DESCRIPTION
This yields a routing problem with reverse proxies. Now we're checking for the configured bucket, which makes more sense anyway.