### PR TITLE
fix(code of conduct): contact mail address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-contact@caluma.io.
+christian.zosel@adfinis.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
contact@caluma.io is not working anymore, and is a hassle to maintain. This replaces the address with my personal one for simplicity.