### PR TITLE
fix(jexl): respect default value in answer transform for hidden fields

### DIFF
--- a/caluma/caluma_form/jexl.py
+++ b/caluma/caluma_form/jexl.py
@@ -66,12 +66,7 @@ class QuestionJexl(JEXL):
                     f"Question `{question_slug}` could not be found in form {self.field.get_form()}"
                 )
 
-        if field.is_hidden():
-            # Hidden fields *always* return the empty value, even if we have
-            # a default
-            return field.question.empty_value()
-        elif field.is_empty():
-            # not hidden, but empty
+        if field.is_hidden() or field.is_empty():
             return _default_or_empty()
 
         return field.get_value()

--- a/caluma/caluma_form/tests/test_jexl.py
+++ b/caluma/caluma_form/tests/test_jexl.py
@@ -729,3 +729,43 @@ def test_jexl_context(form_and_document, snapshot):
         ("cell_question", struct.get_field("table").children()[0].get_field("column")),
     ]:
         assert snapshot(name=name) == dict(field.get_evaluator().context.data)
+
+
+@pytest.mark.parametrize(
+    ("dep_is_hidden", "dep_value", "expected_value"),
+    [
+        (True, None, 2),
+        (False, None, 2),
+        (False, 2, 4),
+    ],
+)
+@pytest.mark.django_db
+def test_calc_expression_default_value(
+    form,
+    dep_value,
+    dep_is_hidden,
+    expected_value,
+    form_and_document,
+    form_question_factory,
+    answer_factory,
+):
+    form, document, questions, answers = form_and_document(
+        use_table=True, use_subform=True
+    )
+
+    dep = form_question_factory(
+        form=form,
+        question__slug="dep",
+        question__type=models.Question.TYPE_INTEGER,
+        question__is_hidden=str(dep_is_hidden).lower(),
+    ).question
+    calc = form_question_factory(
+        form=form,
+        question__slug="calc",
+        question__type=models.Question.TYPE_CALCULATED_FLOAT,
+        question__calc_expression="'dep'|answer(1) * 2",
+    ).question
+
+    answer_factory(document=document, question=dep, value=dep_value)
+
+    assert structure.FieldSet(document).get_field(calc.pk).calculate() == expected_value


### PR DESCRIPTION
Previously, the answer transform ignored any passed default value when the field was hidden, returning the empty value instead. Now hidden fields behave the same as empty fields and fall back to the default when one is given.

This matches the frontend, which already uses the passed default for the same case, and is what users expect.

https://github.com/projectcaluma/ember-caluma/blob/d1165a89a67a4d57baa2fb90bb23cc9ac15d8074/packages/form/addon/lib/document.js#L287-L323