### PR TITLE
chore(release): v12.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v12.2.2 (25 September 2025)
+
+### Fix
+
+* **jexl:** Remove whitespace in stringify transform ([`dd44dd8`](https://github.com/projectcaluma/caluma/commit/dd44dd84d230a7b9b61e6fcc608ad5ab85f21f80))
+
+### Documentation
+
+* **format-validators:** Add missing question argument to docstring ([`25fbcb7`](https://github.com/projectcaluma/caluma/commit/25fbcb7504d721a4c44cff3949a4a99dee18b09d))
+
 # v12.2.1 (12 September 2025)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "caluma"
-version = "12.2.1"
+version = "12.2.2"
 description = "Caluma Service providing GraphQL API"
 homepage = "https://caluma.io"
 repository = "https://github.com/projectcaluma/caluma"


### PR DESCRIPTION
Contains a fix that makes JEXL behave a little more consistent between frontend and backend (#2489) + some documentation/docstring fix (#2483).