### PR TITLE
fix(minio): add endpoint as as parameter keyword since its now required

### DIFF
--- a/caluma/caluma_form/storage_clients.py
+++ b/caluma/caluma_form/storage_clients.py
@@ -62,7 +62,7 @@ class Minio:
                 ),
             )
         self.client = minio.Minio(
-            endpoint,
+            endpoint=endpoint,
             access_key=access_key,
             secret_key=secret_key,
             secure=secure,


### PR DESCRIPTION
Since the minio release 7.2.19 the `endpoint` parameter is now required: https://github.com/minio/minio-py/issues/1532