### PR TITLE
 fix(calc-questions): robust recalculation on deletion and form changes

### DIFF
--- a/caluma/caluma_form/calc_questions.py
+++ b/caluma/caluma_form/calc_questions.py
@@ -38,13 +38,13 @@ def update_calc_dependents(slug, old_expr, new_expr):
     questions = models.Question.objects.filter(pk__in=list(to_add | to_remove))
 
     for question in questions:
-        deps = set(question.calc_dependents)
         if question.slug in to_add:
-            deps.add(slug)
-        else:
-            deps.remove(slug)
-        question.calc_dependents = list(deps)
-        question.save()
+            if slug not in question.calc_dependents:
+                question.calc_dependents.append(slug)
+                question.save()
+        elif slug in question.calc_dependents:
+            question.calc_dependents.remove(slug)
+            question.save()
 
 
 def recalculate_and_update_dependents(calc_field: structure.ValueField):
@@ -212,7 +212,12 @@ class DependencyList(list):
         for field in self:
             log.debug("Recalculating %s", field.get_path())
             is_root = id(field) in self._roots
-            if allow_culling and not is_root and not self.get_reason_for(field):
+            if (
+                allow_culling
+                and not is_root
+                and not self.get_reason_for(field)
+                and field.answer
+            ):
                 # There is no reason (anymore) to recalculate this field,
                 # as none of the recalculations of the dependencies have changed
                 # their value

--- a/caluma/caluma_form/domain_logic.py
+++ b/caluma/caluma_form/domain_logic.py
@@ -166,13 +166,8 @@ class SaveAnswerLogic:
 
     @staticmethod
     def recalculate_dependents(answer, update_info):
-        """Update the dependent calc answers when this given answer has changed.
-
-        The update_info is used in the context of table questions, when we need
-        to know in which rows to look for calc questions (as they may depend on
-        out-of-row questions)
-        """
-        is_table = update_info and answer.question.type == models.Question.TYPE_TABLE
+        """Update the dependent calc answers when this given answer has changed."""
+        is_table = answer.question.type == models.Question.TYPE_TABLE
         if not is_table and not answer.question.calc_dependents:
             return
         if not answer.document:
@@ -191,18 +186,7 @@ class SaveAnswerLogic:
                 f"question={answer.question_id}, root form={struc.get_root().get_form().slug}",
             )
 
-        roots = [field]
-        if is_table and update_info.get("created"):
-            # New rows might have calculated fields depending on fields outside
-            # the table. Make sure we catch them as well
-            created_ids = set(update_info["created"])
-            for row in field.children():
-                if row._document.pk in created_ids:
-                    for child in row.get_all_fields():
-                        if child.question.type == models.Question.TYPE_CALCULATED_FLOAT:
-                            roots.append(child)
-
-        recalculate_dependent_fields(*roots, recalculate_roots=True)
+        recalculate_dependent_fields(field)
 
     @classmethod
     @transaction.atomic
@@ -244,8 +228,56 @@ class SaveAnswerLogic:
 
         cls.recalculate_dependents(answer, update_info)
 
-        answer.refresh_from_db()
         return answer
+
+
+class RemoveAnswerLogic:
+    @classmethod
+    @transaction.atomic
+    def delete(cls, answer: models.Answer, user: Optional[BaseUser] = None):
+        """Delete an answer and trigger recalculation of dependents."""
+        if not answer.document:  # pragma: no cover
+            answer.delete()
+            return
+
+        struc = validators.DocumentValidator().get_validation_context(
+            answer.document.family
+        )
+        field = struc.find_field_by_answer(answer)
+
+        answer.delete()
+
+        if field:
+            field.answer = None
+            recalculate_dependent_fields(field)
+
+
+class RemoveDocumentLogic:
+    @classmethod
+    @transaction.atomic
+    def delete(cls, document: models.Document, user: Optional[BaseUser] = None):
+        """Delete a document and trigger recalculation of table aggregation fields."""
+        if hasattr(document, "case"):
+            raise Exception("You cannot remove a Document, if it's attached to a case.")
+
+        # Find all table answers that reference this document as a row
+        affected_answers = list(models.Answer.objects.filter(documents=document))
+
+        for answer in document.answers.filter(
+            question__type=models.Question.TYPE_TABLE
+        ):
+            for row_doc in answer.documents.all():
+                cls.delete(row_doc, user)
+
+        document.delete()
+
+        for answer in affected_answers:
+            struc = validators.DocumentValidator().get_validation_context(
+                answer.document.family
+            )
+            field = struc.find_field_by_answer(answer)
+            if field:
+                recalculate_dependent_fields(field)
 
 
 class SaveDefaultAnswerLogic(SaveAnswerLogic):

--- a/caluma/caluma_form/factories.py
+++ b/caluma/caluma_form/factories.py
@@ -73,7 +73,6 @@ class QuestionFactory(DjangoModelFactory):
     calc_expression = Maybe(
         "is_calc_float", yes_declaration="-1.0", no_declaration=None
     )
-    calc_dependents = LazyFunction(lambda: [])
 
     # action button question
     action = Maybe(

--- a/caluma/caluma_form/serializers.py
+++ b/caluma/caluma_form/serializers.py
@@ -685,7 +685,7 @@ class RemoveAnswerSerializer(serializers.ModelSerializer):
 
     @transaction.atomic
     def update(self, instance, validated_data):
-        instance.delete()
+        domain_logic.RemoveAnswerLogic.delete(instance, self.context["request"].user)
         return instance
 
     class Meta:
@@ -782,16 +782,9 @@ class RemoveDocumentSerializer(serializers.ModelSerializer):
 
     @transaction.atomic
     def update(self, instance, validated_data):
-        if hasattr(instance, "case"):
-            raise Exception("You cannot remove a Document, if it's attached to a case.")
-
-        for answer in instance.answers.filter(
-            question__type=models.Question.TYPE_TABLE
-        ):
-            answer.documents.all().delete()
-
-        instance.delete()
-
+        domain_logic.RemoveDocumentLogic.delete(
+            instance, user=self.context["request"].user
+        )
         return instance
 
     class Meta:

--- a/caluma/caluma_form/signals.py
+++ b/caluma/caluma_form/signals.py
@@ -115,11 +115,55 @@ def update_calc_from_question(sender, instance, created, update_fields, **kwargs
 
 @receiver(post_save, sender=models.FormQuestion)
 @disable_raw
-@filter_events(
-    lambda instance: instance.question.type == models.Question.TYPE_CALCULATED_FLOAT
-)
 def update_calc_from_form_question(sender, instance, created, **kwargs):
-    _recalculate_all_questions(instance.question)
+    if not created:
+        return
+
+    # Use a fresh question object from DB to avoid stale caches
+    question = models.Question.objects.get(pk=instance.question_id)
+
+    if question.default_answer:
+        for document in models.Document.objects.filter(form=instance.form).iterator():
+            if not models.Answer.objects.filter(
+                question=question, document=document
+            ).exists():
+                question.default_answer.copy(
+                    to_document=document, document_family=document.family
+                )
+
+    if question.type == models.Question.TYPE_CALCULATED_FLOAT:
+        _recalculate_all_questions(question)
+
+    _recalculate_dependents(question)
+
+
+@receiver(post_delete, sender=models.FormQuestion)
+@disable_raw
+def update_calc_on_form_question_delete(sender, instance, **kwargs):
+    _recalculate_dependents(instance.question)
+
+
+@receiver(post_delete, sender=models.Question)
+@disable_raw
+def update_calc_on_question_delete(sender, instance, **kwargs):
+    _recalculate_dependents(instance)
+
+
+def _recalculate_dependents(question):
+    # Find calc questions depending on this question.
+    # We look at both the pre-calculated calc_dependents list AND we search
+    # the calc_expression directly as a fallback.
+    dependents = set(question.calc_dependents)
+    expression_deps = models.Question.objects.filter(
+        type=models.Question.TYPE_CALCULATED_FLOAT,
+        calc_expression__icontains=f"'{question.slug}'",
+    )
+    for q in expression_deps:
+        dependents.add(q.slug)
+
+    for q_calc_slug in dependents:
+        q_calc = models.Question.objects.get(slug=q_calc_slug)
+        _recalculate_all_questions(q_calc)
 
 
 def _recalculate_all_questions(question):

--- a/caluma/caluma_form/tests/test_calc_questions.py
+++ b/caluma/caluma_form/tests/test_calc_questions.py
@@ -1,7 +1,11 @@
 import pytest
 
 from caluma.caluma_form import calc_questions, models, structure
-from caluma.caluma_form.api import save_answer
+from caluma.caluma_form.api import save_answer, save_default_answer, save_document
+from caluma.caluma_form.serializers import (
+    RemoveAnswerSerializer,
+    RemoveDocumentSerializer,
+)
 
 
 @pytest.mark.django_db
@@ -98,10 +102,12 @@ def test_new_table_row_recalculation(
 
     # Create document and set q_root
     doc = document_factory(form=form)
+    q_root.refresh_from_db()
     save_answer(question=q_root, document=doc, value=21)
 
     # Add first row to table
     row1 = document_factory(form=row_form)
+    q_table.refresh_from_db()
     save_answer(question=q_table, document=doc, value=[str(row1.pk)])
 
     # Verify row1 calc
@@ -117,3 +123,190 @@ def test_new_table_row_recalculation(
     # Verify row2 calc
     ans2 = models.Answer.objects.get(question=q_calc, document=row2)
     assert ans2.value == 42.0
+
+
+@pytest.mark.django_db
+def test_delete_document_recalculation(
+    form_factory, question_factory, form_question_factory, document_factory, mocker
+):
+    """Test that deleting a table row triggers recalculation in parent."""
+    # Setup form
+    form = form_factory(slug="form")
+
+    row_form = form_factory(slug="row_form")
+    q_table = question_factory(
+        slug="q_table", type=models.Question.TYPE_TABLE, row_form=row_form
+    )
+    form_question_factory(form=form, question=q_table)
+
+    q_calc = question_factory(
+        slug="q_calc",
+        type=models.Question.TYPE_CALCULATED_FLOAT,
+        calc_expression="'q_table'|answer|length",
+    )
+    form_question_factory(form=form, question=q_calc)
+
+    # Create document
+    doc = document_factory(form=form)
+
+    # Add a row
+    row1 = document_factory(form=row_form)
+    q_table.refresh_from_db()
+    save_answer(question=q_table, document=doc, value=[str(row1.pk)])
+
+    # Verify calc
+    ans_calc = models.Answer.objects.get(question=q_calc, document=doc)
+    assert ans_calc.value == 1.0
+
+    # Now delete row1 via RemoveDocument mutation/serializer
+
+    context = {
+        "mutation": "RemoveDocument",
+        "info": mocker.MagicMock(),
+        "request": mocker.MagicMock(),
+    }
+    serializer = RemoveDocumentSerializer(
+        instance=row1, data={"document": str(row1.pk)}, context=context
+    )
+    assert serializer.is_valid(), serializer.errors
+    serializer.save()
+
+    # Verify row1 is gone
+    assert not models.Document.objects.filter(pk=row1.pk).exists()
+
+    # Verify q_calc is recalculated (should be 0.0)
+    ans_calc.refresh_from_db()
+    assert ans_calc.value == 0.0
+
+
+@pytest.mark.django_db
+def test_delete_answer_recalculation(
+    form_factory, question_factory, form_question_factory, document_factory, mocker
+):
+    """Test that deleting an answer triggers recalculation of dependents."""
+    # Setup form
+    form = form_factory(slug="form")
+    q_root = question_factory(slug="q_root", type=models.Question.TYPE_INTEGER)
+    form_question_factory(form=form, question=q_root)
+
+    q_calc = question_factory(
+        slug="q_calc",
+        type=models.Question.TYPE_CALCULATED_FLOAT,
+        calc_expression="'q_root'|answer * 2",
+    )
+    form_question_factory(form=form, question=q_calc)
+
+    # Create document and set q_root
+    doc = document_factory(form=form)
+
+    # Refresh q_root to get the calc_dependents updated by q_calc creation
+    q_root.refresh_from_db()
+
+    save_answer(question=q_root, document=doc, value=21)
+
+    # Verify calc
+    ans_calc = models.Answer.objects.get(question=q_calc, document=doc)
+    assert ans_calc.value == 42.0
+
+    # Now delete q_root answer
+    ans_root = models.Answer.objects.get(question=q_root, document=doc)
+
+    # We need to use the mutation or the serializer to test the bug.
+    # The issue says RemoveAnswer mutation.
+
+    context = {
+        "mutation": "RemoveAnswer",
+        "info": mocker.MagicMock(),
+        "request": mocker.MagicMock(),
+    }
+    serializer = RemoveAnswerSerializer(
+        instance=ans_root, data={"answer": ans_root.pk}, context=context
+    )
+    assert serializer.is_valid(), serializer.errors
+    serializer.save()
+
+    # Verify q_root answer is gone
+    assert not models.Answer.objects.filter(question=q_root, document=doc).exists()
+
+    # Verify q_calc is recalculated (should be 0 or None * 2 depends on JEXL, but likely 0.0 or something)
+    # Actually 'q_root'|answer returns None if no answer, and None * 2 might be an error or 0.
+    # Let's see what it currently is. It SHOULD have changed.
+    ans_calc.refresh_from_db()
+
+    # If it's NOT recalculated, it will still be 42.0.
+    assert ans_calc.value != 42.0
+
+
+@pytest.mark.django_db
+def test_add_question_to_form_recalculation(
+    form_factory, question_factory, form_question_factory, document_factory
+):
+    """Test that adding a question to a form triggers recalculation of dependents."""
+    # Setup form
+    form = form_factory(slug="form")
+
+    # Create q_new in DB first, so q_calc can register its dependency
+    q_new = models.Question.objects.create(
+        slug="q_new", type=models.Question.TYPE_INTEGER
+    )
+
+    q_calc = question_factory(
+        slug="q_calc",
+        type=models.Question.TYPE_CALCULATED_FLOAT,
+        calc_expression="'q_new'|answer(0) + 10",
+    )
+    form_question_factory(form=form, question=q_calc)
+
+    # Create document
+
+    doc = save_document(form=form)
+
+    # Verify calc (should be 0 + 10 = 10)
+    ans_calc = models.Answer.objects.get(question=q_calc, document=doc)
+    assert ans_calc.value == 10.0
+
+    # Now add q_new to the form with a default answer
+
+    save_default_answer(question=q_new, value=5)
+
+    # Actually adding to form triggers the signal
+    form_question_factory(form=form, question=q_new)
+
+    # Verify q_calc is recalculated (should be 5 + 10 = 15)
+    ans_calc.refresh_from_db()
+    assert ans_calc.value == 15.0
+
+
+@pytest.mark.django_db
+def test_remove_question_from_form_recalculation(
+    form_factory, question_factory, form_question_factory, document_factory
+):
+    """Test that removing a question from a form triggers recalculation of dependents."""
+    # Setup form
+    form = form_factory(slug="form")
+    q_input = question_factory(slug="q_input", type=models.Question.TYPE_INTEGER)
+    form_question_factory(form=form, question=q_input)
+
+    q_calc = question_factory(
+        slug="q_calc",
+        type=models.Question.TYPE_CALCULATED_FLOAT,
+        calc_expression="'q_input'|answer(100) + 10",
+    )
+    form_question_factory(form=form, question=q_calc)
+
+    # Create document and set q_input
+
+    doc = save_document(form=form)
+    q_input.refresh_from_db()
+    save_answer(question=q_input, document=doc, value=5)
+
+    # Verify calc (should be 5 + 10 = 15)
+    ans_calc = models.Answer.objects.get(question=q_calc, document=doc)
+    assert ans_calc.value == 15.0
+
+    # Now remove q_input from the form
+    models.FormQuestion.objects.filter(form=form, question=q_input).delete()
+
+    # Verify q_calc is recalculated (should be 100 + 10 = 110, as q_input|answer(100) returns 100 if missing)
+    ans_calc.refresh_from_db()
+    assert ans_calc.value == 110.0

--- a/caluma/caluma_form/tests/test_question.py
+++ b/caluma/caluma_form/tests/test_question.py
@@ -1298,5 +1298,5 @@ def test_init_of_calc_questions_queries(
         question__calc_expression="'table'|answer|mapby('column')|sum + 'top_question'|answer + 'sub_question'|answer",
     )
 
-    with django_assert_num_queries(27):
+    with django_assert_num_queries(25):
         api.save_answer(questions_dict["top_question"], document, value="1")


### PR DESCRIPTION
Several operations did not correctly trigger the recalculation
of dependent calculated fields, leading to stale data.

Improve the test suite to cover these issues, and fix the found issues.

Refactor answer and document deletion by moving the code into their own
domain logic classes, as other operations have been done before.
This allows us to update the dependent calc questions more easily where
needed.

Add `post_save` and `post_delete` signals for `FormQuestion` and `Question`
to automatically trigger recalculations when questions are added to,
or removed from forms. This allows calculated fields to react to
newly available dependencies or missing ones.

Improved recalculation by refining the culling logic in
`DependencyList.perform_recalculation()`. Now it always recalculates
fields that lack an answer. This handles new table rows and schema
changes better, without requiring manual root collection in the domain
logic.
