### PR TITLE
fix(jexl): remove whitespace in stringify transform

### DIFF
--- a/caluma/caluma_core/jexl.py
+++ b/caluma/caluma_core/jexl.py
@@ -73,7 +73,13 @@ class JEXL(pyjexl.JEXL):
         self._expr_stack = []
 
         self.add_transform("mapby", self._mapby_transform)
-        self.add_transform("stringify", lambda obj: json.dumps(obj))
+        self.add_transform(
+            "stringify",
+            # Eliminate whitespace through the json.dumps separators parameter
+            # to ensure the stringify transform result is the same in caluma
+            # and ember-caluma
+            lambda obj: json.dumps(obj, separators=(",", ":")),
+        )
         self.add_transform("flatten", self._flatten_transform)
         self.add_transform("length", self._length_transform)
         self.add_binary_operator(


### PR DESCRIPTION
Remove whitespace in the result of stringify transform to ensure that the result of the stringify transform in caluma corresponds to the stringify transform in ember-caluma. The JSON.stringify method on an array doesn't include any whitespaces, while json.dumps of an array includes whitespaces between the elements by default, which leads to issues when comparing the result with values in a jexl. This can be set through the separators parameter in the json.dumps method.