### PR TITLE
perf(form): recalculate only once in table rows

### DIFF
--- a/caluma/caluma_form/domain_logic.py
+++ b/caluma/caluma_form/domain_logic.py
@@ -199,6 +199,8 @@ class SaveAnswerLogic:
                 ):
                     recalculate_field(child)
 
+        field_rowset = field.get_containing_rowset()
+
         for dep_slug in field.question.calc_dependents or []:
             # ... maybe this is enough? Cause this will find the closest "match",
             # going only to the outer context from a table if the field is not found
@@ -208,12 +210,25 @@ class SaveAnswerLogic:
                 # a table row, so there could be multiple of them, all needing to
                 # be updated because of "our" change
 
-                log.debug(
-                    "update_calc_dependents(%s): updating question %s",
-                    answer,
-                    dep_field.question.pk,
-                )
-                recalculate_field(dep_field)
+                # If the changed field, and the dependent are both inside a table,
+                # then we only need to update the dependent inside the same row
+                dep_field_rowset = dep_field.get_containing_rowset()
+
+                both_are_tables = field_rowset and dep_field_rowset
+                same_table = field_rowset == dep_field_rowset
+                same_row = dep_field.parent is field.parent
+
+                # need_recalc is only False exactly if both are in the same
+                # table, but not the same row
+                need_recalc = not (both_are_tables and same_table and not same_row)
+
+                if need_recalc:
+                    log.debug(
+                        "update_calc_dependents(%s): updating question %s",
+                        answer,
+                        dep_field.question.pk,
+                    )
+                    recalculate_field(dep_field)
 
     @classmethod
     @transaction.atomic

--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -357,6 +357,20 @@ class BaseField(ABC):
         return FastLoader.for_document(document)
 
     @object_local_memoise
+    def get_containing_rowset(self) -> RowSet | None:
+        """
+        Check if field is part of a table and return the containing rowset if true.
+
+        If the field is not part of a table, return None.
+        """
+        p = self
+        while p:
+            p = p.parent
+            if isinstance(p, RowSet):
+                return p
+        return None
+
+    @object_local_memoise
     def get_evaluator(self) -> QuestionJexl:
         """Return the JEXL evaluator for this field."""
 

--- a/caluma/caluma_form/tests/test_recalculate_calc_answers_command.py
+++ b/caluma/caluma_form/tests/test_recalculate_calc_answers_command.py
@@ -1,7 +1,9 @@
 import os
 
+import pytest
 from django.core.management import call_command
 
+from caluma.caluma_form import structure
 from caluma.caluma_form.api import save_answer, save_document
 from caluma.caluma_form.models import Question
 
@@ -74,3 +76,78 @@ def test_recalculate_calc_answers(
     # assert correct calc_value after migration
     calc_answer.refresh_from_db()
     assert calc_answer.value == 23
+
+
+@pytest.mark.django_db
+def test_recalculate_sibling_rows_in_table(form_factory, form_question_factory, caplog):
+
+    root_form = form_factory(slug="root")
+    row_form = form_factory(slug="row")
+
+    table_q = form_question_factory(
+        form=root_form,
+        question__type=Question.TYPE_TABLE,
+        question__slug="table",
+        question__row_form=row_form,
+    ).question
+
+    column1 = form_question_factory(
+        form=row_form,
+        question__type=Question.TYPE_INTEGER,
+        question__slug="col1",
+        sort=2,
+    ).question
+
+    column2 = form_question_factory(
+        form=row_form,
+        question__slug="col2",
+        question__type=Question.TYPE_CALCULATED_FLOAT,
+        question__calc_expression=f"'{column1}'|answer * 2",
+        sort=1,
+    ).question
+    row_form.refresh_from_db()
+
+    # Just to make sure ...
+    column1.refresh_from_db()
+    assert column1.calc_dependents == [column2.slug]
+
+    main_doc = save_document(form=root_form)
+    row0doc = save_document(form=row_form)
+    row1doc = save_document(form=row_form)
+
+    save_answer(question=table_q, document=main_doc, value=[row0doc.pk, row1doc.pk])
+    row0doc.refresh_from_db()
+    row1doc.refresh_from_db()
+    assert row0doc.family == main_doc
+    assert row1doc.family == main_doc
+
+    save_answer(question=column1, value=10, document=row0doc)
+    save_answer(question=column1, value=20, document=row1doc)
+
+    main_doc.refresh_from_db()
+
+    # Ensure (more for us devs) that we got the right structure
+    assert structure.list_document_structure(main_doc) == [
+        " FieldSet(root)",
+        "    RowSet(row)",
+        "       FieldSet(row)",
+        "          Field(col1, 10)",
+        "          Field(col2, 20)",
+        "       FieldSet(row)",
+        "          Field(col1, 20)",
+        "          Field(col2, 40)",
+    ]
+
+    caplog.clear()
+    with caplog.at_level("DEBUG"):
+        save_answer(question=column1, value=99, document=row1doc)
+
+    # col2 should only be updated once
+    update_msgs = [msg for msg in caplog.messages if "updating question col2" in msg]
+    assert len(update_msgs) == 1
+
+    # Check for correct recalculation
+    row0col2 = row0doc.answers.get(question=column2)
+    row1col2 = row1doc.answers.get(question=column2)
+    assert row0col2.value == 20  # 2*10
+    assert row1col2.value == 198  # 99*2


### PR DESCRIPTION
When updating a calcualted value inside a table, we must take extra care to only update when needed, as this can have compounding effects and slow down recalculation significantly.

We must avoid recalculation if a dependency of a calculation, as well as the calc field itself, are inside the same table, but in a different row.