### PR TITLE
Fix indirect calculations

### DIFF
--- a/caluma/caluma_form/domain_logic.py
+++ b/caluma/caluma_form/domain_logic.py
@@ -157,7 +157,7 @@ class SaveAnswerLogic:
         return answer
 
     @staticmethod
-    def update_calc_dependents(answer, update_info):
+    def recalculate_dependents(answer, update_info):
         """Update the dependent calc answers when this given answer has changed.
 
         The update_info is used in the context of table questions, when we need
@@ -225,7 +225,7 @@ class SaveAnswerLogic:
         if answer.question.type == models.Question.TYPE_TABLE:
             update_info = answer.create_answer_documents(documents)
 
-        cls.update_calc_dependents(answer, update_info)
+        cls.recalculate_dependents(answer, update_info)
 
         return answer
 
@@ -245,7 +245,7 @@ class SaveAnswerLogic:
         if answer.question.type == models.Question.TYPE_TABLE:
             update_info = answer.create_answer_documents(documents)
 
-        cls.update_calc_dependents(answer, update_info)
+        cls.recalculate_dependents(answer, update_info)
 
         answer.refresh_from_db()
         return answer

--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -65,9 +65,7 @@ def object_local_memoise(method):
             # for debugging purposes
             return method(self, *args, **kwargs)
         if not hasattr(self, "_memoise"):
-            self._memoise = {}
-            self._memoise_hit_count = 0
-            self._memoise_miss_count = 0
+            clear_memoise(self)
 
         key = str([args, kwargs, method])
         if key in self._memoise:
@@ -98,6 +96,8 @@ def clear_memoise(obj):
     call `clear_memoise()` on that object to clear all it's cached data.
     """
     obj._memoise = {}
+    obj._memoise_hit_count = 0
+    obj._memoise_miss_count = 0
 
 
 class FastLoader:

--- a/caluma/caluma_form/tests/test_question.py
+++ b/caluma/caluma_form/tests/test_question.py
@@ -1167,7 +1167,7 @@ def test_recalc_missing_dependency(
     sub_question.type = models.Question.TYPE_INTEGER
     sub_question.save()
 
-    spy = mocker.spy(domain_logic.SaveAnswerLogic, "update_calc_dependents")
+    spy = mocker.spy(domain_logic.SaveAnswerLogic, "recalculate_dependents")
 
     # Calculated question in another form
     form_question_factory(


### PR DESCRIPTION
### fix(structure): correctly update structure in-place for recalculations

When calculating a field, we must take better care to update
the dependents, invalidate all the cached values, and ensure the
intermediate values are correctly used.

### refactor(structure): rename `update_calc_dependents()`

Rename `update_calc_dependents()` to `recalculate_dependents()`, because
there's a similarly-named function in caluma_form.utils that does
something else, which is confusing

### refactor(structure): cleanup memoise code to be more resilient



