### PR TITLE
feat(copy): adds on_copy to datasources to alter dynamic values

### DIFF
--- a/caluma/caluma_data_source/data_sources.py
+++ b/caluma/caluma_data_source/data_sources.py
@@ -1,6 +1,7 @@
 import logging
+from typing import Tuple
 
-from caluma.caluma_form.models import DynamicOption
+from caluma.caluma_form.models import Answer, DynamicOption
 from caluma.utils import is_iterable_and_no_string
 
 logger = logging.getLogger(__name__)
@@ -86,3 +87,25 @@ class BaseDataSource:
                 raise e
             return self.default
         return new_data
+
+    def on_copy(
+        self, old_answer: Answer, new_answer: Answer, old_value: Tuple[str, str]
+    ) -> Tuple[str | None, str | None]:
+        """Alter the dynamic option when an Answer with this datasource gets copied.
+
+        When an answer of type TYPE_DYNAMIC_CHOICE or TYPE_DYNAMIC_MULTIPLE_CHOICE
+        gets copied the meaning of the slug and label of the dynamic option could
+        potentially change when the datasource data changes. During the answer copy
+        process the linked datasource it's on_copy method will be called to decide what
+        to do with existing answer values.
+
+        The decided outcome can be either retain, change or discard as follows:
+
+        - return the same slug,label tuple to not perform any change (default behavior)
+        - return an altered slug or(/and) label to save the answer value with
+            a new value or(/and) update the dynamic option label
+        - return a None value in the tuple for the slug, which will discard the
+            answer value, and prevent copying the dynamic option
+
+        """
+        return old_value

--- a/caluma/caluma_data_source/tests/data_sources.py
+++ b/caluma/caluma_data_source/tests/data_sources.py
@@ -1,7 +1,10 @@
+from typing import Tuple
+
 from uuid_extensions import uuid7str
 
 from caluma.caluma_data_source.data_sources import BaseDataSource
 from caluma.caluma_data_source.utils import data_source_cache
+from caluma.caluma_form.models import Answer
 
 
 class MyDataSource(BaseDataSource):
@@ -91,3 +94,43 @@ class MyDataSourceWithContext(BaseDataSource):
             label += f" foo: {context['foo']}"
 
         return [[slug, label]]
+
+
+class MyDataSourceWithOnCopy(BaseDataSource):
+    info = "Data source using on copy for testing"
+
+    def get_data(self):
+        return [
+            ["169cac4c-ab46-4521-bdba-4385f26ffb3", "label1"],
+            ["34948dc6-4b16-4a72-890b-cdbdc7da9f2", "label2"],
+            ["0935c1bc-5ff3-44a4-9089-03eac8872b0", "label3"],
+        ]
+
+    def get_discard_value(self):
+        return (None, None)
+
+    def get_change_value(self):
+        return ("changedv-4b16-4a72-890b-cdbdc7da9f2", "changed label2")
+
+    def on_copy(
+        self, old_answer: Answer, new_answer: Answer, old_value: Tuple[str, str]
+    ) -> Tuple[str | None, str | None]:
+        """Simulate different on_copy behaviors based on the slug.
+
+        Examples:
+            - Pass "discard" as the old slug, to return the get_discard_value to
+                discard the answer
+            - Pass "change" as the old slug, to return the get_change_value to change
+                the answer
+            - In all other cases, return the unchanged old_value
+
+        """
+        old_slug, _ = old_value
+
+        if old_slug == "discard":
+            return self.get_discard_value()
+
+        if old_slug == "change":
+            return self.get_change_value()
+
+        return old_value


### PR DESCRIPTION
Add a on_copy feature for datasources to optionally alter the dynamic option answer value and label