### PR TITLE
fix(jexl): always add root info

### DIFF
--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -162,19 +162,14 @@ class FieldSet(Element):
             self._case = None
             return self._case
 
-        if hasattr(case, "parent_work_item"):
-            root = case.parent_work_item.case.family
-            root_info = {
-                "form": root.document.form.slug,
-                "workflow": root.workflow.slug,
-            }
-        else:
-            root_info = None
-
+        root = case.family
         self._case = {
             "form": case.document.form.slug,
             "workflow": case.workflow.slug,
-            "root": root_info,
+            "root": {
+                "form": root.document.form.slug,
+                "workflow": root.workflow.slug,
+            },
         }
         return self._case
 


### PR DESCRIPTION
info.case.root should always be defined - when we're in the root case, it just resolves to the same value as info.case. This matches the way it is already implemented in ember-caluma.