### PR TITLE
feat(forms): extend structure fastloader to support multiple documents

### DIFF
--- a/caluma/caluma_form/factories.py
+++ b/caluma/caluma_form/factories.py
@@ -132,7 +132,7 @@ class OptionFactory(DjangoModelFactory):
 class QuestionOptionFactory(DjangoModelFactory):
     option = SubFactory(OptionFactory)
     question = SubFactory(QuestionFactory, type=models.Question.TYPE_CHOICE)
-    sort = 0
+    sort = Faker("pyint")
 
     class Meta:
         model = models.QuestionOption

--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -225,7 +225,7 @@ class FastLoader:
                 Question.TYPE_CHOICE,
                 Question.TYPE_MULTIPLE_CHOICE,
             ]:
-                choice_questions.append(fq.question)
+                choice_questions.append(fq.question.pk)
 
         # It could be that the requested forms don't have any questions. We'd still
         # need to add them to our "known" set.
@@ -237,8 +237,10 @@ class FastLoader:
                 self._forms[form.pk] = form
 
         if choice_questions:
+            already_have_options = set(self._question_options.keys())
+            newly_needed = set(choice_questions) - already_have_options
             for qo in (
-                QuestionOption.objects.filter(question__in=choice_questions)
+                QuestionOption.objects.filter(question__in=newly_needed)
                 .order_by("-sort")
                 .select_related("option")
             ):

--- a/caluma/caluma_form/tests/__snapshots__/test_document.ambr
+++ b/caluma/caluma_form/tests/__snapshots__/test_document.ambr
@@ -835,7 +835,7 @@
           }),
           dict({
             'node': dict({
-              'label': 'Mary White',
+              'label': 'Robert Skinner',
               'slug': 'anothervalue',
             }),
           }),

--- a/caluma/caluma_form/tests/__snapshots__/test_question.ambr
+++ b/caluma/caluma_form/tests/__snapshots__/test_question.ambr
@@ -951,8 +951,8 @@
         '__typename': 'MultipleChoiceQuestion',
         'defaultAnswer': dict({
           'value': list([
+            'successful-job',
             'maybe-stock-capital',
-            'court-ask',
           ]),
         }),
         'hintText': 'test',
@@ -964,14 +964,14 @@
           'edges': list([
             dict({
               'node': dict({
-                'label': 'William Ramos',
-                'slug': 'maybe-stock-capital',
+                'label': 'Jennifer Lee',
+                'slug': 'successful-job',
               }),
             }),
             dict({
               'node': dict({
-                'label': 'Scott Powell',
-                'slug': 'court-ask',
+                'label': 'William Ramos',
+                'slug': 'maybe-stock-capital',
               }),
             }),
           ]),

--- a/caluma/caluma_form/tests/test_option.py
+++ b/caluma/caluma_form/tests/test_option.py
@@ -196,9 +196,10 @@ def test_option_is_hidden(
     options = result.data["allDocuments"]["edges"][0]["node"]["answers"]["edges"][0][
         "node"
     ]["question"]["options"]["edges"]
-    expected = [{"node": {"slug": "bar"}}, {"node": {"slug": "thing-piece"}}]
+
+    expected = [{"node": {"slug": "piece-training"}}, {"node": {"slug": "bar"}}]
     if is_hidden:
-        expected = [{"node": {"slug": "thing-piece"}}]
+        expected = [{"node": {"slug": "piece-training"}}]
     assert options == expected
 
 

--- a/caluma/caluma_form/tests/test_structure.py
+++ b/caluma/caluma_form/tests/test_structure.py
@@ -266,7 +266,10 @@ def test_options(simple_form_structure, form_question_factory, question_option_f
         question__type="choice", form=simple_form_structure.form
     ).question
 
-    opts = question_option_factory.create_batch(4, question=choice_q)
+    opts = sorted(
+        question_option_factory.create_batch(4, question=choice_q),
+        key=lambda x: -x.sort,
+    )
     assert choice_q.options.exists()
 
     fieldset = structure.FieldSet(simple_form_structure)


### PR DESCRIPTION
This allows reuse of the fastloader across multiple documents of a queryset, which will speed up things in list views for example