### PR TITLE
fix(validation): fix date and files answer validation

### DIFF
--- a/caluma/caluma_form/tests/test_validators.py
+++ b/caluma/caluma_form/tests/test_validators.py
@@ -1,3 +1,5 @@
+import datetime
+
 import minio
 import pytest
 from rest_framework.exceptions import ValidationError
@@ -839,3 +841,57 @@ def test_validate_options_without_jexl(
         api.save_answer(fq.question, document, value=options[3].option_id)
 
     assert spy.call_count == expect_jexl_evaluations
+
+
+@pytest.mark.parametrize("question__is_required", ["false"])
+@pytest.mark.parametrize(
+    "question__type,method_name",
+    [
+        (Question.TYPE_DATE, "_validate_question_date"),
+        (Question.TYPE_TABLE, "_validate_question_table"),
+        (Question.TYPE_FILES, "_validate_question_files"),
+    ],
+)
+def test_validate_custom_value_field(
+    db,
+    admin_user,
+    answer,
+    document_factory,
+    document,
+    file_factory,
+    form_question,
+    method_name,
+    mocker,
+    question,
+):
+    """Test that question types using other fields than `value` are validated.
+
+    This test makes sure that question types using another property (e.g. date
+    questions using `date`) to get the value are being validated properly and
+    are not wrongly interpreted as empty since the `value` property is `None`.
+    """
+
+    validate_fn = mocker.patch(
+        f"caluma.caluma_form.validators.AnswerValidator.{method_name}"
+    )
+
+    date = None
+    files = []
+    documents = []
+
+    if question.type == Question.TYPE_DATE:
+        date = datetime.date(2026, 5, 7)
+    elif question.type == Question.TYPE_TABLE:
+        documents = document_factory.create_batch(2)
+    elif question.type == Question.TYPE_FILES:
+        files = file_factory.create_batch(2)
+
+    answer.value = None
+    answer.date = date
+    answer.documents.set(documents)
+    answer.files.set(files)
+    answer.save()
+
+    DocumentValidator().validate(document, admin_user)
+
+    assert validate_fn.call_count == 1

--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -297,12 +297,17 @@ class AnswerValidator:
         data_source_context=None,
         **kwargs,
     ):
-        # Check all possible fields for value
-        value = None
-        for i in ["documents", "files", "date", "value"]:
-            value = kwargs.get(i, value)
-            if value:
-                break
+        # Get value from kwargs depending on the question type
+        if question.type == Question.TYPE_DATE:
+            value = kwargs["date"]
+        elif question.type == Question.TYPE_TABLE:
+            documents = kwargs["documents"]
+            value = list(documents) if documents else None
+        elif question.type == Question.TYPE_FILES:
+            files = kwargs["files"]
+            value = list(files) if files else None
+        else:
+            value = kwargs["value"]
 
         # empty values are allowed
         # required check will be done in DocumentValidator
@@ -386,7 +391,9 @@ class DocumentValidator:
                     document=field.answer.document,
                     question=field.question,
                     value=field.answer.value,
+                    date=field.answer.date,
                     documents=field.answer.documents.all(),
+                    files=field.answer.files.all(),
                     user=user,
                     validation_context=field,
                     data_source_context=data_source_context,


### PR DESCRIPTION
When validating a whole document, answers of the type date or files were not being validated as their value (from a custom property) was not passed by the document validator.