### PR TITLE
chore(ci): deprecate python and postgres versions

### DIFF
--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
 
     services:
       postgres:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,13 +125,6 @@ jobs:
       - name: Run tests
         run: poetry run pytest --no-cov-on-fail --cov --create-db -vv
 
-  compatibility-tests-postgres-12:
-    name: "Compatibility tests"
-    uses: ./.github/workflows/compatibility-tests.yml
-    needs: [lint]
-    with:
-      postgres: "12"
-
   compatibility-tests-postgres-13:
     name: "Compatibility tests"
     uses: ./.github/workflows/compatibility-tests.yml
@@ -159,3 +152,10 @@ jobs:
     needs: [lint]
     with:
       postgres: "16"
+
+  compatibility-tests-postgres-17:
+    name: "Compatibility tests"
+    uses: ./.github/workflows/compatibility-tests.yml
+    needs: [lint]
+    with:
+      postgres: "17"


### PR DESCRIPTION
Python version 3.9 and PostgreSQL 12 are being deprecated. In their place, start testing with Python 3.13 and PostgreSQL 17