### PR TITLE
fix(visibilities): don't crash in the suppressable visibility resolver

### DIFF
--- a/caluma/utils.py
+++ b/caluma/utils.py
@@ -154,7 +154,7 @@ def suppressable_visibility_resolver():
     # to validate the behavour as we'd usually do.
     class SuppressableResolver:
         def __call__(self, inner_self, *args, **kwargs):
-            return getattr(inner_self, self.prop)
+            return getattr(inner_self, self.prop, None)
 
         @property
         def _bypass_get_queryset(self):  # pragma: no cover


### PR DESCRIPTION
When an optional property is looked up, the default behaviour would be to just return None (in Graphene), but our code called `getattr()` without default param, causing the code to crash.