### PR TITLE
feat(jexl): add main_case_form to info object

### DIFF
--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -134,7 +134,7 @@ class RowField(Field):
 
 
 class FieldSet(Element):
-    aliases = {"formMeta": "form_meta"}
+    aliases = {"formMeta": "form_meta", "mainCaseForm": "main_case_form"}
 
     def __init__(self, document, form, question=None, parent=None):
         super().__init__(parent)
@@ -144,6 +144,18 @@ class FieldSet(Element):
         self.question = question
         self._fields = None
         self._sub_forms = None
+        self._main_case_form = "NOTSET"
+
+    @property
+    def main_case_form(self):
+        if self._main_case_form == "NOTSET":
+            try:
+                self._main_case_form = (
+                    self.document.family.work_item.case.family.document.form.slug
+                )
+            except Exception:  # pragma: no cover
+                self._main_case_form = None
+        return self._main_case_form
 
     @property
     def fields(self):

--- a/caluma/caluma_form/tests/test_jexl.py
+++ b/caluma/caluma_form/tests/test_jexl.py
@@ -197,16 +197,25 @@ def test_reference_missing_question(
         ("sub_question", "info.parent.form == 'top_form'", True, "subform"),
         ("sub_question", "info.parent.formMeta.level == 0", True, "subform"),
         ("sub_question", "info.parent.formMeta['is-top-form']", True, "subform"),
+        ("sub_question", "info.mainCaseForm == 'main-case-form'", True, "subform"),
         ("column", "info.parent.form == 'top_form'", True, "table"),
         ("column", "info.parent.formMeta.level == 0", True, "table"),
         ("column", "info.parent.formMeta['is-top-form']", True, "table"),
         ("column", "info.root.form == 'top_form'", True, "table"),
         ("column", "info.root.formMeta.level == 0", True, "table"),
         ("column", "info.root.formMeta['is-top-form']", True, "table"),
+        ("column", "info.mainCaseForm == 'main-case-form'", True, "table"),
     ],
 )
 def test_new_jexl_expressions(
-    question, expr, expectation, features, info, form_and_document
+    question,
+    expr,
+    expectation,
+    features,
+    info,
+    form_and_document,
+    case_factory,
+    work_item_factory,
 ):
     """Evaluate a JEXL expression in the context of a full document.
 
@@ -230,6 +239,9 @@ def test_new_jexl_expressions(
     form, document, questions, answers = form_and_document(
         use_table=use_table, use_subform=use_subform
     )
+
+    main_case = case_factory(document__form__slug="main-case-form")
+    work_item_factory(case=main_case, document=document)
 
     # expression test method: we delete an answer and set it's is_hidden
     # to an expression to be tested. If the expression evaluates to True,


### PR DESCRIPTION
This is convenient when you'd like to write a JEXL expression in a task form attached to some work item, that depends on the case's main documents' form.

Related PR in ember-caluma: https://github.com/projectcaluma/ember-caluma/pull/2703

Once we merge this, we should spend a minute to update the caluma docs: https://caluma.gitbook.io/caluma-docs/forms/validation#variables-available-for-evaluation