### PR TITLE
fix(jexl): fix crashes in form validation when validating options

### DIFF
--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from django_filters.constants import EMPTY_VALUES
 from rest_framework import exceptions
 
+from caluma.caluma_core.exceptions import ConfigurationError
 from caluma.caluma_data_source.data_source_handlers import get_data_sources
 from caluma.caluma_form import structure
 from caluma.caluma_workflow.models import Case
@@ -108,7 +109,7 @@ class AnswerValidator:
             if validation_context.slug() != question.slug:  # pragma: no cover
                 # This only happens if *programmer* made an error, therefore we're
                 # not explicitly covering it
-                raise exceptions.ConfigurationError(
+                raise ConfigurationError(
                     f"Passed validation context does not belong to question {question.slug}"
                 )
             return validation_context, validation_context.get_root()
@@ -130,8 +131,10 @@ class AnswerValidator:
             return [o.slug for o in question.options.all()]
 
         field, _root = self._structure_field(document, question, validation_context)
-        if not field:
-            raise exceptions.ConfigurationError(
+        if not field:  # pragma: no cover
+            # This only happens if *programmer* made an error, therefore we're
+            # not explicitly covering it
+            raise ConfigurationError(
                 f"Field for question '{question.slug}' not found "
                 f"in form '{document.form_id}'"
             )


### PR DESCRIPTION
The new structure code has a strict policy of only doing weakrefs from child fields to their parents, to avoid circular dependencies and therefore causing GC leaks.

However the validation code had a situation where a child field was used while the (root) field went out of scope, therefore losing the form structure.

This is now fixed - the private utility method `_structure_field()` now returns the root field as well, even though it's not actually being used.

While we're at it, also raise a ConfigurationError if a field is missing in a form.