### PR TITLE
perf(form): improve calculated-question performance significantly

### DIFF
--- a/caluma/caluma_form/calc_questions.py
+++ b/caluma/caluma_form/calc_questions.py
@@ -1,0 +1,273 @@
+import time
+from collections import defaultdict
+from graphlib import TopologicalSorter
+from logging import getLogger
+from typing import Self
+
+from caluma.caluma_form import models, structure, validators
+from caluma.caluma_form.jexl import QuestionJexl
+
+log = getLogger(__name__)
+
+
+def update_calc_dependents(slug, old_expr, new_expr):
+    """Update the calc_dependents lists of our calc *dependencies*.
+
+    The given (old and new) expressions are analyzed to see which
+    questions are referenced in "our" calc question. Then, those
+    questions' calc_dependents list is updated, such that it correctly
+    represents the new situation.
+
+    Example: If our expression newly contains the question `foo`, then the
+    `foo` question needs to know about it (we add "our" slug to the `foo`s
+    calc dependents)
+    """
+    jexl = QuestionJexl(field=None)
+    old_q = set(
+        list(jexl.extract_referenced_questions(old_expr))
+        + list(jexl.extract_referenced_mapby_questions(old_expr))
+    )
+    new_q = set(
+        list(jexl.extract_referenced_questions(new_expr))
+        + list(jexl.extract_referenced_mapby_questions(new_expr))
+    )
+
+    to_add = new_q - old_q
+    to_remove = old_q - new_q
+
+    questions = models.Question.objects.filter(pk__in=list(to_add | to_remove))
+
+    for question in questions:
+        deps = set(question.calc_dependents)
+        if question.slug in to_add:
+            deps.add(slug)
+        else:
+            deps.remove(slug)
+        question.calc_dependents = list(deps)
+        question.save()
+
+
+def recalculate_and_update_dependents(calc_field: structure.ValueField):
+    """Recalculate the given value field and store the new answer.
+
+    If it's not a calculated field, nothing happens.
+    """
+    if calc_field.question.type != models.Question.TYPE_CALCULATED_FLOAT:
+        return  # pragma: no cover
+
+    did_update = recalculate_field(calc_field)
+    if did_update:
+        recalculate_dependent_fields(calc_field)
+
+
+def recalculate_field(calc_field: structure.ValueField) -> bool:
+    """Recalculate the given value field and store the new answer.
+
+    If it's not a calculated field, nothing happens.
+
+    Unless you know what you're doing, you should probably use
+    `recalculate_and_update_dependents()` instead, as this variant
+    will not update any dependents of the calculated field.
+
+    Return True if an update happened, False otherwise.
+    For non-calculated fields, True is returned to ensure dependents are not culled.
+    """
+    if calc_field.question.type != models.Question.TYPE_CALCULATED_FLOAT:
+        # Not a calc field - skip
+        return True
+
+    start = time.time()
+
+    old_value = calc_field.get_value()
+    value = calc_field.calculate()
+
+    did_change = value != old_value
+
+    if did_change or not calc_field.answer:
+        # If the value changed, or we have no answer for the calc
+        # question: update the value
+        answer, _ = models.Answer.objects.update_or_create(
+            question=calc_field.question,
+            document=calc_field.parent._document,
+            defaults={"value": value},
+        )
+
+        # no need to refresh recursive - all subsequent dependents will be
+        # explicitly recalculated anyway, so we won't need to hit the DB
+        # and refresh them here (repeatedly)
+        calc_field.refresh(answer, recursive=False)
+    duration = time.time() - start
+
+    status = "updated value" if did_change else "did not change value"
+    log.debug(
+        "Recalculation(%s): took %1.3fs, %s", calc_field.get_path(), duration, status
+    )
+
+    return did_change
+
+
+class DependencyList(list):
+    def __init__(self, *changed_fields: structure.BaseField) -> Self:
+        """
+        Build a list of fields that need to be recalculated if the given field changes.
+
+        The list is collected in a way such that an iterative recalculation will
+        implicitly be correct, as the fields that need previous values are sorted
+        later in the list.
+        """
+
+        if not changed_fields:  # pragma: no cover
+            # Nothing to do
+            return
+
+        # field-id -> list[field-id] mapping
+        self._reasons: defaultdict[id, list[id]] = defaultdict(list)
+
+        self.struc = changed_fields[0].get_root()
+        self._roots = {id(f) for f in changed_fields}
+
+        assert all(f.get_root() is self.struc for f in changed_fields), (
+            "DependencyList can only deal with fields of the same structure"
+        )
+
+        dependencies = defaultdict(list)
+
+        # need a lookup table of id->field, as TopologicalSorter needs dict,
+        # and we can't hash the fields directly. So we're using their object IDs
+        # instead and translate between them
+        self._fields_by_id = {}
+
+        for field in changed_fields:
+            self._collect_field_deps(field, dependencies)
+
+        ts = TopologicalSorter(dependencies)
+
+        # TopologicalSorter expects the adjacency_list the "other way around", i.e.
+        # for every node the incoming nodes should be given. To account for this, we
+        # just reverse the resulting order.
+        id_queue = list(reversed(list(ts.static_order())))
+
+        # Fill the dependency list so our users can then run the recalculation
+        self.extend(self._fields_by_id[field_id] for field_id in id_queue)
+
+        # Store the reasons for the particular ordering
+        for field_id, dependents in dependencies.items():
+            for dep in dependents:
+                self._reasons[dep].append(field_id)
+
+    def _collect_field_deps(self, field, dependencies):
+        field_id = id(field)
+
+        if field_id in self._fields_by_id:
+            # Happens if it's already been collected via another path.
+            # Does not need to be collected anymore
+            return
+        self._fields_by_id[field_id] = field
+
+        # Ensure the field is registered in the dependency graph, even if it has no
+        # dependents. Required for TopologicalSorter to include it in the sort.
+        dependencies.setdefault(field_id, [])
+
+        for dep_slug in field.question.calc_dependents:
+            for dep_field in self.struc.find_all_fields_by_slug(dep_slug):
+                dep_field_id = id(dep_field)
+                dependencies[field_id].append(dep_field_id)
+
+                self._collect_field_deps(dep_field, dependencies)
+
+        if isinstance(field, (structure.RowSet, structure.FieldSet)):
+            # if the changed field is a document or rowset, we need
+            # to recalculate everything that depends on it's children
+            # as well
+            for child in field.children():
+                self._collect_field_deps(child, dependencies)
+
+    def remove_reason_for(
+        self, field: structure.ValueField, to_remove: structure.ValueField
+    ):
+        """
+        Remove the given reason for recalculation from the given field.
+
+        If the reason for recalculation (the to_remove field) didn't change,
+        then that field is not a reason for recalculation anymore, and
+        recalculation might be skipped
+        """
+        self._reasons[id(field)].remove(id(to_remove))
+
+    def get_reason_for(self, field: structure.BaseField) -> list[structure.ValueField]:
+        """Return a list of fields that are the reason this given field needs recalc."""
+        reason_ids = self._reasons[id(field)]
+        return [self._fields_by_id[field_id] for field_id in reason_ids]
+
+    def perform_recalculation(self, allow_culling=True, recalculate_roots=True):
+        """Recalculate all fields in the associated structure.
+
+        If allow_culling is set to False, the "culling" optimisation is disabled:
+        It will stop recalculation if all inputs of a calculated question didn't change.
+
+        If recalculate_roots is set to False, the fields that were used to initialize
+        this DependencyList will not be recalculated. This is useful if they have
+        been recalculated already.
+        """
+        for field in self:
+            log.debug("Recalculating %s", field.get_path())
+            is_root = id(field) in self._roots
+            if allow_culling and not is_root and not self.get_reason_for(field):
+                # There is no reason (anymore) to recalculate this field,
+                # as none of the recalculations of the dependencies have changed
+                # their value
+                continue
+
+            if is_root and not recalculate_roots:
+                did_update = True
+            else:
+                did_update = recalculate_field(field)
+
+            if allow_culling and not did_update:
+                for dep_slug in field.question.calc_dependents:
+                    # remove field from reason that dep_slug needs to be recalculated
+                    dep_fields = self.struc.find_all_fields_by_slug(dep_slug)
+                    for dep_field in dep_fields:
+                        self.remove_reason_for(dep_field, field)
+
+
+def recalculate_dependent_fields(
+    *changed_fields: structure.BaseField, recalculate_roots: bool = False
+):
+    """Update any calculated dependencies of the given fields.
+
+    Iterate over all dependents, recursively, and recalculate them
+    in an optimized fashion.
+
+    :param changed_fields: The fields that have changed and trigger recalculation.
+    :param recalculate_roots: Whether to also recalculate the given changed_fields.
+    """
+    if not changed_fields:
+        return  # pragma: no cover
+
+    update_list = DependencyList(*changed_fields)
+    update_list.perform_recalculation(recalculate_roots=recalculate_roots)
+
+
+def recalculate_all_calc_fields(struc):
+    """Fully recalculate all the structure's calculated fields.
+
+    Go through all calculated fields of the structure and update them
+    in an efficient manner.
+    """
+    calculated_fields = (
+        field
+        for field in struc.get_all_fields()
+        if field.question.type == models.Question.TYPE_CALCULATED_FLOAT
+    )
+    DependencyList(*calculated_fields).perform_recalculation()
+
+
+def update_or_create_calc_answer(question, document):
+    """Recalculate all answers in the document after calc dependency change."""
+
+    root = validators.DocumentValidator().get_validation_context(document.family)
+    fields_to_recalc = root.find_all_fields_by_slug(question.slug)
+    dependencies_to_recalc = DependencyList(*fields_to_recalc)
+
+    dependencies_to_recalc.perform_recalculation(allow_culling=False)

--- a/caluma/caluma_form/domain_logic.py
+++ b/caluma/caluma_form/domain_logic.py
@@ -1,4 +1,3 @@
-from graphlib import TopologicalSorter
 from logging import getLogger
 from typing import Optional
 
@@ -10,7 +9,10 @@ from caluma.caluma_core.exceptions import ConfigurationError
 from caluma.caluma_core.models import BaseModel
 from caluma.caluma_core.relay import extract_global_id
 from caluma.caluma_form import models, validators
-from caluma.caluma_form.utils import recalculate_field
+from caluma.caluma_form.calc_questions import (
+    recalculate_all_calc_fields,
+    recalculate_dependent_fields,
+)
 from caluma.caluma_user.models import BaseUser
 from caluma.utils import update_model
 
@@ -188,47 +190,19 @@ class SaveAnswerLogic:
                 "Saved an answer in a form structure where it doesn't belong: "
                 f"question={answer.question_id}, root form={struc.get_root().get_form().slug}",
             )
-        if is_table:
-            # We treat all children of the table as "changed"
-            # Find all children, and if any are of type calc (and are in the "created"
-            # update info bit), recalculate them.
-            for child in field.get_all_fields():
-                if (
-                    child.question.type == models.Question.TYPE_CALCULATED_FLOAT
-                    and child.parent._document.pk in update_info["created"]
-                ):
-                    recalculate_field(child)
 
-        field_rowset = field.get_containing_rowset()
+        roots = [field]
+        if is_table and update_info.get("created"):
+            # New rows might have calculated fields depending on fields outside
+            # the table. Make sure we catch them as well
+            created_ids = set(update_info["created"])
+            for row in field.children():
+                if row._document.pk in created_ids:
+                    for child in row.get_all_fields():
+                        if child.question.type == models.Question.TYPE_CALCULATED_FLOAT:
+                            roots.append(child)
 
-        for dep_slug in field.question.calc_dependents or []:
-            # ... maybe this is enough? Cause this will find the closest "match",
-            # going only to the outer context from a table if the field is not found
-            # inside of it
-            for dep_field in struc.find_all_fields_by_slug(dep_slug):
-                # Need to iterate, because a calc question could reside *inside*
-                # a table row, so there could be multiple of them, all needing to
-                # be updated because of "our" change
-
-                # If the changed field, and the dependent are both inside a table,
-                # then we only need to update the dependent inside the same row
-                dep_field_rowset = dep_field.get_containing_rowset()
-
-                both_are_tables = field_rowset and dep_field_rowset
-                same_table = field_rowset == dep_field_rowset
-                same_row = dep_field.parent is field.parent
-
-                # need_recalc is only False exactly if both are in the same
-                # table, but not the same row
-                need_recalc = not (both_are_tables and same_table and not same_row)
-
-                if need_recalc:
-                    log.debug(
-                        "update_calc_dependents(%s): updating question %s",
-                        answer,
-                        dep_field.question.pk,
-                    )
-                    recalculate_field(dep_field)
+        recalculate_dependent_fields(*roots, recalculate_roots=True)
 
     @classmethod
     @transaction.atomic
@@ -365,39 +339,8 @@ class SaveDocumentLogic:
         document.meta.pop("_defer_calculation", None)
         document.save()
 
-        SaveDocumentLogic._initialize_calculated_answers(document)
-
-        return document
-
-    @staticmethod
-    def _initialize_calculated_answers(document):
-        """
-        Initialize all calculated questions in the document.
-
-        In order to do this efficiently, we get all calculated questions with
-        their dependents, sort them topoligically, and then update their answer.
-        """
         struc = validators.DocumentValidator().get_validation_context(document.family)
-
-        calculated_fields = (
-            field
-            for field in struc.get_all_fields()
-            if field.question.type == models.Question.TYPE_CALCULATED_FLOAT
-        )
-
-        adjacency_list = {
-            field.slug(): field.question.calc_dependents for field in calculated_fields
-        }
-        ts = TopologicalSorter(adjacency_list)
-        # TopologicalSorter expects the adjacency_list the "other way around", i.e.
-        # for every node the incoming nodes should be given. To account for this, we
-        # just reverse the resulting order.
-        sorted_question_slugs = list(reversed(list(ts.static_order())))
-
-        for slug in sorted_question_slugs:
-            print("question", slug)
-            for field in struc.find_all_fields_by_slug(slug):
-                recalculate_field(field, update_recursively=False)
+        recalculate_all_calc_fields(struc)
 
         return document
 

--- a/caluma/caluma_form/management/commands/recalculate_calc_answers.py
+++ b/caluma/caluma_form/management/commands/recalculate_calc_answers.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 
+from caluma.caluma_form.calc_questions import update_or_create_calc_answer
 from caluma.caluma_form.models import Answer, Question
-from caluma.caluma_form.utils import update_or_create_calc_answer
 
 
 class Command(BaseCommand):

--- a/caluma/caluma_form/signals.py
+++ b/caluma/caluma_form/signals.py
@@ -12,7 +12,13 @@ from caluma.caluma_core.events import filter_events
 from caluma.utils import disable_raw
 
 from . import models
-from .utils import update_calc_dependents, update_or_create_calc_answer
+from .calc_questions import (
+    update_calc_dependents,
+    update_or_create_calc_answer,
+)
+from .utils import (
+    forms_containing_question,
+)
 
 
 @receiver(pre_create_historical_record, sender=models.HistoricalAnswer)
@@ -103,11 +109,8 @@ def remove_calc_dependents(sender, instance, **kwargs):
 @filter_events(lambda instance: instance.type == models.Question.TYPE_CALCULATED_FLOAT)
 @filter_events(lambda instance: getattr(instance, "calc_expression_changed", False))
 def update_calc_from_question(sender, instance, created, update_fields, **kwargs):
-    # TODO: we need to find documents that contain this form as a subform
-    # as well. This would only find documents where the question is attached
-    # top-level.
-    for document in models.Document.objects.filter(form__questions=instance).iterator():
-        update_or_create_calc_answer(instance, document)
+
+    _recalculate_all_questions(instance)
 
 
 @receiver(post_save, sender=models.FormQuestion)
@@ -116,8 +119,18 @@ def update_calc_from_question(sender, instance, created, update_fields, **kwargs
     lambda instance: instance.question.type == models.Question.TYPE_CALCULATED_FLOAT
 )
 def update_calc_from_form_question(sender, instance, created, **kwargs):
-    # TODO: we need to find documents that contain this form as a subform
-    # as well. This would only find documents where the question is attached
-    # top-level.
-    for document in instance.form.documents.all().iterator():
-        update_or_create_calc_answer(instance.question, document)
+    _recalculate_all_questions(instance.question)
+
+
+def _recalculate_all_questions(question):
+    forms = forms_containing_question(question)
+    seen_family_ids = set()
+    for document in (
+        models.Document.objects.filter(form__in=forms)
+        .select_related("family")
+        .only("family")
+        .iterator()
+    ):
+        if document.family.pk not in seen_family_ids:
+            update_or_create_calc_answer(question, document.family)
+        seen_family_ids.add(document.family.pk)

--- a/caluma/caluma_form/structure.py
+++ b/caluma/caluma_form/structure.py
@@ -357,20 +357,6 @@ class BaseField(ABC):
         return FastLoader.for_document(document)
 
     @object_local_memoise
-    def get_containing_rowset(self) -> RowSet | None:
-        """
-        Check if field is part of a table and return the containing rowset if true.
-
-        If the field is not part of a table, return None.
-        """
-        p = self
-        while p:
-            p = p.parent
-            if isinstance(p, RowSet):
-                return p
-        return None
-
-    @object_local_memoise
     def get_evaluator(self) -> QuestionJexl:
         """Return the JEXL evaluator for this field."""
 
@@ -561,7 +547,7 @@ class BaseField(ABC):
                 return fld
         return None
 
-    def refresh(self, answer=None):
+    def refresh(self, answer=None, recursive=True):
         """Refresh this field's answer.
 
         If an answer is given, use it and update the structure in-place.
@@ -572,6 +558,12 @@ class BaseField(ABC):
 
         Note: Saving the answer is the caller's responsibility, we only
         update the structure in-memory.
+
+        By default, this will also refresh all calculated questions that
+        depend on this field. If you know what you're doing, you can speed
+        things up by passing `recursive=False` here. It is then your
+        responsibility to refresh / recalculate any dependents as needed to
+        keep the structure in a consistent state.
         """
         if answer:
             self.answer = answer
@@ -583,6 +575,8 @@ class BaseField(ABC):
             ).first()
 
         clear_memoise(self)
+        if not recursive:
+            return
         for dep in self._fastloader.dependents_of_question(self.slug()):
             for dep_field in self.get_root().find_all_fields_by_slug(dep):
                 dep_field.refresh()
@@ -610,13 +604,13 @@ class BaseField(ABC):
         except exceptions.QuestionMissing:
             raise
         except Exception as exc:
-            log.error(
-                f"Error while evaluating expression on question {self.slug()}: "
+            log.debug(
+                f"Error while evaluating expression on question {self.get_path()}: "
                 f"{expression!r}: {str(exc)}"
             )
             if raise_on_error:
                 raise RuntimeError(
-                    f"Error while evaluating expression on question {self.slug()}: "
+                    f"Error while evaluating expression on question {self.get_path()}: "
                     f"{expression!r}. The system log contains more information"
                 )
             # return None is implied
@@ -634,7 +628,7 @@ class BaseField(ABC):
         parent_form = self.parent.form if self.parent else None
         return parent_form or self.form or None
 
-    def get_path(self):  # pragma: no cover
+    def get_path(self):
         """Return a path to the current field.
 
         The path is a human-readable path to the current field, starting from
@@ -643,10 +637,15 @@ class BaseField(ABC):
 
         # This is mainly for debugging
         if not self.parent:
-            return "(root)"
+            # root fieldset, return form slug
+            return f"({self.form.slug})"
+        # special case: if parent is a rowset, inject the row number
+        row_idx = ""
+        if isinstance(self.parent, RowSet) and self.rownum is not None:
+            row_idx = f"[{self.rownum}]"
+
         ppath = self.parent.get_path()
-        typeinfo = type(self).__name__[0]
-        return f"{ppath} -> {typeinfo}:{self.slug()}"
+        return f"{ppath}{row_idx}.{self.slug()}"
 
 
 @dataclass
@@ -720,6 +719,8 @@ class ValueField(BaseField):
 
 
 class FieldSet(BaseField):
+    rownum: int | None = field(default=None)
+
     def __init__(
         self,
         document,
@@ -727,12 +728,12 @@ class FieldSet(BaseField):
         parent=None,
         question=None,
         global_context=None,
+        rownum=None,
         _fastloader=None,
     ):
-        # TODO: prefetch document once we have the structure built up
-        #
         self.question = question
         self._document = document
+        self.rownum = rownum
 
         self._fastloader = _fastloader or self._make_fastloader(document)
         self.form = form or self._fastloader.form_by_id(document.form_id)
@@ -875,12 +876,15 @@ class FieldSet(BaseField):
                 )
 
     def __str__(self):
-        return f"FieldSet({self.form.slug})"
+        rowinfo = f" #{self.rownum}" if self.rownum else ""
+
+        return f"FieldSet({self.form.slug}{rowinfo})"
 
     def __repr__(self):
         q_slug = self.question.slug if self.question else "(root)"
+        rowinfo = f", r={self.rownum}" if self.rownum else ""
 
-        return f"FieldSet(q={q_slug}, f={self.form.slug})"
+        return f"FieldSet(q={q_slug}, f={self.form.slug}{rowinfo})"
 
     def print_structure(self, print_fn=None, method=str):  # pragma: no cover
         """Print the structure as a hierarchical list of text.
@@ -928,9 +932,12 @@ class RowSet(BaseField):
                     form=self._fastloader.form_by_id(question.row_form_id),
                     parent=self,
                     global_context=self.get_global_context(),
+                    rownum=rownum,
                     _fastloader=self._fastloader,
                 )
-                for row_doc in self._fastloader.rows_for_table_answer(answer.pk)
+                for rownum, row_doc in enumerate(
+                    self._fastloader.rows_for_table_answer(answer.pk), start=1
+                )
             ]
         else:
             self.rows = []

--- a/caluma/caluma_form/tests/test_calc_questions.py
+++ b/caluma/caluma_form/tests/test_calc_questions.py
@@ -1,0 +1,119 @@
+import pytest
+
+from caluma.caluma_form import calc_questions, models, structure
+from caluma.caluma_form.api import save_answer
+
+
+@pytest.mark.django_db
+def test_recalculate_and_update_dependents(
+    form_factory, form_question_factory, document_factory, answer_factory
+):
+    """Test recalculate_and_update_dependents utility."""
+    form = form_factory(slug="calc_test")
+
+    q_a = form_question_factory(
+        form=form, question__type=models.Question.TYPE_INTEGER, question__slug="q_a"
+    ).question
+
+    q_b = form_question_factory(
+        form=form,
+        question__type=models.Question.TYPE_CALCULATED_FLOAT,
+        question__slug="q_b",
+        question__calc_expression=f"'{q_a.slug}'|answer * 2",
+    ).question
+
+    q_c = form_question_factory(
+        form=form,
+        question__type=models.Question.TYPE_CALCULATED_FLOAT,
+        question__slug="q_c",
+        question__calc_expression=f"'{q_b.slug}'|answer * 2",
+    ).question
+
+    # Refresh to ensure calc_dependents are set
+    q_a.refresh_from_db()
+    q_b.refresh_from_db()
+    assert q_b.slug in q_a.calc_dependents
+    assert q_c.slug in q_b.calc_dependents
+
+    doc = document_factory(form=form)
+    save_answer(question=q_a, document=doc, value=10)
+
+    root = structure.FieldSet(doc)
+    field_a = root.get_field(q_a.slug)
+    field_b = root.get_field(q_b.slug)
+    field_c = root.get_field(q_c.slug)
+
+    # Refresh A in the structure to ensure B and C are also refreshed
+    field_a.refresh()
+
+    # Force recalculation of B and its dependents (C)
+    calc_questions.recalculate_and_update_dependents(field_b)
+
+    assert field_b.get_value() == 20.0
+    assert field_c.get_value() == 40.0
+
+    # Change A and verify that only calling it on B updates B and C
+    save_answer(question=q_a, document=doc, value=5)
+    # Ensure field_a in our structure sees the new value
+    field_a.refresh()
+
+    # save_answer already triggered B and C updates via signals.
+    # To test that recalculate_and_update_dependents(field_b) actually
+    # triggers C when B changes, we manually set B and C to wrong values first.
+    models.Answer.objects.filter(question=q_b, document=doc).update(value=0)
+    models.Answer.objects.filter(question=q_c, document=doc).update(value=0)
+    field_b.refresh()
+    field_c.refresh()
+    assert field_b.get_value() == 0
+    assert field_c.get_value() == 0
+
+    calc_questions.recalculate_and_update_dependents(field_b)
+
+    assert field_b.get_value() == 10.0
+    assert field_c.get_value() == 20.0
+
+
+@pytest.mark.django_db
+def test_new_table_row_recalculation(
+    form_factory, question_factory, form_question_factory, document_factory
+):
+    """Test that calculated fields in new table rows are recalculated."""
+    # Setup form
+    form = form_factory(slug="form")
+    q_root = question_factory(slug="q_root", type=models.Question.TYPE_INTEGER)
+    form_question_factory(form=form, question=q_root)
+
+    row_form = form_factory(slug="row_form")
+    q_table = question_factory(
+        slug="q_table", type=models.Question.TYPE_TABLE, row_form=row_form
+    )
+    form_question_factory(form=form, question=q_table)
+
+    q_calc = question_factory(
+        slug="q_calc",
+        type=models.Question.TYPE_CALCULATED_FLOAT,
+        calc_expression="'q_root'|answer * 2",
+    )
+    form_question_factory(form=row_form, question=q_calc)
+
+    # Create document and set q_root
+    doc = document_factory(form=form)
+    save_answer(question=q_root, document=doc, value=21)
+
+    # Add first row to table
+    row1 = document_factory(form=row_form)
+    save_answer(question=q_table, document=doc, value=[str(row1.pk)])
+
+    # Verify row1 calc
+    ans1 = models.Answer.objects.get(question=q_calc, document=row1)
+    assert ans1.value == 42.0
+
+    # Add second row to table, DON'T change q_root
+    row2 = document_factory(form=row_form)
+
+    # This calls SaveAnswerLogic.update for the table answer
+    save_answer(question=q_table, document=doc, value=[str(row1.pk), str(row2.pk)])
+
+    # Verify row2 calc
+    ans2 = models.Answer.objects.get(question=q_calc, document=row2)
+    assert ans2.value == 42.0

--- a/caluma/caluma_form/tests/test_complex_jexl.py
+++ b/caluma/caluma_form/tests/test_complex_jexl.py
@@ -39,10 +39,10 @@ def complex_jexl_doc(complex_jexl_form):
 
     FieldSet(demo-formular-1)
        Field(demo-outer-table-question-1, None)
-          FieldSet(demo-table-form-1)
+          FieldSet(demo-table-form-1 #1)
              Field(demo-table-question-1, 3)
              Field(demo-table-question-2, 1)
-          FieldSet(demo-table-form-1)
+          FieldSet(demo-table-form-1 #2)
              Field(demo-table-question-1, 20)
              Field(demo-table-question-2, 100)
        Field(demo-outer-question-1, demo-outer-question-1-outer-option-a)
@@ -90,10 +90,10 @@ def test_evaluating_calc_inside_table(
     assert structure.list_document_structure(doc, method=repr) == [
         " FieldSet(q=(root), f=demo-formular-1)",
         "    RowSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
-        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=1)",
         "          ValueField(q=demo-table-question-1, v=3)",
         "          ValueField(q=demo-table-question-2, v=1)",
-        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=2)",
         "          ValueField(q=demo-table-question-1, v=20)",
         "          ValueField(q=demo-table-question-2, v=100)",
         "    ValueField(q=demo-outer-question-1, v=demo-outer-question-1-outer-option-a)",
@@ -109,10 +109,10 @@ def test_update_calc_dependency_inside_table(
     assert structure.list_document_structure(doc, method=repr) == [
         " FieldSet(q=(root), f=demo-formular-1)",
         "    RowSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
-        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=1)",
         "          ValueField(q=demo-table-question-1, v=3)",
         "          ValueField(q=demo-table-question-2, v=1)",
-        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=2)",
         "          ValueField(q=demo-table-question-1, v=20)",
         "          ValueField(q=demo-table-question-2, v=100)",
         "    ValueField(q=demo-outer-question-1, v=demo-outer-question-1-outer-option-a)",
@@ -126,10 +126,10 @@ def test_update_calc_dependency_inside_table(
         == [
             " FieldSet(q=(root), f=demo-formular-1)",
             "    RowSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
-            "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+            "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=1)",
             "          ValueField(q=demo-table-question-1, v=30)",  # this was set
             "          ValueField(q=demo-table-question-2, v=100)",  # should have been recalc'd
-            "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+            "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=2)",
             "          ValueField(q=demo-table-question-1, v=20)",
             "          ValueField(q=demo-table-question-2, v=100)",
             "    ValueField(q=demo-outer-question-1, v=demo-outer-question-1-outer-option-a)",
@@ -143,10 +143,10 @@ def test_update_calc_dependency_inside_table(
     assert structure.list_document_structure(doc, method=repr) == [
         " FieldSet(q=(root), f=demo-formular-1)",
         "    RowSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
-        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=1)",
         "          ValueField(q=demo-table-question-1, v=3)",  # updated again
         "          ValueField(q=demo-table-question-2, v=1)",  # recalculated again
-        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=2)",
         "          ValueField(q=demo-table-question-1, v=20)",
         "          ValueField(q=demo-table-question-2, v=100)",
         "    ValueField(q=demo-outer-question-1, v=demo-outer-question-1-outer-option-a)",
@@ -161,10 +161,10 @@ def test_update_calc_dependency_inside_table(
         == [
             " FieldSet(q=(root), f=demo-formular-1)",
             "    RowSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
-            "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+            "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=1)",
             "          ValueField(q=demo-table-question-1, v=3)",
             "          ValueField(q=demo-table-question-2, v=1)",
-            "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+            "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=2)",
             "          ValueField(q=demo-table-question-1, v=40)",  # updated here
             "          ValueField(q=demo-table-question-2, v=100)",  # recalculated , same value
             "    ValueField(q=demo-outer-question-1, v=demo-outer-question-1-outer-option-a)",
@@ -178,10 +178,10 @@ def test_update_calc_dependency_inside_table(
     assert structure.list_document_structure(doc, method=repr) == [
         " FieldSet(q=(root), f=demo-formular-1)",
         "    RowSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
-        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=1)",
         "          ValueField(q=demo-table-question-1, v=3)",
         "          ValueField(q=demo-table-question-2, v=1)",
-        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1)",
+        "       FieldSet(q=demo-outer-table-question-1, f=demo-table-form-1, r=2)",
         "          ValueField(q=demo-table-question-1, v=2)",  # updated
         "          ValueField(q=demo-table-question-2, v=1)",  # recalculated
         "    ValueField(q=demo-outer-question-1, v=demo-outer-question-1-outer-option-a)",
@@ -197,10 +197,10 @@ def test_update_calc_dependency_inside_table_with_outer_reference(
     assert structure.list_document_structure(doc) == [
         " FieldSet(demo-formular-1)",
         "    RowSet(demo-outer-table-question-1)",
-        "       FieldSet(demo-table-form-1)",
+        "       FieldSet(demo-table-form-1 #1)",
         "          Field(demo-table-question-1, 3)",
         "          Field(demo-table-question-2, 1)",
-        "       FieldSet(demo-table-form-1)",
+        "       FieldSet(demo-table-form-1 #2)",
         "          Field(demo-table-question-1, 20)",
         "          Field(demo-table-question-2, 100)",
         "    Field(demo-outer-question-1, demo-outer-question-1-outer-option-a)",
@@ -245,15 +245,15 @@ def test_update_calc_dependency_inside_table_with_outer_reference(
     assert structure.list_document_structure(doc) == [
         " FieldSet(demo-formular-1)",
         "    RowSet(demo-outer-table-question-1)",
-        "       FieldSet(demo-table-form-1)",
+        "       FieldSet(demo-table-form-1 #1)",
         "          Field(demo-table-question-1, 3)",
         "          Field(demo-table-question-2, 1)",
-        "       FieldSet(demo-table-form-1)",
+        "       FieldSet(demo-table-form-1 #2)",
         "          Field(demo-table-question-1, 20)",
         "          Field(demo-table-question-2, 100)",
         "    Field(demo-outer-question-1, demo-outer-question-1-outer-option-a)",
         "    RowSet(demo-outer-table-question-2)",
-        "       FieldSet(demo-table-form-2)",
+        "       FieldSet(demo-table-form-2 #1)",
         "          Field(demo-table-question-outer-ref-hidden, 30)",
         "          Field(demo-table-question-outer-ref-calc, 30)",
     ]
@@ -267,15 +267,15 @@ def test_update_calc_dependency_inside_table_with_outer_reference(
     assert structure.list_document_structure(doc) == [
         " FieldSet(demo-formular-1)",
         "    RowSet(demo-outer-table-question-1)",
-        "       FieldSet(demo-table-form-1)",
+        "       FieldSet(demo-table-form-1 #1)",
         "          Field(demo-table-question-1, 3)",
         "          Field(demo-table-question-2, 1)",
-        "       FieldSet(demo-table-form-1)",
+        "       FieldSet(demo-table-form-1 #2)",
         "          Field(demo-table-question-1, 20)",
         "          Field(demo-table-question-2, 100)",
         "    Field(demo-outer-question-1, demo-outer-question-1-outer-option-a)",
         "    RowSet(demo-outer-table-question-2)",
-        "       FieldSet(demo-table-form-2)",
+        "       FieldSet(demo-table-form-2 #1)",
         "          Field(demo-table-question-outer-ref-hidden, 20)",
         "          Field(demo-table-question-outer-ref-calc, 20)",
     ]
@@ -290,10 +290,10 @@ def test_structure_caching(transactional_db, complex_jexl_form, complex_jexl_doc
     assert structure.list_document_structure(doc) == [
         " FieldSet(demo-formular-1)",
         "    RowSet(demo-outer-table-question-1)",
-        "       FieldSet(demo-table-form-1)",
+        "       FieldSet(demo-table-form-1 #1)",
         "          Field(demo-table-question-1, 3)",
         "          Field(demo-table-question-2, 1)",
-        "       FieldSet(demo-table-form-1)",
+        "       FieldSet(demo-table-form-1 #2)",
         "          Field(demo-table-question-1, 20)",
         "          Field(demo-table-question-2, 100)",
         "    Field(demo-outer-question-1, demo-outer-question-1-outer-option-a)",

--- a/caluma/caluma_form/tests/test_document.py
+++ b/caluma/caluma_form/tests/test_document.py
@@ -503,6 +503,7 @@ def test_save_document_client(
     assert len(result.data["saveDocument"]["document"]["answers"]["edges"]) == (
         1 if update else 3
     )
+
     if not update:
         assert sorted(
             [

--- a/caluma/caluma_form/tests/test_jexl.py
+++ b/caluma/caluma_form/tests/test_jexl.py
@@ -360,7 +360,7 @@ def test_answer_transform_on_hidden_question(info, form_and_document):
         " FieldSet(q=(root), f=top_form)",
         "    ValueField(q=top_question, v=xyz)",
         "    RowSet(q=table, f=row_form)",
-        "       FieldSet(q=table, f=row_form)",
+        "       FieldSet(q=table, f=row_form, r=1)",
         "          ValueField(q=column, v=None)",  # this is our test field
         "    FieldSet(q=form, f=sub_form)",
         "       ValueField(q=sub_question, v=None)",

--- a/caluma/caluma_form/tests/test_question.py
+++ b/caluma/caluma_form/tests/test_question.py
@@ -1138,6 +1138,7 @@ def test_calculated_question_update_calc_expr(
 
     calc_ans = document.answers.get(question_id="calc_question")
     assert calc_ans.value == 101
+
     # spying on update_or_create_calc_answer doesn't seem to work, so we spy on
     # QuestionJexl.evaluate instead
     spy = mocker.spy(QuestionJexl, "evaluate")
@@ -1297,5 +1298,5 @@ def test_init_of_calc_questions_queries(
         question__calc_expression="'table'|answer|mapby('column')|sum + 'top_question'|answer + 'sub_question'|answer",
     )
 
-    with django_assert_num_queries(33):
+    with django_assert_num_queries(27):
         api.save_answer(questions_dict["top_question"], document, value="1")

--- a/caluma/caluma_form/tests/test_recalculate_calc_answers_command.py
+++ b/caluma/caluma_form/tests/test_recalculate_calc_answers_command.py
@@ -130,10 +130,10 @@ def test_recalculate_sibling_rows_in_table(form_factory, form_question_factory, 
     assert structure.list_document_structure(main_doc) == [
         " FieldSet(root)",
         "    RowSet(table)",
-        "       FieldSet(row)",
+        "       FieldSet(row #1)",
         "          Field(col1, 10)",
         "          Field(col2, 20)",
-        "       FieldSet(row)",
+        "       FieldSet(row #2)",
         "          Field(col1, 20)",
         "          Field(col2, 40)",
     ]
@@ -143,7 +143,11 @@ def test_recalculate_sibling_rows_in_table(form_factory, form_question_factory, 
         save_answer(question=column1, value=99, document=row1doc)
 
     # col2 should only be updated once
-    update_msgs = [msg for msg in caplog.messages if "updating question col2" in msg]
+    update_msgs = [
+        msg
+        for msg in caplog.messages
+        if "Recalculating (root).table[2].table.col2" in msg
+    ]
     assert len(update_msgs) == 1
 
     # Check for correct recalculation

--- a/caluma/caluma_form/tests/test_structure.py
+++ b/caluma/caluma_form/tests/test_structure.py
@@ -108,11 +108,11 @@ def test_printing_structure(simple_form_structure):
         "       Field(sub_leaf1, None)",
         "       Field(sub_leaf2, None)",
         "       RowSet(sub_table)",
-        "          FieldSet(too-wonder-option)",
+        "          FieldSet(too-wonder-option #1)",
         "             Field(row_field_1, 2025-01-13)",
         "             Field(row_field_2, 99.5)",
         "             Field(row_calc, None)",
-        "          FieldSet(too-wonder-option)",
+        "          FieldSet(too-wonder-option #2)",
         "             Field(row_field_1, 2025-01-10)",
         "             Field(row_field_2, 23.0)",
         "             Field(row_calc, None)",
@@ -373,11 +373,11 @@ def test_fastloader_multiple_documents(
         "       Field(sub_leaf1, None)",
         "       Field(sub_leaf2, None)",
         "       RowSet(sub_table)",
-        "          FieldSet(too-wonder-option)",
+        "          FieldSet(too-wonder-option #1)",
         "             Field(row_field_1, 2025-01-13)",
         "             Field(row_field_2, 99.5)",
         "             Field(row_calc, None)",
-        "          FieldSet(too-wonder-option)",
+        "          FieldSet(too-wonder-option #2)",
         "             Field(row_field_1, 2025-01-10)",
         "             Field(row_field_2, 23.0)",
         "             Field(row_calc, None)",
@@ -466,13 +466,58 @@ def test_multistage_calculation_updates(
         "       Field(sub_leaf1, None)",
         "       Field(sub_leaf2, None)",
         "       RowSet(sub_table)",
-        "          FieldSet(too-wonder-option)",
+        "          FieldSet(too-wonder-option #1)",
         "             Field(row_field_1, 2025-01-13)",
         "             Field(row_field_2, 101.5)",
         "             Field(row_calc, 134.5)",
-        "          FieldSet(too-wonder-option)",
+        "          FieldSet(too-wonder-option #2)",
         "             Field(row_field_1, 2025-01-10)",
         "             Field(row_field_2, 25.0)",
         "             Field(row_calc, 58.0)",
         "    Field(outer-calc, 192.5)",
     ]
+
+
+@pytest.mark.django_db
+def test_get_all_fields(form_and_document):
+    """Test get_all_fields utility on FieldSet and RowSet."""
+
+    form, doc, questions, answers = form_and_document(
+        use_table=True, use_subform=True, table_row_count=2
+    )
+
+    root = structure.FieldSet(doc)
+    all_fields = list(root.get_all_fields())
+
+    slugs = [f.slug() for f in all_fields]
+    assert "top_question" in slugs
+    assert "table" in slugs
+    assert "column" in slugs
+    assert slugs.count("column") == 2
+    assert "form" in slugs
+    assert "sub_question" in slugs
+
+    # Total field count:
+    # * top_question
+    # * table
+    # * row1_fs
+    # * row1_col
+    # * row2_fs
+    # * row2_col
+    # * subform_fs
+    # * sub_question
+    assert len(all_fields) == 8
+
+    # Test RowSet.get_all_fields specifically
+    table_rowset = root.get_field("table")
+    assert isinstance(table_rowset, structure.RowSet)
+    table_fields = list(table_rowset.get_all_fields())
+
+    # Expected table fields:
+    # 1. row 1 (FieldSet)
+    # 2. row 1 column (ValueField)
+    # 3. row 2 (FieldSet)
+    # 4. row 2 column (ValueField)
+    assert len(table_fields) == 4
+    table_slugs = [f.slug() for f in table_fields]
+    assert table_slugs.count("column") == 2

--- a/caluma/caluma_form/tests/test_validators.py
+++ b/caluma/caluma_form/tests/test_validators.py
@@ -332,7 +332,7 @@ def test_validate_empty_answers(
             "'foo' in blah",
             "false",
             "",
-            "Error while evaluating expression on question q-slug: \"'foo' in blah\". The system log contains more information",
+            "Error while evaluating expression on question ({form_slug}).{question_slug}: \"'foo' in blah\". The system log contains more information",
         ),
         (
             "q-slug",
@@ -340,7 +340,7 @@ def test_validate_empty_answers(
             "true",
             "'foo' in blah",
             "",
-            "Error while evaluating expression on question q-slug: \"'foo' in blah\". The system log contains more information",
+            "Error while evaluating expression on question ({form_slug}).{question_slug}: \"'foo' in blah\". The system log contains more information",
         ),
         (
             "q-slug",
@@ -356,6 +356,9 @@ def test_validate_invalid_jexl(
     db, form_question, document, answer, question, exception_message, admin_user
 ):
     if exception_message is not None:
+        exception_message = exception_message.format(
+            form_slug=document.form.slug, question_slug=question.slug
+        )
         with pytest.raises(RuntimeError) as exc:
             DocumentValidator().validate(document, admin_user)
         assert exc.value.args[0] == exception_message

--- a/caluma/caluma_form/utils.py
+++ b/caluma/caluma_form/utils.py
@@ -1,92 +1,23 @@
-from logging import getLogger
+from django.db.models import Q
 
-from caluma.caluma_form import models, structure, validators
-from caluma.caluma_form.jexl import QuestionJexl
-
-log = getLogger(__name__)
+from caluma.caluma_form import models
 
 
-def update_calc_dependents(slug, old_expr, new_expr):
-    """Update the calc_dependents lists of our calc *dependencies*.
-
-    The given (old and new) expressions are analyzed to see which
-    questions are referenced in "our" calc question. Then, those
-    questions' calc_dependents list is updated, such that it correctly
-    represents the new situation.
-
-    Example: If our expression newly contains the question `foo`, then the
-    `foo` question needs to know about it (we add "our" slug to the `foo`s
-    calc dependents)
+def forms_containing_question(question: models.Question) -> list[models.Form]:
     """
-    jexl = QuestionJexl(field=None)
-    old_q = set(
-        list(jexl.extract_referenced_questions(old_expr))
-        + list(jexl.extract_referenced_mapby_questions(old_expr))
-    )
-    new_q = set(
-        list(jexl.extract_referenced_questions(new_expr))
-        + list(jexl.extract_referenced_mapby_questions(new_expr))
-    )
+    Return list of all forms that have the given quesiton in their structure.
 
-    to_add = new_q - old_q
-    to_remove = old_q - new_q
-
-    questions = models.Question.objects.filter(pk__in=list(to_add | to_remove))
-
-    for question in questions:
-        deps = set(question.calc_dependents)
-        if question.slug in to_add:
-            deps.add(slug)
-        else:
-            deps.remove(slug)
-        question.calc_dependents = list(deps)
-        question.save()
-
-
-def recalculate_field(
-    calc_field: structure.ValueField, update_recursively: bool = True
-):
-    """Recalculate the given value field and store the new answer.
-
-    If it's not a calculated field, nothing happens.
+    This contains indirect structures as well, so you can use it to find all
+    documents where the given question is part of the data.
     """
-    if calc_field.question.type != models.Question.TYPE_CALCULATED_FLOAT:
-        # Not a calc field - skip
-        return  # pragma: no cover
+    result = []
+    for fq in models.FormQuestion.objects.filter(question=question).select_related(
+        "form"
+    ):
+        form = fq.form
+        result.append(form)
+        parents = models.Question.objects.filter(Q(row_form=form) | Q(sub_form=form))
+        for parent in parents:
+            result.extend(forms_containing_question(parent))
 
-    value = calc_field.calculate()
-
-    answer, _ = models.Answer.objects.update_or_create(
-        question=calc_field.question,
-        document=calc_field.parent._document,
-        defaults={"value": value},
-    )
-    # also save new answer to structure for reuse
-    calc_field.refresh(answer)
-    if update_recursively:
-        recalculate_dependent_fields(calc_field, update_recursively)
-
-
-def recalculate_dependent_fields(
-    changed_field: structure.ValueField, update_recursively: bool = True
-):
-    """Update any calculated dependencies of the given field.
-
-    If `update_recursively=False` is passed, no subsequent calc dependencies
-    are updated (left to the caller in that case).
-    """
-    for dep_slug in changed_field.question.calc_dependents:
-        dep_field = changed_field.get_field(dep_slug)
-        if not dep_field:  # pragma: no cover
-            # Calculated field is not in our form structure, which is
-            # absolutely valid and OK
-            continue
-        recalculate_field(dep_field, update_recursively)
-
-
-def update_or_create_calc_answer(question, document, update_dependents=True):
-    """Recalculate all answers in the document after calc dependency change."""
-
-    root = validators.DocumentValidator().get_validation_context(document.family)
-    for field in root.find_all_fields_by_slug(question.slug):
-        recalculate_field(field, update_recursively=update_dependents)
+    return result

--- a/caluma/caluma_form/validators.py
+++ b/caluma/caluma_form/validators.py
@@ -111,7 +111,9 @@ class AnswerValidator:
         # If we need to create the context ourselves here, we'll need to fetch
         # the field from the context.
         validation_context = DocumentValidator().get_validation_context(document)
-        return validation_context.get_field(question.slug), validation_context
+        field_candidates = validation_context.find_all_fields_by_slug(question.slug)
+        field = next(f for f in field_candidates if f.parent._document == document)
+        return field, validation_context
 
     def _evaluate_options_jexl(
         self, document, question, validation_context=None, qs=None

--- a/caluma/utils.py
+++ b/caluma/utils.py
@@ -39,7 +39,7 @@ def col_type_from_db(field, connection):
     return res
 
 
-def fix_foreign_key_types(apps, connection):
+def fix_foreign_key_types(apps, connection):  # pragma: no cover
     """Ensure all foreign keys pointing to slug fields are correct type."""
 
     # I'm really not happy that this code needs to exist. I'ts a sign that


### PR DESCRIPTION
This should greatly improve performance, as recalculation of calculated
fields is only done when absolutely necessary. This is done via a few
mechanisms:

A) don't do recalculation recursively anymore, but instead build up a
   topoligically-ordered list of the fields to be recalculated. This
   avoids recalculation of the same field within the same change (Request
   or similar)

B) Culling of dependent calc questions if none of their input changed:
   If we come to a question in the ordered list (see above) and the
   result of the recalculation of all it's dependencies has not yielded
   a change, we don't need to recalculate said question either.

C) After recalculation, don't refresh all calc dependents. This is not
   needed in our structured recalculation anymore, and slows us down
   by a big margin, as it could in theory hit the DB for dozens of answers
   that are going to be recalculated in a few milliseconds anyway.

Drive-By changes & cleanups:

- Move calc question code into it's own module
- optimize get_path and add row number to fieldsets, so we can easily
  lookup the row number of a table row
- refactor global recalculation code as well (the stuff that recalculates
  when a calc_expression changes, or a calc question gets added to a form)
- keep row number in field sets that are part of a RowSet, and output it
  in the print utility functions (print_structure() and list_structure())