### PR TITLE
Validation graph improvements and fixes

### DIFF
--- a/caluma/caluma_form/schema.py
+++ b/caluma/caluma_form/schema.py
@@ -25,7 +25,7 @@ from ..caluma_data_source.data_source_handlers import get_data_source_data
 from ..caluma_data_source.schema import DataSourceDataConnection
 from . import filters, models, serializers
 from .format_validators import get_format_validators
-from .validators import get_document_validity
+from .validators import get_validity
 
 
 def resolve_answer(answer):
@@ -1179,7 +1179,7 @@ class ValidationEntry(ObjectType):
 
 
 class ValidationResult(ObjectType):
-    id = graphene.ID(description="References the document ID")
+    id = graphene.ID(description="References the document or answer ID")
 
     is_valid = graphene.Boolean()
     errors = graphene.List(ValidationEntry)
@@ -1190,13 +1190,17 @@ class DocumentValidityConnection(CountableConnectionBase):
         node = ValidationResult
 
 
-def validate_document(info, document_global_id, **kwargs):
-    document_id = extract_global_id(document_global_id)
+class AnswerValidityConnection(CountableConnectionBase):
+    class Meta:
+        node = ValidationResult
 
-    document_qs = Document.get_queryset(models.Document.objects.all(), info)
 
-    document = get_object_or_404(document_qs, pk=document_id)
-    result = get_document_validity(document, info.context.user, **kwargs)
+def validate(qs, info, global_id, **kwargs):
+    result = get_validity(
+        get_object_or_404(qs, pk=extract_global_id(global_id)),
+        info.context.user,
+        **kwargs,
+    )
 
     errors = result.pop("errors")
     result = ValidationResult(
@@ -1243,11 +1247,30 @@ class Query:
         data_source_context=graphene.JSONString(),
     )
 
+    answer_validity = ConnectionField(
+        DocumentValidityConnection,
+        id=graphene.ID(required=True),
+        data_source_context=graphene.JSONString(),
+    )
+
     def resolve_all_format_validators(self, info, **kwargs):
         return get_format_validators()
 
     def resolve_document_validity(self, info, id, **kwargs):
-        return validate_document(info, id, **kwargs)
+        return validate(
+            Document.get_queryset(models.Document.objects.all(), info),
+            info,
+            id,
+            **kwargs,
+        )
+
+    def resolve_answer_validity(self, info, id, **kwargs):
+        return validate(
+            Answer.get_queryset(models.Answer.objects.all(), info),
+            info,
+            id,
+            **kwargs,
+        )
 
 
 QUESTION_ANSWER_TYPES = {

--- a/caluma/caluma_form/tests/test_answer.py
+++ b/caluma/caluma_form/tests/test_answer.py
@@ -583,3 +583,53 @@ def test_modify_changed_choice_answer(
         answer.modify_changed_choice_answer(question, old_slug, new_slug, answer_value)
         == expected
     )
+
+
+@pytest.mark.parametrize("is_valid", [True, False])
+def test_answer_validity(
+    db,
+    document,
+    form_question_factory,
+    form,
+    schema_executor,
+    is_valid,
+):
+    question = form_question_factory(
+        form=form,
+        question__type=Question.TYPE_TEXT,
+        question__is_required="true",
+        question__format_validators=["email"],
+    ).question
+
+    value = "test@test.com" if is_valid else "test.com"
+    answer = document.answers.create(question=question, value=value)
+
+    query = """
+        query($id: ID!) {
+          answerValidity(id: $id) {
+            edges {
+              node {
+                id
+                isValid
+                errors {
+                  slug
+                  errorMsg
+                  errorCode
+                  documentId
+                }
+              }
+            }
+          }
+        }
+    """
+
+    result = schema_executor(query, variable_values={"id": str(answer.id)})
+
+    # if is_valid, we expect 0 errors, otherwise one
+    num_errors = int(not is_valid)
+
+    validity = result.data["answerValidity"]["edges"][0]["node"]
+
+    assert validity["id"] == str(answer.id)
+    assert validity["isValid"] == is_valid
+    assert len(validity["errors"]) == num_errors

--- a/caluma/caluma_form/tests/test_document.py
+++ b/caluma/caluma_form/tests/test_document.py
@@ -1851,3 +1851,83 @@ def test_efficient_init_of_calc_questions(
 
     calc_ans = document.answers.get(question_id="calc-2")
     assert calc_ans.value == 2
+
+
+@pytest.mark.parametrize("is_valid", [True, False])
+def test_validity_query_table(
+    db,
+    document,
+    document_factory,
+    form_question_factory,
+    form_factory,
+    form,
+    is_valid,
+    schema_executor,
+    settings,
+):
+    settings.DATA_SOURCE_CLASSES = [
+        "caluma.caluma_data_source.tests.data_sources.MyDataSource"
+    ]
+
+    root_question = form_question_factory(
+        form=form,
+        question__slug="root-question",
+        question__type=Question.TYPE_TEXT,
+    ).question
+
+    table_question = form_question_factory(
+        form=form,
+        question__type=Question.TYPE_TABLE,
+        question__is_required="true",
+        question__row_form=form_factory(),
+    ).question
+
+    row_question = form_question_factory(
+        form=table_question.row_form,
+        question__type=Question.TYPE_TEXT,
+        question__is_required="'root-question'|answer == 'require-table'",
+    ).question
+
+    document.form = form
+    document.save()
+
+    document.answers.create(
+        question=root_question,
+        value="dont-require-table" if is_valid else "require-table",
+    )
+
+    table_document = document_factory(form=table_question.row_form, family=document)
+    table_document.answers.create(question=row_question, value=None)
+
+    table_answer = document.answers.create(question=table_question)
+    table_answer.documents.add(table_document)
+
+    query = """
+        query($id: ID!) {
+          documentValidity(id: $id) {
+            edges {
+              node {
+                id
+                isValid
+                errors {
+                  slug
+                  errorMsg
+                  errorCode
+                  documentId
+                }
+              }
+            }
+          }
+        }
+    """
+
+    result = schema_executor(query, variable_values={"id": str(table_document.id)})
+
+    # if is_valid, we expect 0 errors, otherwise one
+    num_errors = int(not is_valid)
+
+    validity = result.data["documentValidity"]["edges"][0]["node"]
+
+    assert validity["id"] == str(table_document.id)
+    assert validity["isValid"] == is_valid
+    assert len(validity["errors"]) == num_errors

--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -1,5 +1,6 @@
 import sys
 from datetime import date
+from functools import singledispatch
 from logging import getLogger
 
 from django_filters.constants import EMPTY_VALUES
@@ -522,13 +523,12 @@ class QuestionValidator:
             self._validate_data_source(data["dataSource"])
 
 
-def get_document_validity(document, user, **kwargs):
-    validator = DocumentValidator()
+def run_validation(validation_fn, *args, **kwargs):
     is_valid = True
     errors = []
 
     try:
-        validator.validate(document, user, **kwargs)
+        validation_fn(*args, **kwargs)
     except CustomValidationError as exc:
         is_valid = False
         detail = exc.detail[0]
@@ -542,4 +542,36 @@ def get_document_validity(document, user, **kwargs):
             for slug in exc.slugs
         ]
 
+    return is_valid, errors
+
+
+@singledispatch
+def get_validity():  # pragma: no cover
+    raise NotImplementedError()
+
+
+@get_validity.register(models.Document)
+def _(document, user, **kwargs):
+    is_valid, errors = run_validation(
+        DocumentValidator().validate,
+        document=document,
+        user=user,
+        **kwargs,
+    )
+
     return {"id": document.id, "is_valid": is_valid, "errors": errors}
+
+
+@get_validity.register(models.Answer)
+def _(answer, user, **kwargs):
+    is_valid, errors = run_validation(
+        AnswerValidator().validate,
+        document=answer.document,
+        question=answer.question,
+        value=answer.value,
+        documents=answer.documents.all(),
+        user=user,
+        **kwargs,
+    )
+
+    return {"id": answer.id, "is_valid": is_valid, "errors": errors}

--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -552,10 +552,14 @@ def get_validity():  # pragma: no cover
 
 @get_validity.register(models.Document)
 def _(document, user, **kwargs):
+    validator = DocumentValidator()
+    validation_context = validator.get_validation_context(document.family)
+
     is_valid, errors = run_validation(
-        DocumentValidator().validate,
+        validator.validate,
         document=document,
         user=user,
+        validation_context=validation_context,
         **kwargs,
     )
 
@@ -564,6 +568,10 @@ def _(document, user, **kwargs):
 
 @get_validity.register(models.Answer)
 def _(answer, user, **kwargs):
+    validation_context = DocumentValidator().get_validation_context(
+        answer.document.family
+    )
+
     is_valid, errors = run_validation(
         AnswerValidator().validate,
         document=answer.document,
@@ -571,6 +579,7 @@ def _(answer, user, **kwargs):
         value=answer.value,
         documents=answer.documents.all(),
         user=user,
+        validation_context=validation_context,
         **kwargs,
     )
 

--- a/caluma/tests/__snapshots__/test_schema.ambr
+++ b/caluma/tests/__snapshots__/test_schema.ambr
@@ -1946,6 +1946,7 @@
     allFormatValidators(before: String, after: String, first: Int, last: Int): FormatValidatorConnection
     allUsedDynamicOptions(offset: Int, before: String, after: String, first: Int, last: Int, filter: [DynamicOptionFilterSetType], order: [DynamicOptionOrderSetType]): DynamicOptionConnection
     documentValidity(id: ID!, dataSourceContext: JSONString, before: String, after: String, first: Int, last: Int): DocumentValidityConnection
+    answerValidity(id: ID!, dataSourceContext: JSONString, before: String, after: String, first: Int, last: Int): DocumentValidityConnection
     node(
       """The ID of the object"""
       id: ID!
@@ -3444,7 +3445,7 @@
   }
   
   type ValidationResult {
-    """References the document ID"""
+    """References the document or answer ID"""
     id: ID
     isValid: Boolean
     errors: [ValidationEntry]


### PR DESCRIPTION
- **feat(validation): add graph to validate a single answer**
  This will mainly be used in the frontend to validate questions using format validators as those can't be validated in the frontend.
- **fix(validation): make sure validity graphs pass full context**
  When validating a table row document, the validation was only scoped to that specific document. This lead to errors when a question in that document referenced to other questions in the root document.