### PR TITLE
docs: update release procedure in maintainer instructions

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -2,20 +2,32 @@
 
 ## Make a new release
 
-We're using `python-semantic-release` to generate a changelog and suggest the next version.
+We use `python-semantic-release` to generate a changelog and suggest the next version. Ensure it is installed before following the steps below:
 
-1. Checkout `main` branch, ensure you have all tags
-2. Figure out the next version
-3. Update code (CHANGELOG, version info)
-4. Pull Request with the version bump.
-5. Create tag and release on the merge commit with the changelog
+    poetry install
 
-```bash
-# Ensure you're on the current `main` branch and have all release tags
-git checkout main
-git pull origin --tags
-# Figure out the next version
-poetry run semantic-release version --noop
-# Prepare changelog
-poetry run semantic-release changelog --noop --unreleased
-```
+**Note**: For the following instructions, we assume that the main Caluma repository is the `origin` remote and `main` is set up to track that remote's `main` branch. Please adapt the commands as necessary if your local setup differs.
+
+1. Check out the latest `main` branch and ensure you have all the tags:
+   ```
+   git checkout main
+   git pull origin --tags
+   ```
+2. Determine the next version:
+   ```
+   poetry run semantic-release version --noop
+   ```
+3. Generate the changelog entries:
+   ```
+   poetry run semantic-release changelog --noop --unreleased
+   ```
+4. Update `CHANGELOG.md` and `pyproject.toml` with the information determined above.
+5. Create a GitHub Pull Request with the changes.
+6. After the PR is merged, pull from the remote, tag the merge commit, and push it back to GitHub:
+   ```
+   git pull origin
+   git tag vXX.X.X
+   git push --tags
+   ```
+7. Create a new release on GitHub (*Releases* › *Draft a new release*), and reuse the changelog text generated above for the release description.
+    - Note: If you want a review of the release notes, you may save the release as a draft, to be published later.


### PR DESCRIPTION
Unify to one list of instructions, add missing information or more details for some of the steps.