### PR TITLE
 chore(ci): update minimal python version in github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "poetry"
 
       - name: Set UID
@@ -108,7 +108,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "poetry"
 
       - name: Set UID


### PR DESCRIPTION
I believe this version should be updated accordingly to https://github.com/projectcaluma/caluma/pull/2393