### PR TITLE
refactor: drop prefetch_document()

### DIFF
--- a/caluma/caluma_form/domain_logic.py
+++ b/caluma/caluma_form/domain_logic.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ValidationError
 
 from caluma.caluma_core.models import BaseModel
 from caluma.caluma_core.relay import extract_global_id
-from caluma.caluma_form import models, structure, utils, validators
+from caluma.caluma_form import models, structure, validators
 from caluma.caluma_form.utils import recalculate_field
 from caluma.caluma_user.models import BaseUser
 from caluma.utils import update_model
@@ -171,9 +171,7 @@ class SaveAnswerLogic:
             return
         log.debug("update_calc_dependents(%s)", answer)
 
-        root_doc = utils.prefetch_document(answer.document.family_id)
-        struc = structure.FieldSet(root_doc)
-
+        struc = structure.FieldSet(answer.document.family)
         field = struc.find_field_by_answer(answer)
         if is_table:
             # We treat all children of the table as "changed"
@@ -345,8 +343,7 @@ class SaveDocumentLogic:
         In order to do this efficiently, we get all calculated questions with
         their dependents, sort them topoligically, and then update their answer.
         """
-        root_doc = utils.prefetch_document(document.family_id)
-        struc = structure.FieldSet(root_doc)
+        struc = structure.FieldSet(document.family)
 
         calculated_fields = (
             field

--- a/caluma/caluma_form/tests/test_question.py
+++ b/caluma/caluma_form/tests/test_question.py
@@ -1295,8 +1295,5 @@ def test_init_of_calc_questions_queries(
         question__calc_expression="'table'|answer|mapby('column')|sum + 'top_question'|answer + 'sub_question'|answer",
     )
 
-    with django_assert_num_queries(42):
-        # This used to be 35 queries, however they were more complex and
-        # therefore more demanding on the DB. The fastloader tries to do
-        # as little JOINs as possible to speed things up
+    with django_assert_num_queries(31):
         api.save_answer(questions_dict["top_question"], document, value="1")


### PR DESCRIPTION
This is now done by the structure's own fastloader, so we don't need to prefetch anymore. The FastLoader is also much easier to understand than the prefetch here.